### PR TITLE
Pressing Alt + ←/→ does not interfere now with browser

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2201,7 +2201,7 @@
         // left-arrow
         case 37:
           if (ev.altKey) {
-            ev.preventDefault();
+            this.cancel(ev, true);
             key = '\x1bb' // Jump a word back
             break;
           } else if (this.applicationCursor) {
@@ -2213,7 +2213,7 @@
         // right-arrow
         case 39:
           if (ev.altKey) {
-            ev.preventDefault();
+            this.cancel(ev, true);
             key = '\x1bf' // Jump a word forward
             break;
           } else if (this.applicationCursor) {

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2201,6 +2201,7 @@
         // left-arrow
         case 37:
           if (ev.altKey) {
+            ev.preventDefault();
             key = '\x1bb' // Jump a word back
             break;
           } else if (this.applicationCursor) {
@@ -2212,6 +2213,7 @@
         // right-arrow
         case 39:
           if (ev.altKey) {
+            ev.preventDefault();
             key = '\x1bf' // Jump a word forward
             break;
           } else if (this.applicationCursor) {


### PR DESCRIPTION
Previously, when on Chrome for Windows, if default was not prevented the browser history backward/forward was triggered.

Fixes #19