### PR TITLE
Use shift() when reducing lines to preserve lines up to cursor

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2520,10 +2520,10 @@
       } else if (j > y) {
         while (j-- > y) {
           if (this.lines.length > y + this.ybase) {
-            this.lines.pop();
+            this.lines.shift();
           }
           if (this.children.length > y) {
-            el = this.children.pop();
+            el = this.children.shift();
             if (!el) continue;
             el.parentNode.removeChild(el);
           }


### PR DESCRIPTION
The previous behavior of a resize to a smaller height kept the start of the buffer and tacked on a prompt line.  This fix allows the text up to the existing prompt to be preserved.


