### PR TITLE
Workaround a known bug in Babel JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Makefile.gyp
 example/*.log
 docs/
 npm-debug.log
+/.idea/

--- a/test/test.js
+++ b/test/test.js
@@ -378,7 +378,7 @@ describe('xterm.js', function() {
 
   describe('unicode - surrogates', function() {
     it('2 characters per cell', function () {
-      var high = '\uD800';
+      var high = String.fromCharCode(0xD800);
       for (var i=0xDC00; i<=0xDCFF; ++i) {
         xterm.write(high + String.fromCharCode(i));
         var tchar = xterm.lines[0][0];
@@ -390,7 +390,7 @@ describe('xterm.js', function() {
       }
     });
     it('2 characters at last cell', function() {
-      var high = '\uD800';
+      var high = String.fromCharCode(0xD800);
       for (var i=0xDC00; i<=0xDCFF; ++i) {
         xterm.x = xterm.cols - 1;
         xterm.write(high + String.fromCharCode(i));
@@ -401,7 +401,7 @@ describe('xterm.js', function() {
       }
     });
     it('2 characters per cell over line end with autowrap', function() {
-      var high = '\uD800';
+      var high = String.fromCharCode(0xD800);
       for (var i=0xDC00; i<=0xDCFF; ++i) {
         xterm.x = xterm.cols - 1;
         xterm.wraparoundMode = true;
@@ -414,7 +414,7 @@ describe('xterm.js', function() {
       }
     });
     it('2 characters per cell over line end without autowrap', function() {
-      var high = '\uD800';
+      var high = String.fromCharCode(0xD800);
       for (var i=0xDC00; i<=0xDCFF; ++i) {
         xterm.x = xterm.cols - 1;
         xterm.wraparoundMode = false;
@@ -426,7 +426,7 @@ describe('xterm.js', function() {
       }
     });
     it('splitted surrogates', function() {
-      var high = '\uD800';
+      var high = String.fromCharCode(0xD800);
       for (var i=0xDC00; i<=0xDCFF; ++i) {
         xterm.write(high);
         xterm.write(String.fromCharCode(i));


### PR DESCRIPTION
Details can be found here: https://github.com/babel/babel/issues/3826

It causes tests to fail after the first run, due to babel cache which save unicode string wrong.
The fix was simply to replace the string representation of the character with a numeric one, then convert it into a string.

I also made a minor change to the .gitignore file to ignore .idea, the settings directory Injellij IDE.