### PR TITLE
Bound refresh max rows to this.rows not this.lines

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1135,9 +1135,9 @@
       width = this.cols;
       y = start;
 
-      if (end >= this.lines.length) {
+      if (end >= this.rows.length) {
         this.log('`end` is too large. Most likely a bad CSR.');
-        end = this.lines.length - 1;
+        end = this.rows.length - 1;
       }
 
       for (; y <= end; y++) {


### PR DESCRIPTION
this.row is the size of rows in the viewport, this.lines is the buffer. It's
only possible to refresh `0` to `this.rows - 1`.

Fixes #86 

---

This prevents an exception when calling refresh incorrectly.