### PR TITLE
Stop marking spans as `inline-block`

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -2131,11 +2131,3 @@
 .terminal .xterm-rows > div {
     line-height: normal;
 }
-
-/**
- * All styled spans inside terminal lines should be inline-blocks,
- * in orde to achieve better height adjustment.
- */
-.terminal .xterm-rows span {
-    display: inline-block;
-}


### PR DESCRIPTION
This is not needed after 670b179140.

Fix #85