### PR TITLE
By more explicit in security warning

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -31,7 +31,7 @@
             </div>
           </div>
         </div>
-        <p><strong>Attention:</strong> The demo should be used only for evaluation of xterm.js and not be exposed or shared to public, as this will introduce security risks for the host.</p>
+        <p><strong>Attention:</strong> The demo is a barebones implementation and is designed for xterm.js evaluation purposes only. Exposing the demo to the public as is would introduce security risks for the host.</p>
         <script src="main.js" defer ></script>
     </body>
 </html>


### PR DESCRIPTION
Calling out that the insecurity is due to the barebones implementation
of the demo will prevent people thinking that the library is inherently
insecure.