### PR TITLE
Improve scroll to work with blank lines after the cursor

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2607,7 +2607,8 @@
         , el
         , i
         , j
-        , ch;
+        , ch
+        , addToY;
 
       if (x === this.cols && y === this.rows) {
         return;
@@ -2639,11 +2640,23 @@
 
       // resize rows
       j = this.rows;
+      addToY = 0;
       if (j < y) {
         el = this.element;
         while (j++ < y) {
+          // y is rows, not this.y
           if (this.lines.length < y + this.ybase) {
-            this.lines.push(this.blankLine());
+            if (this.ybase > 0 && this.lines.length <= this.ybase + this.y + addToY + 1) {
+              // There is room above the buffer and there are no empty elements below the line,
+              // scroll up
+              this.ybase--;
+              this.ydisp--;
+              addToY++
+            } else {
+              // Add a blank line if there is no buffer left at the top to scroll to, or if there
+              // are blank lines after the cursor
+              this.lines.push(this.blankLine());
+            }
           }
           if (this.children.length < y) {
             this.insertRow();
@@ -2652,11 +2665,11 @@
       } else { // (j > y)
         while (j-- > y) {
           if (this.lines.length > y + this.ybase) {
-            if (this.y + this.ybase < j) {
-              // The line is after the cursor, remove it
+            if (this.lines.length > this.ybase + this.y + 1) {
+              // The line is a blank line below the cursor, remove it
               this.lines.pop();
             } else {
-              // The line is the cursor, push the viewport down
+              // The line is the cursor, scroll down
               this.ybase++;
               this.ydisp++;
             }
@@ -2675,6 +2688,9 @@
       */
       if (this.y >= y) {
         this.y = y - 1;
+      }
+      if (addToY) {
+        this.y += addToY;
       }
 
       if (this.x >= x) {


### PR DESCRIPTION
This commit works fixes scrolling when there were blank lines after the cursor.
Here is what it does (blank rows are those added by running `clear`):

```
when increasing rows:
  if there are blank rows below the cursor:
    add a blank row to the bottom
  else if there is room in the buffer above the viewport
    scroll up
  else
    add a blank row to the bottom

when decreasing rows:
  if there are blank rows below the cursor:
    remove a blank row from the bottom
  else
    scroll down
```

Fixes #111