### PR TITLE
Fixed copy event in IE11

### DIFF
--- a/src/handlers/Clipboard.js
+++ b/src/handlers/Clipboard.js
@@ -35,11 +35,16 @@ function prepareTextForClipboard(text) {
  * Binds copy functionality to the given terminal.
  * @param {ClipboardEvent} ev The original copy event to be handled
  */
-function copyHandler (ev) {
+function copyHandler(ev, term) {
   var copiedText = window.getSelection().toString(),
       text = prepareTextForClipboard(copiedText);
 
-  ev.clipboardData.setData('text/plain', text);
+  if (term.browser.isMSIE) {
+    window.clipboardData.setData('Text', text);
+  } else {
+    ev.clipboardData.setData('text/plain', text);
+  }
+
   ev.preventDefault(); // Prevent or the original text will be copied.
 }
 
@@ -57,8 +62,7 @@ function pasteHandler(ev, term) {
     return term.cancel(ev);
   };
 
-  var userAgent = window.navigator.userAgent.toLowerCase();
-  if (userAgent.match(/msie|MSIE/) || userAgent.match(/(T|t)rident/)) {
+  if (term.browser.isMSIE) {
     if (window.clipboardData) {
       var text = window.clipboardData.getData('Text');
       dispatchPaste(text);

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -16,7 +16,7 @@ let userAgent = (isNode) ? 'node' : navigator.userAgent;
 let platform = (isNode) ? 'node' : navigator.platform;
 
 export let isFirefox = !!~userAgent.indexOf('Firefox');
-export let isMSIE = !!~userAgent.indexOf('MSIE');
+export let isMSIE = !!~userAgent.indexOf('MSIE') || !!~userAgent.indexOf('Trident');
 
 // Find the users platform. We use this to interpret the meta key
 // and ISO third level shifts.

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -447,11 +447,12 @@ Terminal.prototype.initGlobal = function() {
   Terminal.bindBlur(this);
 
   // Bind clipboard functionality
-  on(this.element, 'copy', copyHandler);
+  on(this.element, 'copy', function (ev) {
+    copyHandler.call(this, ev, term);
+  });
   on(this.textarea, 'paste', function (ev) {
     pasteHandler.call(this, ev, term);
   });
-
 
   function rightClickHandlerWrapper (ev) {
     rightClickHandler.call(this, ev, term);


### PR DESCRIPTION
hello!,
an error occurs by the copy event in IE11.
problems similar to https://github.com/sourcelair/xterm.js/pull/334
this pr will fix it, so please check.

![2016-11-04 15 27 20](https://cloud.githubusercontent.com/assets/916624/19998109/2e1e37ca-a2ae-11e6-95b0-d79f245236f5.png)
