### PR TITLE
Allow Ctrl/Shift + insert to copy/paste on windows and linux

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -519,6 +519,11 @@
             term.leaseContentEditable();
           }
         }
+
+        if (!term.isMac && ev.keyCode == 45 && ev.shiftKey && !ev.ctrlKey) {
+          // Shift + Insert pastes on windows and many linuxes
+          term.leaseContentEditable();
+        }
       });
 
       /**
@@ -2387,7 +2392,11 @@
           break;
         // insert
         case 45:
-          key = '\x1b[2~';
+          if (!ev.shiftKey && !ev.ctrlKey) {
+            // <Ctrl> or <Shift> + <Insert> are used to
+            // copy-paste on some systems.
+            key = '\x1b[2~';
+          }
           break;
         // home
         case 36:


### PR DESCRIPTION
Many systems (including MS Windows and many linuxes) map <kbd>Ctrl</kbd> + <kbd>Insert</kbd> to copy and <kbd>Shift</kbd> + <kbd>Insert</kbd> to paste. That serves as a handy fallback when the more common <kbd>Ctrl</kbd> + <kbd>C</kbd> and <kbd>Ctrl</kbd> + <kbd>V</kbd> keybindings have their default prevented to send signals to the terminal.

Currently all keydown-events with the insert key send `\x1b[2~` to the terminal. Instead this PR won’t send anything if either the `shiftKey` or the `ctrlKey` are present in the event. Also it will enable `contentEditable` when `shiftKey` is present to allow for pasting in Firefox and Edge.