### PR TITLE
Make add-ons load Terminal from dist

### DIFF
--- a/addons/attach/attach.js
+++ b/addons/attach/attach.js
@@ -11,12 +11,12 @@
     /*
      * CommonJS environment
      */
-    module.exports = attach(require('../../src/xterm'));
+    module.exports = attach(require('../../dist/xterm'));
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
      */
-    define(['../../src/xterm'], attach);
+    define(['../../dist/xterm'], attach);
   } else {
     /*
      * Plain browser environment

--- a/addons/fit/fit.js
+++ b/addons/fit/fit.js
@@ -16,12 +16,12 @@
     /*
      * CommonJS environment
      */
-    module.exports = fit(require('../../src/xterm'));
+    module.exports = fit(require('../../dist/xterm'));
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
      */
-    define(['../../src/xterm'], fit);
+    define(['../../dist/xterm'], fit);
   } else {
     /*
      * Plain browser environment

--- a/addons/fullscreen/fullscreen.js
+++ b/addons/fullscreen/fullscreen.js
@@ -15,12 +15,12 @@
     /*
      * CommonJS environment
      */
-    module.exports = fullscreen(require('../../src/xterm'));
+    module.exports = fullscreen(require('../../dist/xterm'));
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
      */
-    define(['../../src/xterm'], fullscreen);
+    define(['../../dist/xterm'], fullscreen);
   } else {
     /*
      * Plain browser environment

--- a/addons/linkify/linkify.js
+++ b/addons/linkify/linkify.js
@@ -3,12 +3,12 @@
     /*
      * CommonJS environment
      */
-    module.exports = linkify(require('../../src/xterm'));
+    module.exports = linkify(require('../../dist/xterm'));
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
      */
-    define(['../../src/xterm'], linkify);
+    define(['../../dist/xterm'], linkify);
   } else {
     /*
      * Plain browser environment

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -642,7 +642,7 @@ Terminal.prototype.open = function(parent) {
 Terminal.loadAddon = function(addon, callback) {
   if (typeof exports === 'object' && typeof module === 'object') {
     // CommonJS
-    return require(__dirname + '/../addons/' + addon);
+    return require('../addons/' + addon);
   } else if (typeof define == 'function') {
     // RequireJS
     return require(['../addons/' + addon + '/' + addon], callback);

--- a/test/addons/linkify-test.js
+++ b/test/addons/linkify-test.js
@@ -1,5 +1,5 @@
 var assert = require('chai').assert;
-var Terminal = require('../../src/xterm');
+var Terminal = require('../../dist/xterm');
 var linkify = require('../../addons/linkify/linkify');
 
 describe('linkify addon', function () {

--- a/test/addons/test.js
+++ b/test/addons/test.js
@@ -1,10 +1,11 @@
 var assert = require('chai').assert;
 var Terminal = require('../../src/xterm');
+var distTerminal = require('../../dist/xterm');
 
 describe('xterm.js addons', function() {
   it('should load addons with Terminal.loadAddon', function () {
     Terminal.loadAddon('attach');
-    // Test that function was loaded successfully
-    assert.equal(typeof Terminal.prototype.attach, 'function');
+    // Test that addon was loaded successfully
+    assert.equal(typeof distTerminal.prototype.attach, 'function');
   });
 });


### PR DESCRIPTION
Make add-ons load Terminal from `dist`, or else they will break on environments with module systems that do not support ES2015 modules.

I also tweaked the tests to made sure that the `dist` constructor gets overloaded, even if  `loadAddon` is being called from `src/xterm.js`. I am not quite happy with this hack though 😕  .

Fix #305.