### PR TITLE
Use constant line-height

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -2141,9 +2141,9 @@
 }
 
 /**
- * All terminal rows should have explicitly declared height,
- * in order to allow child elements to adjust.
+ * All terminal rows should have explicitly declared height, in order to allow child elements to
+ * adjust. line-height:normal does not provide a fixed height for all unicode characters.
  */
 .terminal .xterm-rows > div {
-    line-height: normal;
+    line-height: 18px;
 }


### PR DESCRIPTION
Unicode characters have a constant height when using a decimal (eg. 1.2) but
can overlap which looks unattractive on some browsers that use transparent
selections (Chrome). "normal" line-height differs for CJK and other unicode
chars, only exactly pixel sized seems to work all the time.

Fixes #149