### PR TITLE
Set package.json main to build/xterm.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test",
     ".gitignore"
   ],
-  "main": "src/xterm.js",
+  "main": "build/xterm.js",
   "repository": "https://github.com/sourcelair/xterm.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
build/xterm.js should be used when require is used when installed via npm.