### PR TITLE
Disable application mode in viewport on soft reset

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -4561,8 +4561,8 @@
             break;
           case 66:
             this.log('Switching back to normal keypad.');
-            this.viewport.setApplicationMode(false);
             this.applicationKeypad = false;
+            this.viewport.setApplicationMode(false);
             break;
           case 9: // X10 Mouse
           case 1000: // vt200 mouse
@@ -4849,6 +4849,7 @@
       this.originMode = false;
       this.wraparoundMode = false; // autowrap
       this.applicationKeypad = false; // ?
+      this.viewport.setApplicationMode(false);
       this.applicationCursor = false;
       this.scrollTop = 0;
       this.scrollBottom = this.rows - 1;


### PR DESCRIPTION
Fixes #242 

---

I could not reproduce but it makes sense that this would it be, it's the only place that `Viewport.setApplicationMode` is not being set but should be.