### PR TITLE
Fix selection lost on keyup

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -487,8 +487,6 @@ Terminal.bindKeys = function(term) {
     term.keyPress(ev);
   }, true);
 
-  on(term.element, 'keyup', term.focus.bind(term));
-
   on(term.textarea, 'keydown', function(ev) {
     term.keyDown(ev);
   }, true);


### PR DESCRIPTION
Fixes https://github.com/sourcelair/xterm.js/issues/348.

Currently, releasing a key destroys the selection, even a modifier key like shift or command. This leads to bugs like https://github.com/Microsoft/vscode/issues/15200. This does not change the behavior that inserting a character will remove the selection.

This is the same behavior that other terminals have.