### PR TITLE
Fixed selection in firefox

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -584,8 +584,10 @@
       this.startBlink();
 
       on(this.element, 'mouseup', function() {
-        var selection = document.getSelection();
-        if (selection.isCollapsed) {
+        var selection = document.getSelection(),
+            collapsed = selection.isCollapsed,
+            isRange = typeof collapsed == 'boolean' ? !collapsed : selection.type == 'Range';
+        if (!isRange) {
           self.focus();
         }
       });

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -585,7 +585,7 @@
 
       on(this.element, 'mouseup', function() {
         var selection = document.getSelection();
-        if (selection.type != 'Range') {
+        if (selection.isCollapsed) {
           self.focus();
         }
       });


### PR DESCRIPTION
Selection.type was always undefined in Firefox.
I added a check of selection.isCollapsed which seems to be working fine.
>Selection.isCollapsed
>Returns a Boolean indicating whether the selection's start and end points are at the same position.

fixes #39 
It also seems to fix #12 
update: also seems to fix #30 