### PR TITLE
Have ' ' chars get inserted correctly after a resize

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2828,7 +2828,7 @@
       // resize cols
       j = this.cols;
       if (j < x) {
-        ch = [this.defAttr, ' ']; // does xterm use the default attr?
+        ch = [this.defAttr, ' ', 1]; // does xterm use the default attr?
         i = this.lines.length;
         while (i--) {
           while (this.lines[i].length < x) {


### PR DESCRIPTION
Since the character spec didn't contain a character width it was being skipped
during refresh.

Fixes #159