### PR TITLE
Correctly size and position the composition view

### DIFF
--- a/src/CompositionHelper.js
+++ b/src/CompositionHelper.js
@@ -182,7 +182,8 @@ CompositionHelper.prototype.updateCompositionElements = function(dontRecurse) {
     this.compositionView.style.top = cursor.offsetTop + 'px';
     var compositionViewBounds = this.compositionView.getBoundingClientRect();
     this.textarea.style.left = cursor.offsetLeft + compositionViewBounds.width + 'px';
-    this.textarea.style.top = (cursor.offsetTop + cursor.offsetHeight) + 'px';
+    this.textarea.style.top = cursor.offsetTop + 'px';
+    this.textarea.style.bottom = (cursor.offsetTop + cursor.offsetHeight) + 'px';
   }
   if (!dontRecurse) {
     setTimeout(this.updateCompositionElements.bind(this, true), 0);

--- a/src/CompositionHelper.js
+++ b/src/CompositionHelper.js
@@ -178,12 +178,18 @@ CompositionHelper.prototype.updateCompositionElements = function(dontRecurse) {
   }
   var cursor = this.terminal.element.querySelector('.terminal-cursor');
   if (cursor) {
+    // Take .xterm-rows offsetTop into account as well in case it's positioned absolutely within
+    // the .xterm element.
+    var xtermRows = this.terminal.element.querySelector('.xterm-rows');
+    var cursorTop = xtermRows.offsetTop + cursor.offsetTop;
+
     this.compositionView.style.left = cursor.offsetLeft + 'px';
-    this.compositionView.style.top = cursor.offsetTop + 'px';
+    this.compositionView.style.top = cursorTop + 'px';
+    this.compositionView.style.height = cursor.offsetHeight + 'px';
+    this.compositionView.style.lineHeight = cursor.offsetHeight + 'px';
     var compositionViewBounds = this.compositionView.getBoundingClientRect();
     this.textarea.style.left = cursor.offsetLeft + compositionViewBounds.width + 'px';
-    this.textarea.style.top = cursor.offsetTop + 'px';
-    this.textarea.style.bottom = (cursor.offsetTop + cursor.offsetHeight) + 'px';
+    this.textarea.style.top = cursor.cursorTop + 'px';
   }
   if (!dontRecurse) {
     setTimeout(this.updateCompositionElements.bind(this, true), 0);


### PR DESCRIPTION
This PR does the following:

- Ensures the textarea is kept within the bounds of the viewport by aligning it to the top of the cursor instead of the bottom
- Takes `.xterm-rows` offset into account if it's positioned absolutely within `.xterm` (as in vscode)
- Forces `height` and `line-height` on the composition view to be the size of the cursor

Fixes #299 