### PR TITLE
Keep slave program in sync with terminal

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -32,6 +32,9 @@ app.ws('/bash', function(ws, req) {
   });
   term.on('data', function(data) {
     try {
+      // XOFF - stop pty pipe
+      // XON will be triggered by emulator before processing data chunk
+      term.write('\x13');
       ws.send(data);
     } catch (ex) {
       // The WebSocket is not open, ignore

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -294,6 +294,9 @@
       this.prefix = '';
       this.postfix = '';
 
+      // user input states
+      this.user_xoff = false;  // user pressed XOFF
+
       /**
        * An array of all lines in the entire buffer, including the prompt. The lines are array of
        * characters which are 2-length arrays where [0] is an attribute and [1] is the character.
@@ -1458,6 +1461,11 @@
      * @public
      */
     Terminal.prototype.write = function(data) {
+      // XON - about to process data, thus we can get more
+      // dont send XON if user pressed XOFF
+      if (!this.user_xoff)
+        this.send('\x11');
+
       var l = data.length, i = 0, j, cs, ch;
 
       this.refreshStart = this.y;
@@ -2655,6 +2663,10 @@
           }
           break;
       }
+      if (result.key === '\x13')
+        this.user_xoff = true;
+      else if (result.key === '\x11')
+        this.user_xoff = false;
       return result;
     };
 

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1462,7 +1462,7 @@
      */
     Terminal.prototype.write = function(data) {
       // XON - about to process data, thus we can get more
-      // dont send XON if user pressed XOFF
+      // dont lift XOFF if user pressed it
       if (!this.user_xoff)
         this.send('\x11');
 


### PR DESCRIPTION
Since I got no anwser to https://github.com/sourcelair/xterm.js/issues/134#issuecomment-227474863 here is a PR addressing the out of sync problem of the slave program and the terminal emulator.

The problem boils down to the nonblocking websocket handling, which cant propagate back the "uhmm, I'm still busy, please wait" of the terminal emulator and buffers more and more bytes. In the result the emulator lacks far behind in data processing. Thus a long running output heavy task seems not to be interruptable (which is not the case, it is just the terminal emulator, which has to get through the big amount of data to the point where the interrupt happened).
This PR uses XON/XOFF flow control to keep the backend and frontend in sync.

You can test this with any long running output intensive task, e.g. `ls -lR /`

Related issues are #134 and https://github.com/Microsoft/vscode/issues/7801