### PR TITLE
Draw cursor at correct position when scrolling

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1102,9 +1102,8 @@
         line = this.lines[row];
         out = '';
 
-        if (y === this.y
+        if (this.y === y - (this.ybase - this.ydisp)
             && this.cursorState
-            && (this.ydisp === this.ybase)
             && !this.cursorHidden) {
           x = this.x;
         } else {


### PR DESCRIPTION
Fixes #64 

---

Was just a matter of detecting the right display row to draw the cursor on.