### PR TITLE
Added lenient option to linkify

### DIFF
--- a/addons/linkify/linkify.js
+++ b/addons/linkify/linkify.js
@@ -7,14 +7,14 @@
     } else {
         /*
          * Plain browser environment
-         */ 
+         */
         linkify(this.Xterm);
     }
 })(function (Xterm) {
 	'use strict';
 
     /**
-     * This module provides methods for convertings valid URL substrings 
+     * This module provides methods for convertings valid URL substrings
      * into HTML anchor elements (links), inside a terminal view.
      *
      * @module xterm/addons/linkify/linkify
@@ -31,8 +31,11 @@
         bodyClause = hostClause + pathClause,
         start = '(?:^|' + negatedDomainCharacterSet + ')(',
         end = ')($|' + negatedPathCharacterSet + ')',
-        urlClause = start + protocolClause + '?' + bodyClause + end,
-        urlRegex = new RegExp(urlClause);
+        lenientUrlClause = start + protocolClause + '?' + bodyClause + end,
+        strictUrlClause = start + protocolClause + bodyClause + end,
+        lenientUrlRegex = new RegExp(lenientUrlClause),
+        strictUrlRegex = new RegExp(strictUrlClause);
+
 
     /**
      * Converts all valid URLs found in the given terminal line into
@@ -46,7 +49,7 @@
      * @emits linkify
      * @emits linkify:line
      */
-    exports.linkifyTerminalLine = function (terminal, line) {
+    exports.linkifyTerminalLine = function (terminal, line, lenient) {
         if (typeof line == 'number') {
             line = terminal.rowContainer.children[line];
         } else if (! (line instanceof HTMLDivElement)) {
@@ -60,7 +63,8 @@
             nodes = line.childNodes;
 
         for (var j=0; j<nodes.length; j++) {
-            var node = nodes[j];
+            var node = nodes[j],
+                match;
 
             /*
              * Since we cannot access the TextNode's HTML representation
@@ -79,8 +83,12 @@
                 continue;
             }
 
-            
-            var match = node.data.match(urlRegex);
+
+            if (lenient) {
+                match = node.data.match(lenientUrlRegex);
+            } else {
+                match = node.data.match(strictUrlRegex);
+            }
 
             /*
              * If no URL was found in the current text, return.
@@ -117,15 +125,16 @@
      * @emits linkify
      * @emits linkify:line
      */
-    exports.linkify = function (terminal) {
+    exports.linkify = function (terminal, lenient) {
         var rows = terminal.rowContainer.children;
 
+        lenient = (typeof lenient == "boolean") ? lenient : true;
         for (var i=0; i<rows.length; i++) {
             var line = rows[i];
 
-			exports.linkifyTerminalLine(terminal, line);
+			exports.linkifyTerminalLine(terminal, line, lenient);
         }
-        
+
         /**
          * This event gets emitted when conversion of  all URL substrings to
          * HTML anchor elements (links) has finished for the current Xterm
@@ -147,18 +156,18 @@
      * @memberof Xterm
      * @param {number|HTMLDivElement} line - The terminal line that should get
      *								  		 "linkified".
-     */   
-    Xterm.prototype.linkifyTerminalLine = function (line) {
-        return exports.linkifyTerminalLine(this, line);
+     */
+    Xterm.prototype.linkifyTerminalLine = function (line, lenient) {
+        return exports.linkifyTerminalLine(this, line, lenient);
     };
 
    /**
      * Converts all valid URLs found in the current terminal into hyperlinks.
      *
      * @memberof Xterm
-     */   
-    Xterm.prototype.linkify = function () {
-        return exports.linkify(this);
+     */
+    Xterm.prototype.linkify = function (lenient) {
+        return exports.linkify(this, lenient);
     };
 
     return exports;

--- a/addons/linkify/linkify.js
+++ b/addons/linkify/linkify.js
@@ -46,6 +46,8 @@
      * @param {Xterm} terminal - The terminal that owns the given line.
      * @param {number|HTMLDivElement} line - The terminal line that should get
      *								  		 "linkified".
+     * @param {boolean} lenient - The regex type that will be used to identify links. If lenient is
+     *                            false, the regex requires a protocol clause. Defaults to true.
      * @emits linkify
      * @emits linkify:line
      */
@@ -122,6 +124,8 @@
      * Converts all valid URLs found in the terminal view into hyperlinks.
      *
      * @param {Xterm} terminal - The terminal that should get "linkified".
+     * @param {boolean} lenient - The regex type that will be used to identify links. If lenient is
+     *                            false, the regex requires a protocol clause. Defaults to true.
      * @emits linkify
      * @emits linkify:line
      */
@@ -156,6 +160,8 @@
      * @memberof Xterm
      * @param {number|HTMLDivElement} line - The terminal line that should get
      *								  		 "linkified".
+     * @param {boolean} lenient - The regex type that will be used to identify links. If lenient is
+     *                            false, the regex requires a protocol clause. Defaults to true.
      */
     Xterm.prototype.linkifyTerminalLine = function (line, lenient) {
         return exports.linkifyTerminalLine(this, line, lenient);
@@ -165,6 +171,8 @@
      * Converts all valid URLs found in the current terminal into hyperlinks.
      *
      * @memberof Xterm
+     * @param {boolean} lenient - The regex type that will be used to identify links. If lenient is
+     *                            false, the regex requires a protocol clause. Defaults to true.
      */
     Xterm.prototype.linkify = function (lenient) {
         return exports.linkify(this, lenient);


### PR DESCRIPTION
This PR introduces the ability to chose between lenient and strict url recognision.
By strict I mean that the url **must** have match a protocol clause, while with lenient the functionality remains unchanged.
If not provided, `lenient` defaults to true.