### PR TITLE
Fixed marginal width geometry

### DIFF
--- a/addons/fit/fit.js
+++ b/addons/fit/fit.js
@@ -50,7 +50,7 @@
         subjectRow.innerHTML = contentBuffer;
 
         rows = parseInt(availableHeight / characterHeight);
-        cols = parseInt(availableWidth / characterWidth);
+        cols = parseInt(availableWidth / characterWidth) - 1;
 
         geometry = {cols: cols, rows: rows};
         return geometry;


### PR DESCRIPTION
#42 was an attempt to better utilize the full width provided and not cut the lines short.
The new calculations were too marginal and there were cases were a `-` character would introduce an unnecessary line break.