### PR TITLE
Better filtering of input

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2346,7 +2346,7 @@
           break;
         default:
           // a-z and space
-          if (ev.ctrlKey && !ev.shiftKey) {
+          if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
             if (ev.keyCode >= 65 && ev.keyCode <= 90) {
               key = String.fromCharCode(ev.keyCode - 64);
             } else if (ev.keyCode === 32) {

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2346,7 +2346,7 @@
           break;
         default:
           // a-z and space
-          if (ev.ctrlKey) {
+          if (ev.ctrlKey && !ev.shiftKey) {
             if (ev.keyCode >= 65 && ev.keyCode <= 90) {
               key = String.fromCharCode(ev.keyCode - 64);
             } else if (ev.keyCode === 32) {


### PR DESCRIPTION
In default case, do not treat `Ctrl` + `Shift` + `<character/symbol>` the same way as `Ctrl` + `<character/symbol>`.
This lead to cases like `Ctrl` + `Shift` + `C` being handled like `Ctrl` + `C` 