### PR TITLE
Implement scroll bar

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -43,7 +43,8 @@
     position: relative;
 }
 
-.terminal.focus {
+.terminal.focus,
+.terminal:focus {
     outline: none;
 }
 

--- a/src/xterm.css
+++ b/src/xterm.css
@@ -103,6 +103,13 @@
     display: block;
 }
 
+.terminal .xterm-char-measure-element {
+    display: inline-block;
+    visibility: hidden;
+    position: absolute;
+    left: -9999em;
+}
+
 /*
  *  Determine default colors for xterm.js
  */
@@ -2168,12 +2175,4 @@
 
 .terminal .xterm-bg-color-255 {
     background-color: #eeeeee;
-}
-
-/**
- * All terminal rows should have explicitly declared height,
- * in order to allow child elements to adjust.
- */
-.terminal .xterm-rows > div {
-    line-height: normal;
 }

--- a/src/xterm.css
+++ b/src/xterm.css
@@ -103,6 +103,20 @@
     display: block;
 }
 
+.terminal .xterm-viewport {
+    overflow-y: scroll;
+}
+
+.terminal .xterm-rows {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.terminal .xterm-scroll-area {
+    visibility: hidden;
+}
+
 .terminal .xterm-char-measure-element {
     display: inline-block;
     visibility: hidden;

--- a/src/xterm.css
+++ b/src/xterm.css
@@ -104,6 +104,8 @@
 }
 
 .terminal .xterm-viewport {
+    /* On OS X this is required in order for the scroll bar to appear fully opaque */
+    background-color: #000;
     overflow-y: scroll;
 }
 

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -327,6 +327,10 @@
     /**
      * Represents the viewport of a terminal, the visible area within the larger buffer of output.
      * Logic for the virtual scroll bar is included in this object.
+     * @param {Terminal} terminal The Terminal object.
+     * @param {HTMLElement} viewportElement The DOM element acting as the viewport
+     * @param {HTMLElement} charMeasureElement A DOM element used to measure the character size of
+     *   the terminal.
      */
     function Viewport(terminal, viewportElement, charMeasureElement) {
       this.terminal = terminal;

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -219,7 +219,7 @@
       }
 
       return true;
-    }
+    };
 
     /**
      * Finalizes the composition, resuming regular input actions. This is called when a composition
@@ -275,7 +275,7 @@
           }
         }, 0);
       }
-    }
+    };
 
     /**
      * Apply any changes made to the textarea after the current event chain is allowed to complete.
@@ -296,7 +296,7 @@
           }
         }
       }, 0);
-    }
+    };
 
     /**
      * Positions the composition view on top of the cursor and the textarea just below it (so the
@@ -322,7 +322,7 @@
     CompositionHelper.prototype.clearTextareaPosition = function() {
       this.textarea.style.left = '';
       this.textarea.style.top = '';
-    }
+    };
 
     /**
      * Represents the viewport of a terminal, the visible area within the larger buffer of output.
@@ -332,13 +332,11 @@
      * @param {HTMLElement} charMeasureElement A DOM element used to measure the character size of
      *   the terminal.
      */
-    function Viewport(terminal, viewportElement, charMeasureElement) {
+    function Viewport(terminal, viewportElement, scrollArea, charMeasureElement) {
       this.terminal = terminal;
       this.viewportElement = viewportElement;
+      this.scrollArea = scrollArea;
       this.charMeasureElement = charMeasureElement;
-      this.scrollArea = document.createElement('div');
-      this.scrollArea.classList.add('xterm-scroll-area');
-      this.viewportElement.appendChild(this.scrollArea);
       this.currentRowHeight = 0;
       this.lastRecordedBufferLength = 0;
       this.lastRecordedViewportHeight = 0;
@@ -368,7 +366,7 @@
           this.lastRecordedViewportHeight = this.terminal.rows;
           this.viewportElement.style.height = size.height * this.terminal.rows + 'px';
         }
-        this.scrollArea.style.height = (size.height * this.terminal.lines.length) + 'px';
+        this.scrollArea.style.height = (size.height * this.lastRecordedBufferLength) + 'px';
       }
     };
 
@@ -377,7 +375,7 @@
      */
     Viewport.prototype.syncScrollArea = function() {
       if (this.isApplicationMode) {
-        this.lastRecordedBufferLength = this.currentRowHeight * this.terminal.rows;
+        this.lastRecordedBufferLength = this.terminal.rows;
         this.refresh();
         return;
       }
@@ -965,6 +963,9 @@
       this.viewportElement = document.createElement('div');
       this.viewportElement.classList.add('xterm-viewport');
       this.element.appendChild(this.viewportElement);
+      this.viewportScrollArea = document.createElement('div');
+      this.viewportScrollArea.classList.add('xterm-scroll-area');
+      this.viewportElement.appendChild(this.viewportScrollArea);
 
       /*
       * Create the container that will hold the lines of the terminal and then
@@ -1012,7 +1013,7 @@
       }
       this.parent.appendChild(this.element);
 
-      this.viewport = new Viewport(this, this.viewportElement, this.charMeasureElement);
+      this.viewport = new Viewport(this, this.viewportElement, this.viewportScrollArea, this.charMeasureElement);
 
       // Draw the screen.
       this.refresh(0, this.rows - 1);
@@ -5387,6 +5388,7 @@
 
     Terminal.EventEmitter = EventEmitter;
     Terminal.CompositionHelper = CompositionHelper;
+    Terminal.Viewport = Viewport;
     Terminal.inherits = inherits;
 
     /**

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -413,6 +413,8 @@
         multiplier = this.currentRowHeight * this.terminal.rows;
       }
       this.viewportElement.scrollTop += ev.deltaY * multiplier;
+      // Prevent the page from scrolling when the terminal scrolls
+      ev.preventDefault();
     };
 
     /**

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -407,12 +407,23 @@
     Viewport.prototype.onWheel = function(ev) {
       // Fallback to WheelEvent.DOM_DELTA_PIXEL 
       var multiplier = 1;
-      if (ev.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+      var delta = 0;
+      if (ev.type === 'DOMMouseScroll') {
+        if (ev.axis !== MouseScrollEvent.VERTICAL_AXIS) {
+          return;
+        } 
+        delta = ev.detail;
+        // Firefox treats ev.detail as lines, not pixels
         multiplier = this.currentRowHeight;
-      } else if (ev.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
-        multiplier = this.currentRowHeight * this.terminal.rows;
+      } else if (ev.type === 'mousewheel') {
+        delta = ev.deltaY
+        if (ev.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+          multiplier = this.currentRowHeight;
+        } else if (ev.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+          multiplier = this.currentRowHeight * this.terminal.rows;
+        }
       }
-      this.viewportElement.scrollTop += ev.deltaY * multiplier;
+      this.viewportElement.scrollTop += delta * multiplier;
       // Prevent the page from scrolling when the terminal scrolls
       ev.preventDefault();
     };

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -362,6 +362,7 @@
         if (size.height !== this.currentRowHeight) {
           this.currentRowHeight = size.height;
           this.viewportElement.style.lineHeight = size.height + 'px';
+          this.terminal.rowContainer.style.lineHeight = size.height + 'px';
         }
         if (this.lastRecordedViewportHeight !== this.terminal.rows) {
           this.lastRecordedViewportHeight = this.terminal.rows;

--- a/test/composition-helper-test.js
+++ b/test/composition-helper-test.js
@@ -19,14 +19,14 @@ describe('CompositionHelper', function () {
         top: 0
       },
       textContent: ''
-    }
+    };
     textarea = {
       value: '',
       style: {
         left: 0,
         top: 0
       }
-    }
+    };
     terminal = {
       element: {
         querySelector: function () {
@@ -36,7 +36,7 @@ describe('CompositionHelper', function () {
       handler: function (text) {
         handledText += text;
       }
-    }
+    };
     handledText = '';
     compositionHelper = new Terminal.CompositionHelper(textarea, compositionView, terminal);
   });

--- a/test/viewport-test.js
+++ b/test/viewport-test.js
@@ -1,0 +1,79 @@
+var assert = require('chai').assert;
+var Terminal = require('../src/xterm');
+
+describe('Viewport', function () {
+  var terminal;
+  var viewportElement;
+  var charMeasureElement;
+  var viewport;
+
+  var CHARACTER_HEIGHT = 10;
+
+  beforeEach(function () {
+    terminal = {
+      lines: [],
+      rows: 0,
+      ydisp: 0,
+      on: function () {},
+      rowContainer: {
+        style: {
+          lineHeight: 0
+        }
+      }
+    };
+    viewportElement = {
+      addEventListener: function () {},
+      style: {
+        height: 0,
+        lineHeight: 0
+      }
+    };
+    scrollAreaElement = {
+      style: {
+        height: 0
+      }
+    };
+    charMeasureElement = {
+      getBoundingClientRect: function () {
+        return { width: null, height: CHARACTER_HEIGHT };
+      }
+    };
+    viewport = new Terminal.Viewport(terminal, viewportElement, scrollAreaElement, charMeasureElement);
+  });
+
+  describe('Public API', function () {
+    it('should define Viewport.prototype.onWheel', function () {
+      assert.isDefined(Terminal.Viewport.prototype.onWheel);
+    });
+    it('should define Viewport.prototype.setApplicationMode', function () {
+      assert.isDefined(Terminal.Viewport.prototype.setApplicationMode);
+    });
+  });
+
+  describe('setApplicationMode', function () {
+    it('should restrict the scroll area to the viewport', function () {
+      terminal.lines.push('');
+      terminal.lines.push('');
+      terminal.rows = 1;
+      viewport.syncScrollArea();
+      assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
+      viewport.setApplicationMode(true);
+      assert.equal(scrollAreaElement.style.height, CHARACTER_HEIGHT + 'px');
+      viewport.setApplicationMode(false);
+      assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
+    });
+  });
+
+  describe('refresh', function () {
+    it('should set the line-height of the terminal', function () {
+      assert.equal(viewportElement.style.lineHeight, CHARACTER_HEIGHT + 'px');
+      assert.equal(terminal.rowContainer.style.lineHeight, CHARACTER_HEIGHT + 'px');
+      charMeasureElement.getBoundingClientRect = function () {
+        return { width: null, height: 1 };
+      };
+      viewport.refresh();
+      assert.equal(viewportElement.style.lineHeight, '1px');
+      assert.equal(terminal.rowContainer.style.lineHeight, '1px');
+    });
+  });
+});

--- a/test/viewport-test.js
+++ b/test/viewport-test.js
@@ -76,4 +76,19 @@ describe('Viewport', function () {
       assert.equal(terminal.rowContainer.style.lineHeight, '1px');
     });
   });
+
+  describe('syncScrollArea', function () {
+    it('should sync the scroll area', function () {
+      terminal.lines.push('');
+      terminal.rows = 1;
+      assert.equal(scrollAreaElement.style.height, 0 * CHARACTER_HEIGHT + 'px');
+      viewport.syncScrollArea();
+      assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+      assert.equal(scrollAreaElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+      terminal.lines.push('');
+      viewport.syncScrollArea();
+      assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+      assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #77
Fixes #149

### Implementation

The scroll bar is implemented using a `.xterm-scroll-area` element which is resized based on what the entire buffer is, this is contained within `.xterm-viewport` which uses `overflow-y: scroll` to show a native scroll bar. The viewport is kept separate from the rows in order to prevent calls to `refresh` triggering `scroll` events on the viewport.

Scroll and wheel events are then delegated to the viewport which in turn passes it on to the terminal. This can happen in two ways, events originating from the viewport (mouse wheel, drag and drop scroll bar, up/down buttons on scroll bar) and events originating from the terminal (scrolling via keyboard, new output, etc.).

The implementation supports various scroll configurations, properly utilizing `WheelEvent.deltaY` based on the [`WheelEvent.deltaMode`](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode), this allows certain configurations to specify whether the user prefers to scroll by pixels, lines or pages.

### Remaining tasks

- [x] Write some tests
- [x] Manually test on Windows
  - [x] Edge
  - [x] Chrome
  - [x] Firefox
  - [x] IE11
- [ ] See if anything can be improved with OS X scroll bar visibility
- [ ] Allow custom `line-height`?
- [x] Disable/fill scroll bar when in an application such as `vim`

### Notes

- I dropped support for `mousewheel` and `DOMMouseScroll` events in favor of `WheelEvent` since it's just complicating the support and xterm.js' [supported browsers](https://github.com/sourcelair/xterm.js#browser-support) are well within [the browsers supporting `WheelEvent`](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent#Browser_compatibility)
- Eventually a bunch of `Terminal`'s variables (`ydisp`, `y`, `ybase`) could be pulled into `Viewport` to simplify code, the virtual selection implementation would probably best live here too.
- Safari's scroll bar seems a little glitchy around drag of the scroll bar. This is not a big issue though considering it's probably not a very common use case on Macs.

### What it looks like

Ubuntu 16.04/Chrome 52:

![image](https://cloud.githubusercontent.com/assets/2193314/17381587/7f6a24de-5981-11e6-8820-902aaf52106d.png)

Ubuntu 16.04/Firefox 47

![image](https://cloud.githubusercontent.com/assets/2193314/17382044/dea4e09a-5983-11e6-862d-089311a5a9c0.png)

Windows 10/Edge 14

![image](https://cloud.githubusercontent.com/assets/2193314/17424710/81d7d8ba-5a7b-11e6-989d-d390c26dc058.png)
