### PR TITLE
Sync scroll bar instead of disabling on enter app mode

### DIFF
--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -55,13 +55,6 @@ Viewport.prototype.refresh = function(charSize) {
  * Updates dimensions and synchronizes the scroll area if necessary.
  */
 Viewport.prototype.syncScrollArea = function() {
-  if (this.isApplicationMode) {
-    // Fix scroll bar in application mode
-    this.lastRecordedBufferLength = this.terminal.rows;
-    this.refresh();
-    return;
-  }
-
   if (this.lastRecordedBufferLength !== this.terminal.lines.length) {
     // If buffer height changed
     this.lastRecordedBufferLength = this.terminal.lines.length;
@@ -85,25 +78,11 @@ Viewport.prototype.syncScrollArea = function() {
 };
 
 /**
- * Sets the application mode of the viewport.
- * @param {boolean} isApplicationMode Sets whether the terminal is in application mode. true
- * for application mode (DECKPAM) and false for normal mode (DECKPNM).
- */
-Viewport.prototype.setApplicationMode = function(isApplicationMode) {
-  this.isApplicationMode = isApplicationMode;
-  this.syncScrollArea();
-};
-
-/**
  * Handles scroll events on the viewport, calculating the new viewport and requesting the
  * terminal to scroll to it.
  * @param {Event} ev The scroll event.
  */
 Viewport.prototype.onScroll = function(ev) {
-  if (this.isApplicationMode) {
-    // Scrolling via the scroll bar is disabled during application mode
-    return;
-  }
   var newRow = Math.round(this.viewportElement.scrollTop / this.currentRowHeight);
   var diff = newRow - this.terminal.ydisp;
   this.terminal.scrollDisp(diff, true);

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1692,7 +1692,7 @@ Terminal.prototype.write = function(data) {
           case '=':
             this.log('Serial port requested application keypad.');
             this.applicationKeypad = true;
-            this.viewport.setApplicationMode(true);
+            this.viewport.syncScrollArea();
             this.state = normal;
             break;
 
@@ -1700,7 +1700,7 @@ Terminal.prototype.write = function(data) {
           case '>':
             this.log('Switching back to normal keypad.');
             this.applicationKeypad = false;
-            this.viewport.setApplicationMode(false);
+            this.viewport.syncScrollArea();
             this.state = normal;
             break;
 
@@ -4064,7 +4064,7 @@ Terminal.prototype.setMode = function(params) {
       case 66:
         this.log('Serial port requested application keypad.');
         this.applicationKeypad = true;
-        this.viewport.setApplicationMode(true);
+        this.viewport.syncScrollArea();
         break;
       case 9: // X10 Mouse
         // no release, no motion, no wheel, no modifiers.
@@ -4264,7 +4264,7 @@ Terminal.prototype.resetMode = function(params) {
       case 66:
         this.log('Switching back to normal keypad.');
         this.applicationKeypad = false;
-        this.viewport.setApplicationMode(false);
+        this.viewport.syncScrollArea();
         break;
       case 9: // X10 Mouse
       case 1000: // vt200 mouse
@@ -4551,7 +4551,7 @@ Terminal.prototype.softReset = function(params) {
   this.originMode = false;
   this.wraparoundMode = false; // autowrap
   this.applicationKeypad = false; // ?
-  this.viewport.setApplicationMode(false);
+  this.viewport.syncScrollArea();
   this.applicationCursor = false;
   this.scrollTop = 0;
   this.scrollBottom = this.rows - 1;

--- a/test/viewport-test.js
+++ b/test/viewport-test.js
@@ -46,23 +46,6 @@ describe('Viewport', function () {
     it('should define Viewport.prototype.onWheel', function () {
       assert.isDefined(Terminal.Viewport.prototype.onWheel);
     });
-    it('should define Viewport.prototype.setApplicationMode', function () {
-      assert.isDefined(Terminal.Viewport.prototype.setApplicationMode);
-    });
-  });
-
-  describe('setApplicationMode', function () {
-    it('should restrict the scroll area to the viewport', function () {
-      terminal.lines.push('');
-      terminal.lines.push('');
-      terminal.rows = 1;
-      viewport.syncScrollArea();
-      assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
-      viewport.setApplicationMode(true);
-      assert.equal(scrollAreaElement.style.height, CHARACTER_HEIGHT + 'px');
-      viewport.setApplicationMode(false);
-      assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
-    });
   });
 
   describe('refresh', function () {


### PR DESCRIPTION
Fixes #286

---

This makes it behave just like gnome-terminal. In `git log` for example you can scroll the buffer just like normal since it adds to the buffer. `vim` will have the scroll bar disabled not hidden after syncing the scroll bar.