### PR TITLE
Clean out/* on build in case src/* files were deleted

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
 
+# Clean out/* to prevent confusion if files were deleted in src/
+rm -rf out/*
+
 # Build all TypeScript files (including tests) to out/
 tsc
 


### PR DESCRIPTION
If files in src/ were compiled and then deleted they will hang around in out/
until deleted. This can potentially cause difficult to diagnose build/test
errors. This commit removes all files from out/ but keeps the folder to
prevent editor file watchers from seeing the folder was deleted and shifting
the file explorer around.

Fixed #381