### PR TITLE
Set up source maps

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,7 +4,13 @@
 tsc
 
 # Concat all xterm.js files into a single file and output as a UMD to dist/xterm.js
-browserify out/xterm.js --standalone Terminal -p [ tsify ] --outfile dist/xterm.js
+browserify ./out/xterm.js --standalone Terminal --debug --outfile ./dist/xterm.js
+cat ./dist/xterm.js | exorcist ./dist/xterm.js.map -b ./dist > ./dist/xterm.temp.js
+rm ./dist/xterm.js
+mv ./dist/xterm.temp.js ./dist/xterm.js
+
+# Resolve the chain of sourcemaps so that ./dist/xterm.js.map points at ./src
+sorcery -i dist/xterm.js
 
 # Copy all CSS files from src/ to dist/
 cd src

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "browserify": "^13.1.0",
     "chai": "3.5.0",
     "docdash": "0.4.0",
+    "exorcist": "^0.4.0",
     "express": "4.13.4",
     "express-ws": "2.0.0-rc.1",
     "glob": "^7.0.5",
@@ -22,7 +23,7 @@
     "nodemon": "1.10.2",
     "pty.js": "0.3.1",
     "sleep": "^3.0.1",
-    "tsify": "^1.0.7",
+    "sorcery": "^0.10.0",
     "typescript": "^2.0.3"
   },
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es5",
     "rootDir": "src",
     "allowJs": true,
-    "outDir": "out"
+    "outDir": "out",
+    "sourceMap": true
   },
   "exclude": [
     "addons",


### PR DESCRIPTION
Fixes #354 

---

Adds deps `exorcist` to extract `browserify`'s inline source maps and `sorcery` to resolve the chain of source maps so that `./dist/xterm.js` points at `./src` files.

Depends on https://github.com/sourcelair/xterm.js/pull/353 to fix demo