### PR TITLE
Add main property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,9 @@
 {
   "name": "xterm.js",
   "version": "2.0.1",
-  "ignore": ["demo", "test", ".gitignore"]
+  "ignore": ["demo", "test", ".gitignore"],
+  "main": [
+    "dist/xterm.js",
+    "dist/xterm.css"
+  ]
 }


### PR DESCRIPTION
This patch adds the main property to the project's bower.json for better
interoperability with tools like wiredep etc.