### PR TITLE
Allow right-click paste (again)

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -2,6 +2,7 @@
   "source": {
     "include": [
       "src/xterm.js",
+      "src/handlers/Clipboard.js",
       "addons/attach/attach.js",
       "addons/fit/fit.js",
       "addons/fullscreen/fullscreen.js",

--- a/src/handlers/Clipboard.js
+++ b/src/handlers/Clipboard.js
@@ -39,6 +39,7 @@ function copyHandler (ev) {
   var copiedText = window.getSelection().toString(),
       text = prepareTextForClipboard(copiedText);
 
+  ev.clipboardData.setData('text/plain', text);
   ev.preventDefault(); // Prevent or the original text will be copied.
 }
 

--- a/src/handlers/Clipboard.js
+++ b/src/handlers/Clipboard.js
@@ -4,12 +4,17 @@
  */
 
 /**
+ * Clipboard handler module. This module contains methods for handling all
+ * clipboard-related events appropriately in the terminal.
+ * @module xterm/handlers/Clipboard
+ */
+
+/**
  * Prepares text copied from terminal selection, to be saved in the clipboard by:
  *   1. stripping all trailing white spaces
  *   2. converting all non-breaking spaces to regular spaces
  * @param {string} text The copied text that needs processing for storing in clipboard
  * @returns {string}
- * @static
  */
 function prepareTextForClipboard(text) {
   var space = String.fromCharCode(32),
@@ -28,7 +33,7 @@ function prepareTextForClipboard(text) {
 
 /**
  * Binds copy functionality to the given terminal.
- * @static
+ * @param {ClipboardEvent} ev The original copy event to be handled
  */
 function copyHandler (ev) {
   var copiedText = window.getSelection().toString(),
@@ -38,8 +43,9 @@ function copyHandler (ev) {
 }
 
 /**
- * Bind to paste event and allow both keyboard and right-click pasting, without having the
- * contentEditable value set to true.
+ * Redirect the clipboard's data to the terminal's input handler.
+ * @param {ClipboardEvent} ev The original paste event to be handled
+ * @param {Terminal} term The terminal on which to apply the handled paste event
  */
 function pasteHandler(ev, term) {
   ev.stopPropagation();
@@ -51,7 +57,20 @@ function pasteHandler(ev, term) {
   }
 }
 
-function rightClickHandler(ev) {
+/**
+ * Bind to right-click event and allow right-click copy and paste.
+ *
+ * **Logic**
+ * If text is selected and right-click happens on selected text, then
+ * do nothing to allow seamless copying.
+ * If no text is selected or right-click is outside of the selection
+ * area, then bring the terminal's input below the cursor, in order to
+ * trigger the event on the textarea and allow-right click paste, without
+ * caring about disappearing selection.
+ * @param {ClipboardEvent} ev The original paste event to be handled
+ * @param {Terminal} term The terminal on which to apply the handled paste event
+ */
+function rightClickHandler(ev, term) {
   var s = document.getSelection(),
       sText = prepareTextForClipboard(s.toString()),
       r = s.getRangeAt(0);

--- a/src/handlers/Clipboard.js
+++ b/src/handlers/Clipboard.js
@@ -1,0 +1,106 @@
+/**
+ * xterm.js: xterm, in the browser
+ * Copyright (c) 2016, SourceLair Private Company <www.sourcelair.com> (MIT License)
+ */
+
+/**
+ * Prepares text copied from terminal selection, to be saved in the clipboard by:
+ *   1. stripping all trailing white spaces
+ *   2. converting all non-breaking spaces to regular spaces
+ * @param {string} text The copied text that needs processing for storing in clipboard
+ * @returns {string}
+ * @static
+ */
+function prepareTextForClipboard(text) {
+  var space = String.fromCharCode(32),
+      nonBreakingSpace = String.fromCharCode(160),
+      allNonBreakingSpaces = new RegExp(nonBreakingSpace, 'g'),
+      processedText = text.split('\n').map(function (line) {
+        // Strip all trailing white spaces and convert all non-breaking spaces
+        // to regular spaces.
+        var processedLine = line.replace(/\s+$/g, '').replace(allNonBreakingSpaces, space);
+
+        return processedLine;
+      }).join('\n');
+
+  return processedText;
+}
+
+/**
+ * Binds copy functionality to the given terminal.
+ * @static
+ */
+function copyHandler (ev) {
+  var copiedText = window.getSelection().toString(),
+      text = prepareTextForClipboard(copiedText);
+
+  ev.preventDefault(); // Prevent or the original text will be copied.
+}
+
+/**
+ * Bind to paste event and allow both keyboard and right-click pasting, without having the
+ * contentEditable value set to true.
+ */
+function pasteHandler(ev, term) {
+  ev.stopPropagation();
+  if (ev.clipboardData) {
+    var text = ev.clipboardData.getData('text/plain');
+    term.handler(text);
+    term.textarea.value = '';
+    return term.cancel(ev);
+  }
+}
+
+function rightClickHandler(ev) {
+  var s = document.getSelection(),
+      sText = prepareTextForClipboard(s.toString()),
+      r = s.getRangeAt(0);
+
+  var x = ev.clientX,
+      y = ev.clientY;
+
+  var cr = r.getClientRects(),
+      clickIsOnSelection = false,
+      i, rect;
+
+  for (i=0; i<cr.length; i++) {
+    rect = cr[i];
+    clickIsOnSelection = (
+      (x > rect.left) && (x < rect.right) &&
+      (y > rect.top) && (y < rect.bottom)
+    );
+    // If we clicked on selection and selection is not a single space,
+    // then mark the right click as copy-only. We check for the single
+    // space selection, as this can happen when clicking on an &nbsp;
+    // and there is not much pointing in copying a single space.
+    // Single space is char
+    if (clickIsOnSelection && (sText !== ' ')) {
+      break;
+    }
+  }
+
+  // Bring textarea at the cursor position
+  if (!clickIsOnSelection) {
+    term.textarea.style.position = 'fixed';
+    term.textarea.style.width = '10px';
+    term.textarea.style.height = '10px';
+    term.textarea.style.left = x + 'px';
+    term.textarea.style.top = y + 'px';
+    term.textarea.style.zIndex = 1000;
+    term.textarea.focus();
+
+    // Reset the terminal textarea's styling
+    setTimeout(function () {
+      term.textarea.style.position = null;
+      term.textarea.style.width = null;
+      term.textarea.style.height = null;
+      term.textarea.style.left = null;
+      term.textarea.style.top = null;
+      term.textarea.style.zIndex = null;
+    }, 1);
+  }
+}
+
+export {
+  prepareTextForClipboard, copyHandler, pasteHandler, rightClickHandler
+};

--- a/src/xterm.css
+++ b/src/xterm.css
@@ -54,13 +54,13 @@
 }
 
 .terminal .xterm-helper-textarea {
-    position: absolute;
     /*
      * HACK: to fix IE's blinking cursor
      * Move textarea out of the screen to the far left, so that the cursor is not visible.
      */
-    left: -9999em;
+    position: absolute;
     opacity: 0;
+    left: -9999em;
     width: 0;
     height: 0;
     z-index: -10;

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -967,6 +967,57 @@ Terminal.prototype.bindMouse = function() {
     };
   }
 
+  // Handle right-click
+  on(el, 'contextmenu', function (ev) {
+    var s = document.getSelection(),
+        sText = Terminal.prepareCopiedTextForClipboard(s.toString()),
+        r = s.getRangeAt(0);
+
+    var x = ev.clientX,
+        y = ev.clientY;
+
+    var cr = r.getClientRects(),
+        clickIsOnSelection = false,
+        i, rect;
+
+    for (i=0; i<cr.length; i++) {
+      rect = cr[i];
+      clickIsOnSelection = (
+        (x > rect.left) && (x < rect.right) &&
+        (y > rect.top) && (y < rect.bottom)
+      )
+      // If we clicked on selection and selection is not a single space,
+      // then mark the right click as copy-only. We check for the single
+      // space selection, as this can happen when clicking on an &nbsp;
+      // and there is not much pointing in copying a single space.
+      // Single space is char
+      if (clickIsOnSelection && (sText !== ' ')) {
+        break;
+      }
+    }
+
+    // Bring textarea at the cursor position
+    if (!clickIsOnSelection) {
+      term.textarea.style.position = 'fixed';
+      term.textarea.style.width = '10px';
+      term.textarea.style.height = '10px';
+      term.textarea.style.left = x + 'px';
+      term.textarea.style.top = y + 'px';
+      term.textarea.style.zIndex = 1000;
+      term.textarea.focus();
+
+      // Reset the terminal textarea's styling
+      setTimeout(function () {
+        term.textarea.style.position = null;
+        term.textarea.style.width = null;
+        term.textarea.style.height = null;
+        term.textarea.style.left = null;
+        term.textarea.style.top = null;
+        term.textarea.style.zIndex = null;
+      }, 1);
+    }
+  });
+
   on(el, 'mousedown', function(ev) {
     if (!self.mouseEvents) return;
 

--- a/test/clipboard-test.js
+++ b/test/clipboard-test.js
@@ -1,0 +1,18 @@
+var assert = require('chai').assert;
+var Terminal = require('../src/xterm');
+var Clipboard = require('../src/handlers/Clipboard');
+
+
+describe('evaluateCopiedTextProcessing', function () {
+  it('should strip trailing whitespaces and replace nbsps with spaces', function () {
+    var nonBreakingSpace = String.fromCharCode(160),
+        copiedText = 'echo' + nonBreakingSpace + 'hello' + nonBreakingSpace,
+        processedText = Clipboard.prepareTextForClipboard(copiedText);
+
+    // No trailing spaces
+    assert.equal(processedText.match(/\s+$/), null);
+
+    // No non-breaking space
+    assert.equal(processedText.indexOf(nonBreakingSpace), -1);
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -245,20 +245,6 @@ describe('xterm.js', function() {
     });
   });
 
-  describe('evaluateCopiedTextProcessing', function () {
-    it('should strip trailing whitespaces and replace nbsps with spaces', function () {
-			var nonBreakingSpace = String.fromCharCode(160),
-          copiedText = 'echo' + nonBreakingSpace + 'hello' + nonBreakingSpace,
-          processedText = Terminal.prepareCopiedTextForClipboard(copiedText);
-
-      // No trailing spaces
-      assert.equal(processedText.match(/\s+$/), null);
-
-      // No non-breaking space
-      assert.equal(processedText.indexOf(nonBreakingSpace), -1);
-    });
-  });
-
   describe('Third level shift', function() {
     var evKeyDown = {
           preventDefault: function() {},


### PR DESCRIPTION
Allow right-click paste in the terminal, with the hidden textarea.

For the purposes of this PR, I branched out all clipboard logic into a new module and documented everything with JSDoc.

This PR closes #202 and renders #232 useless for the moment.