### PR TITLE
Refresh the height of the viewport when the line-height changed

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -357,12 +357,14 @@
     Viewport.prototype.refresh = function(charSize) {
       var size = charSize || this.charMeasureElement.getBoundingClientRect();
       if (size.height > 0) {
-        if (size.height !== this.currentRowHeight) {
+        var rowHeightChanged = size.height !== this.currentRowHeight;
+        if (rowHeightChanged) {
           this.currentRowHeight = size.height;
           this.viewportElement.style.lineHeight = size.height + 'px';
           this.terminal.rowContainer.style.lineHeight = size.height + 'px';
         }
-        if (this.lastRecordedViewportHeight !== this.terminal.rows) {
+        var viewportHeightChanged = this.lastRecordedViewportHeight !== this.terminal.rows;
+        if (rowHeightChanged || viewportHeightChanged) {
           this.lastRecordedViewportHeight = this.terminal.rows;
           this.viewportElement.style.height = size.height * this.terminal.rows + 'px';
         }

--- a/test/viewport-test.js
+++ b/test/viewport-test.js
@@ -75,6 +75,18 @@ describe('Viewport', function () {
       assert.equal(viewportElement.style.lineHeight, '1px');
       assert.equal(terminal.rowContainer.style.lineHeight, '1px');
     });
+    it('should set the height of the viewport when the line-height changed', function () {
+      terminal.lines.push('');
+      terminal.lines.push('');
+      terminal.rows = 1;
+      viewport.refresh();
+      assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+      charMeasureElement.getBoundingClientRect = function () {
+        return { width: null, height: 20 };
+      };
+      viewport.refresh();
+      assert.equal(viewportElement.style.height, 20 + 'px');
+    });
   });
 
   describe('syncScrollArea', function () {


### PR DESCRIPTION
hello,
we can't scroll buffer correctly after the line-height was changed, until `rows` is changed.
this pr will fix it, so please check.