### PR TITLE
Stop auto scrolling to bottom on output

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -231,6 +231,9 @@ function Terminal(options) {
 
   this.tabs;
   this.setupStops();
+
+  // Store if user went browsing history in scrollback
+  this.userScrolling = false;
 }
 
 inherits(Terminal, EventEmitter);
@@ -1250,7 +1253,9 @@ Terminal.prototype.scroll = function() {
     this.lines = this.lines.slice(-(this.ybase + this.rows) + 1);
   }
 
-  this.ydisp = this.ybase;
+  if (!this.userScrolling) {
+    this.ydisp = this.ybase;
+  }
 
   // last line
   row = this.ybase + this.rows - 1;
@@ -1272,7 +1277,9 @@ Terminal.prototype.scroll = function() {
   if (this.scrollTop !== 0) {
     if (this.ybase !== 0) {
       this.ybase--;
-      this.ydisp = this.ybase;
+      if (!this.userScrolling) {
+        this.ydisp = this.ybase;
+      }
     }
     this.lines.splice(this.ybase + this.scrollTop, 1);
   }
@@ -1292,6 +1299,12 @@ Terminal.prototype.scroll = function() {
  * viewport originally.
  */
 Terminal.prototype.scrollDisp = function(disp, suppressScrollEvent) {
+  if (disp < 0) {
+    this.userScrolling = true;
+  } else if (disp + this.ydisp >= this.ybase) {
+    this.userScrolling = false;
+  }
+
   this.ydisp += disp;
 
   if (this.ydisp > this.ybase) {
@@ -1339,11 +1352,11 @@ Terminal.prototype.write = function(data) {
   this.refreshStart = this.y;
   this.refreshEnd = this.y;
 
-  if (this.ybase !== this.ydisp) {
-    this.ydisp = this.ybase;
-    this.emit('scroll', this.ydisp);
-    this.maxRange();
-  }
+  // if (this.ybase !== this.ydisp) {
+  //   this.ydisp = this.ybase;
+  //   this.emit('scroll', this.ydisp);
+  //   this.maxRange();
+  // }
 
   // apply leftover surrogate high from last write
   if (this.surrogate_high) {

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1352,12 +1352,6 @@ Terminal.prototype.write = function(data) {
   this.refreshStart = this.y;
   this.refreshEnd = this.y;
 
-  // if (this.ybase !== this.ydisp) {
-  //   this.ydisp = this.ybase;
-  //   this.emit('scroll', this.ydisp);
-  //   this.maxRange();
-  // }
-
   // apply leftover surrogate high from last write
   if (this.surrogate_high) {
     data = this.surrogate_high + data;
@@ -2423,6 +2417,11 @@ Terminal.prototype.attachCustomKeydownHandler = function(customKeydownHandler) {
  * @param {KeyboardEvent} ev The keydown event to be handled.
  */
 Terminal.prototype.keyDown = function(ev) {
+  // Scroll down to prompt, whenever the user presses a key.
+  if (this.ybase !== this.ydisp) {
+    this.scrollToBottom();
+  }
+
   if (this.customKeydownHandler && this.customKeydownHandler(ev) === false) {
     return false;
   }
@@ -2974,7 +2973,7 @@ Terminal.prototype.updateRange = function(y) {
 };
 
 /**
- * Set the range of refreshing to the maximyum value
+ * Set the range of refreshing to the maximum value
  */
 Terminal.prototype.maxRange = function() {
   this.refreshStart = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -181,6 +181,25 @@ describe('xterm.js', function() {
         assert.equal(xterm.ydisp, startYDisp);
       });
     });
+
+    describe('keyDown', function () {
+      it('should scroll down, when a key is pressed and terminal is scrolled up', function () {
+        var terminal = new Terminal();
+
+        // Do not process the keyDown event, to avoid side-effects
+        terminal.attachCustomKeydownHandler(function () {
+          return false;
+        });
+
+        terminal.ydisp = 0;
+        terminal.ybase = 40;
+
+        terminal.keyDown();
+
+        // Ensure that now the terminal is scrolled to bottom
+        assert.equal(terminal.ydisp, terminal.ybase);
+      });
+    });
   });
 
   describe('evaluateKeyEscapeSequence', function() {


### PR DESCRIPTION
This PR is a continuation of #326 by @jupe. I kept all original commits, to maintain the appropriate credits 😊 .

This PR introduces this new behavior:

- When the user has scrolled up the terminal and output is being printed (by the back-end), the terminal now is not scrolling down to bottom, as it used to
- The terminal scrolls down to bottom when the user presses a key

Closes #216.

/cc @Tyriar to take a look since you opened the initial issue and commented also in the original PR.