### PR TITLE
Fixed IE issues with classList.add

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -532,7 +532,9 @@
       * Create main element container
       */
       this.element = this.document.createElement('div');
-      this.element.classList.add('terminal', 'xterm', 'xterm-theme-' + this.theme);
+      this.element.classList.add('terminal');
+      this.element.classList.add('xterm');
+      this.element.classList.add('xterm-theme-' + this.theme);
       this.element.setAttribute('tabindex', 0);
 
       /*


### PR DESCRIPTION
`classList.add` in IE does not take more than one parameter and this would not work. Split in 3 statements to fix it.