### PR TITLE
Allow wheel events in application mode

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1017,7 +1017,6 @@ Terminal.prototype.bindMouse = function() {
   // the shell for example
   on(el, 'wheel', function(ev) {
     if (self.mouseEvents) return;
-    if (self.applicationKeypad) return;
     self.viewport.onWheel(ev);
     return self.cancel(ev);
   });


### PR DESCRIPTION
This change allows wheel events in application mode which fixes mouse wheel
scrolling in oh-my-zsh and powershell for Linux (among others). Along with #287
a functional scroll bar will also be usable in those shells.

Fixes #151

---

There was quite a lot of discussion in the thread, but it seems this simple change with minimal side effects will fix it. One counter example used in #151 is that vim will call `scrollDisp` and cause the viewport to get broken, this is actually false since vim seems to clear the buffer.