### PR TITLE
Disable ligatures which mess up rendering for certain fonts

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -39,6 +39,7 @@
     background-color: #000;
     color: #fff;
     font-family: courier-new, courier, monospace;
+    font-feature-settings: "liga" 0;
     position: relative;
 }
 


### PR DESCRIPTION
A ligature is when two characters render as one glyph. This makes text look better but is problematic for a fixed-width environment such as a terminal. For instance [this monospace font](https://github.com/powerline/fonts/tree/master/Meslo) uses turns "fi" into a ligature which should be disabled for proper rendering.

https://en.wikipedia.org/wiki/Typographic_ligature
https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings