### PR TITLE
Point to correct assets after TS build

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -7,7 +7,7 @@ var pty = require('pty.js');
 var terminals = {},
     logs = {};
 
-app.use('/build', express.static(__dirname + '/../build'));
+app.use('/dist', express.static(__dirname + '/../dist'));
 
 app.get('/', function(req, res){
   res.sendFile(__dirname + '/index.html');

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,14 +2,14 @@
 <html>
     <head>
         <title>xterm.js demo</title>
-        <link rel="stylesheet" href="../build/xterm.css" />
-        <link rel="stylesheet" href="../build/addons/fullscreen/fullscreen.css" />
+        <link rel="stylesheet" href="../dist/xterm.css" />
+        <link rel="stylesheet" href="../dist/addons/fullscreen/fullscreen.css" />
         <link rel="stylesheet" href="style.css" />
       	<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
-        <script src="/build/xterm.js" ></script>
-        <script src="/build/addons/attach/attach.js" ></script>
-        <script src="/build/addons/fit/fit.js" ></script>
-        <script src="/build/addons/fullscreen/fullscreen.js" ></script>
+        <script src="/dist/xterm.js" ></script>
+        <script src="/dist/addons/attach/attach.js" ></script>
+        <script src="/dist/addons/fit/fit.js" ></script>
+        <script src="/dist/addons/fullscreen/fullscreen.js" ></script>
     </head>
     <body>
         <h1>xterm.js: xterm, in the browser</h1>

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,8 +2,8 @@
 <html>
     <head>
         <title>xterm.js demo</title>
-        <link rel="stylesheet" href="../dist/xterm.css" />
-        <link rel="stylesheet" href="../dist/addons/fullscreen/fullscreen.css" />
+        <link rel="stylesheet" href="/dist/xterm.css" />
+        <link rel="stylesheet" href="/dist/addons/fullscreen/fullscreen.css" />
         <link rel="stylesheet" href="style.css" />
       	<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
         <script src="/dist/xterm.js" ></script>


### PR DESCRIPTION
The demo was still pointing at `./build`, not `./dist` so the assets were 404ing