### PR TITLE
Copy(Ctrl + c) failed in the Windows environment except IE11

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2693,7 +2693,10 @@ Terminal.prototype.evaluateKeyEscapeSequence = function(ev) {
       break;
     default:
       // a-z and space
-      if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
+      var selection = document.getSelection(),
+          collapsed = selection.isCollapsed,
+          isRange = typeof collapsed == 'boolean' ? !collapsed : selection.type == 'Range';
+      if (!isRange && (ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey)) {
         if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           result.key = String.fromCharCode(ev.keyCode - 64);
         } else if (ev.keyCode === 32) {


### PR DESCRIPTION
Hi,
Could not be copied(<kbd>ctrl</kbd> + <kbd>c</kbd>) due to the SIGINT is sent to the process.

It was modified so that it does not send the SIGINT In the range selection.
Could you please check this pr.