### PR TITLE
Add http:// to demo output address

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -45,5 +45,5 @@ app.ws('/bash', function(ws, req) {
 var port = process.env.PORT || 3000,
     host = '0.0.0.0';
 
-console.log('App listening to ' + host + ':' + port);
+console.log('App listening to http://' + host + ':' + port);
 app.listen(port, host);


### PR DESCRIPTION
This makes it easy to launch the demo in a browser by right clicking the URL in
gnome-terminal