### PR TITLE
:arrow_up: pty.js@0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "express": "4.13.4",
     "express-ws": "2.0.0-rc.1",
-    "pty.js": "0.3.0",
+    "pty.js": "0.3.1",
     "mocha": "2.5.3",
     "chai": "3.5.0",
     "jsdoc": "3.4.0",


### PR DESCRIPTION
This PR updates `pty.js` to `0.3.1`. On my system (OS X `10.11.5`, node  `v6.3.0`) the package fails during the install stage with the previous version of `pty` but everything seems to work with `0.3.1` so far. I had the same problem on another system running an earlier version of node 6.