### PR TITLE
Initial webpack implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ Makefile.gyp
 *.target.gyp.mk
 *.node
 example/*.log
+dist/
 docs/
 npm-debug.log

--- a/demo/app.js
+++ b/demo/app.js
@@ -4,8 +4,10 @@ var expressWs = require('express-ws')(app);
 var os = require('os');
 var pty = require('pty.js');
 
+app.use('/dist', express.static(__dirname + '/../dist'));
+// TODO: Expose CSS in some static dir, away from the JS
 app.use('/src', express.static(__dirname + '/../src'));
-app.use('/addons', express.static(__dirname + '/../addons'));
+//app.use('/addons', express.static(__dirname + '/../addons'));
 
 app.get('/', function(req, res){
   res.sendFile(__dirname + '/index.html');

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,12 +3,12 @@
     <head>
         <title>xterm.js demo</title>
         <link rel="stylesheet" href="../src/xterm.css" />
-        <link rel="stylesheet" href="../addons/fullscreen/fullscreen.css" />
+        <!--<link rel="stylesheet" href="../addons/fullscreen/fullscreen.css" />-->
         <link rel="stylesheet" href="style.css" />
-        <script src="../src/xterm.js" ></script>
-        <script src="../addons/attach/attach.js" ></script>
+        <script src="../dist/xterm.js" ></script>
+        <!--<script src="../addons/attach/attach.js" ></script>
         <script src="../addons/fit/fit.js" ></script>
-        <script src="../addons/fullscreen/fullscreen.js" ></script>
+        <script src="../addons/fullscreen/fullscreen.js" ></script>-->
     </head>
     <body>
         <h1>

--- a/demo/main.js
+++ b/demo/main.js
@@ -24,7 +24,8 @@ function createTerminal() {
   socket = new WebSocket(socketURL);
 
   term.open(terminalContainer);
-  term.fit();
+  // TODO: Add fit addon back
+  //term.fit();
 
   socket.onopen = runRealTerminal;
   socket.onclose = runFakeTerminal;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test",
     ".gitignore"
   ],
-  "main": "dist/bundle.js",
+  "main": "dist/xterm.js",
   "repository": "https://github.com/sourcelair/xterm.js",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test",
     ".gitignore"
   ],
-  "main": "src/xterm.js",
+  "main": "dist/bundle.js",
   "repository": "https://github.com/sourcelair/xterm.js",
   "license": "MIT",
   "devDependencies": {
@@ -18,11 +18,14 @@
     "jsdoc": "3.4.0",
     "mocha": "2.5.3",
     "pty.js": "0.3.0",
-    "sleep": "^3.0.1"
+    "sleep": "^3.0.1",
+    "webpack": "^1.13.1"
   },
   "scripts": {
     "start": "node demo/app",
+    "dev": "webpack --watch",
     "test": "mocha --recursive",
+    "build": "webpack",
     "build:docs": "node_modules/.bin/jsdoc -c jsdoc.json"
   }
 }

--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -1,0 +1,85 @@
+/**
+ * xterm.js: xterm, in the browser
+ * Copyright (c) 2014, sourceLair Limited (www.sourcelair.com (MIT License)
+ * Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
+ * https://github.com/chjj/term.js
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+function EventEmitter() {
+  this._events = this._events || {};
+}
+
+EventEmitter.prototype.addListener = function(type, listener) {
+  this._events[type] = this._events[type] || [];
+  this._events[type].push(listener);
+};
+
+EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+
+EventEmitter.prototype.removeListener = function(type, listener) {
+  if (!this._events[type]) return;
+
+  var obj = this._events[type]
+    , i = obj.length;
+
+  while (i--) {
+    if (obj[i] === listener || obj[i].listener === listener) {
+      obj.splice(i, 1);
+      return;
+    }
+  }
+};
+
+EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+
+EventEmitter.prototype.removeAllListeners = function(type) {
+  if (this._events[type]) delete this._events[type];
+};
+
+EventEmitter.prototype.once = function(type, listener) {
+  var self = this;
+  function on() {
+    var args = Array.prototype.slice.call(arguments);
+    self.removeListener(type, on);
+    return listener.apply(self, args);
+  }
+  on.listener = listener;
+  return this.on(type, on);
+};
+
+EventEmitter.prototype.emit = function(type) {
+  if (!this._events[type]) return;
+
+  var args = Array.prototype.slice.call(arguments, 1)
+    , obj = this._events[type]
+    , l = obj.length
+    , i = 0;
+
+  for (; i < l; i++) {
+    obj[i].apply(this, args);
+  }
+};
+
+EventEmitter.prototype.listeners = function(type) {
+  return this._events[type] = this._events[type] || [];
+};
+
+module.exports = EventEmitter;

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -800,7 +800,7 @@
      * @param {string} addon The name of the addon to load
      * @static
      */
-    Terminal.loadAddon = function(addon, callback) {
+    /*Terminal.loadAddon = function(addon, callback) {
       if (typeof exports === 'object' && typeof module === 'object') {
         // CommonJS
         return require(__dirname + '/../addons/' + addon);
@@ -811,7 +811,97 @@
         console.error('Cannot load a module without a CommonJS or RequireJS environment.');
         return false;
       }
+    };*/
+
+
+
+    // TODO: Move the attach addon into an addon module
+
+    function attach(term, socket, bidirectional, buffered) {
+      bidirectional = (typeof bidirectional == 'undefined') ? true : bidirectional;
+      term.socket = socket;
+
+      term._flushBuffer = function () {
+        term.write(term._attachSocketBuffer);
+        term._attachSocketBuffer = null;
+        clearTimeout(term._attachSocketBufferTimer);
+        term._attachSocketBufferTimer = null;
+      };
+
+      term._pushToBuffer = function (data) {
+        if (term._attachSocketBuffer) {
+          term._attachSocketBuffer += data;
+        } else {
+          term._attachSocketBuffer = data;
+          setTimeout(term._flushBuffer, 10);
+        }
+      };
+
+      term._getMessage = function (ev) {
+        if (buffered) {
+          term._pushToBuffer(ev.data);
+        } else {
+          term.write(ev.data);
+        }
+      };
+
+      term._sendData = function (data) {
+        socket.send(data);
+      };
+
+      socket.addEventListener('message', term._getMessage);
+
+      if (bidirectional) {
+        term.on('data', term._sendData);
+      }
+
+      socket.addEventListener('close', term.detach.bind(term, socket));
+      socket.addEventListener('error', term.detach.bind(term, socket));
     };
+
+    /**
+     * Detaches the given terminal from the given socket
+     *
+     * @param {Xterm} term - The terminal to be detached from the given socket.
+     * @param {WebSocket} socket - The socket from which to detach the current
+     *                             terminal.
+     */
+    function detach(term, socket) {
+      term.off('data', term._sendData);
+
+      socket = (typeof socket == 'undefined') ? term.socket : socket;
+
+      if (socket) {
+        socket.removeEventListener('message', term._getMessage);
+      }
+
+      delete term.socket;
+    };
+
+    /**
+     * Attaches the current terminal to the given socket
+     *
+     * @param {WebSocket} socket - The socket to attach the current terminal.
+     * @param {boolean} bidirectional - Whether the terminal should send data
+     *                                  to the socket as well.
+     * @param {boolean} buffered - Whether the rendering of incoming data
+     *                             should happen instantly or at a maximum
+     *                             frequency of 1 rendering per 10ms.
+     */
+    Terminal.prototype.attach = function (socket, bidirectional, buffered) {
+      return attach(this, socket, bidirectional, buffered);
+    };
+
+    /**
+     * Detaches the current terminal from the given socket.
+     *
+     * @param {WebSocket} socket - The socket from which to detach the current
+     *                             terminal.
+     */
+    Terminal.prototype.detach = function (socket) {
+      return detach(this, socket);
+    };
+
 
 
     /**

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -31,6 +31,8 @@
  *   other features.
  */
 
+var EventEmitter = require('./event-emitter');
+
 (function (xterm) {
     if (typeof exports === 'object' && typeof module === 'object') {
         /*
@@ -68,70 +70,6 @@
      */
 
     var window = this, document = this.document;
-
-    /**
-     * EventEmitter
-     */
-
-    function EventEmitter() {
-      this._events = this._events || {};
-    }
-
-    EventEmitter.prototype.addListener = function(type, listener) {
-      this._events[type] = this._events[type] || [];
-      this._events[type].push(listener);
-    };
-
-    EventEmitter.prototype.on = EventEmitter.prototype.addListener;
-
-    EventEmitter.prototype.removeListener = function(type, listener) {
-      if (!this._events[type]) return;
-
-      var obj = this._events[type]
-        , i = obj.length;
-
-      while (i--) {
-        if (obj[i] === listener || obj[i].listener === listener) {
-          obj.splice(i, 1);
-          return;
-        }
-      }
-    };
-
-    EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-
-    EventEmitter.prototype.removeAllListeners = function(type) {
-      if (this._events[type]) delete this._events[type];
-    };
-
-    EventEmitter.prototype.once = function(type, listener) {
-      var self = this;
-      function on() {
-        var args = Array.prototype.slice.call(arguments);
-        self.removeListener(type, on);
-        return listener.apply(self, args);
-      }
-      on.listener = listener;
-      return this.on(type, on);
-    };
-
-    EventEmitter.prototype.emit = function(type) {
-      if (!this._events[type]) return;
-
-      var args = Array.prototype.slice.call(arguments, 1)
-        , obj = this._events[type]
-        , l = obj.length
-        , i = 0;
-
-      for (; i < l; i++) {
-        obj[i].apply(this, args);
-      }
-    };
-
-    EventEmitter.prototype.listeners = function(type) {
-      return this._events[type] = this._events[type] || [];
-    };
-
 
     /**
      * States

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,19 @@
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+  entry: './src/xterm.js',
+  output: {
+    // TODO: Expose an "xtermjs" object that contains Terminal
+    library: 'Terminal',
+    libraryTarget: "var",
+    path: path.join(__dirname, './dist'),
+    filename: 'xterm.js'
+  },
+  plugins: [
+    new webpack.WatchIgnorePlugin([
+        // TODO: Move addons to their own repositories/modules
+        path.resolve(__dirname, './addons/'),
+    ]),
+  ]
+};


### PR DESCRIPTION
Part of #158 

---

@parisk this PR is a bit messy at the moment, let me know your thoughts on the general approach here. Basically the following changes would come with/after this change:

- Builds are done using webpack, the module is built at `npm install` time and the file that is relied upon is `./dist/xterm.js` (see `main` in `package.json`)
- Addons will be pulled out into their own repositories and published as independent modules, this means that not all addons need to be loaded at once and are more modular in nature
- We can split out all the different pieces of logic in xterm.js into a well structured tree
- Development is done by running:
  - First terminal: `npm run dev` to watch/compile sources
  - Second terminal: `npm start` to start server as before
- Eventually change to exposing the library in an xtermjs object that contains a Terminal object would be preferable particularly for TypeScript as a proper typings file could be written for the library (ie. `export { Terminal: Terminal };` vs `export Terminal`)
- We can start using babel or similar to enable more elegant/efficient syntax without hurting compatibility in the resulting distributable
- We can get rid of the AMD header as it's all handled by webpack
- Allow minification/removal of comments in prod version, pushing the size of the distributable down significantly