### PR TITLE
restore customKeydownHandler on reset(RIS)

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -3467,7 +3467,9 @@
     Terminal.prototype.reset = function() {
       this.options.rows = this.rows;
       this.options.cols = this.cols;
+      var customKeydownHandler = this.customKeydownHandler;
       Terminal.call(this, this.options);
+      this.customKeydownHandler = customKeydownHandler;
       this.refresh(0, this.rows - 1);
     };
 

--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,15 @@ describe('xterm.js', function() {
       });
       assert.equal(xterm.keyDown(Object.assign({}, evKeyDown, { keyCode: 77 })), false);
     });
+    
+    it('should alive after reset(ESC c Full Reset (RIS))', function () {
+      xterm.attachCustomKeydownHandler(function (ev) {
+        return ev.keyCode !== 77;
+      });
+      assert.equal(xterm.keyDown(Object.assign({}, evKeyDown, { keyCode: 77 })), false);
+      xterm.reset();
+      assert.equal(xterm.keyDown(Object.assign({}, evKeyDown, { keyCode: 77 })), false);
+    });
   });
 
   describe('evaluateCopiedTextProcessing', function () {


### PR DESCRIPTION
hello, thank you cool project
i noticed, my `customKeydownHandler` may be lost.
it happens after i execute `less` , `fzf`, etc.
these commands have something in common. they raise "ESC c Full Reset (RIS)".
please review this pr for fix it.