### PR TITLE
Introduce resizing option in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -12,9 +12,7 @@
         <script src="../addons/fullscreen/fullscreen.js" ></script>
     </head>
     <body>
-        <h1>
-            xterm.js: xterm, in the browser
-        </h1>
+        <h1>xterm.js: xterm, in the browser</h1>
         <div id="terminal-container"></div>
         <div>
           <h2>Options</h2>
@@ -33,6 +31,7 @@
             </div>
           </div>
         </div>
+        <p><strong>Attention:</strong> The demo should be used only for evaluation of xterm.js and not be exposed or shared to public, as this will introduce security risks for the host.</p>
         <script src="main.js" defer ></script>
     </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,6 +5,7 @@
         <link rel="stylesheet" href="../src/xterm.css" />
         <link rel="stylesheet" href="../addons/fullscreen/fullscreen.css" />
         <link rel="stylesheet" href="style.css" />
+      	<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
         <script src="../src/xterm.js" ></script>
         <script src="../addons/attach/attach.js" ></script>
         <script src="../addons/fit/fit.js" ></script>
@@ -18,6 +19,19 @@
         <div>
           <h2>Options</h2>
           <label><input type="checkbox" id="option-cursor-blink"> cursorBlink</label>
+          <div>
+          	<h3>Size</h3>
+            <div>
+              <div style="display: inline-block; margin-right: 16px;">
+                <label for="cols">Columns</label>
+                <input type="number" id="cols" />
+              </div>
+              <div style="display: inline-block; margin-right: 16px;">
+                <label for="rows">Rows</label>
+                <input type="number" id="rows" />
+              </div>
+            </div>
+          </div>
         </div>
         <script src="main.js" defer ></script>
     </body>

--- a/demo/style.css
+++ b/demo/style.css
@@ -9,8 +9,8 @@ h1 {
 }
 
 #terminal-container {
-    width: 960px;
-    height: 600px;
+    width: 800px;
+    height: 450px;
     margin: 0 auto;
     padding: 2px;
 }


### PR DESCRIPTION
- Closes #217 
- Closes #211
- Closes #171

This PR introduces resizing functionality in the demo. This includes

- binding most endpoints to the PID id the corresponding back-end terminal's process
- introducing of appropriate endpoint for resizing terminals
- UI controls for updating the terminal's size

The implementation is neither optimal nor *secure*, anyone can create a back-end terminal process, and anyone that knows the PID of a terminal can attach to it and resize it. I did not deal with securing any of these endpoints since **the demo should be used only personally for evaluating this library**.

## Demo screenshot

![screenshot](https://s32.postimg.org/s0bedw12r/xterm_js_demo.png)