### PR TITLE
nodejs module definition

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -32,7 +32,12 @@
  */
 
 (function (xterm) {
-    if (typeof define == 'function') {
+    if (typeof exports === 'object' && typeof module === 'object') {
+        /*
+         * npm/nodejs project
+         */
+        module.exports = xterm.call(this);
+    } else if (typeof define == 'function') {
         /*
          * Require.js is available
          */


### PR DESCRIPTION
Allow importing xterm into  a nodejs application (for instance an electron
application, or perhaps a test environment using phantomjs which
also has a DOM),