### PR TITLE
Column resize caching

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -3098,7 +3098,6 @@ Terminal.prototype.clear = function() {
   for (var i = 1; i < this.rows; i++) {
     this.lines.push(this.blankLine());
   }
-  this.lineCache = [this.lineCache.pop()] // only leave last line
   this.refresh(0, this.rows - 1);
   this.emit('scroll', this.ydisp);
 };

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -235,11 +235,6 @@ function Terminal(options) {
     this.lines.push(this.blankLine());
   }
 
-  /**
-   * An array of lines, corresponding to this.lines to cache characters in case of a resize
-   */
-  this.lineCache = this.lines.map(l => this.blankLine())
-
   this.tabs;
   this.setupStops();
 
@@ -2866,7 +2861,6 @@ Terminal.prototype.error = function() {
  * @param {number} x The number of columns to resize to.
  * @param {number} y The number of rows to resize to.
  */
-
 Terminal.prototype.resize = function(x, y) {
   var line
   , el
@@ -2889,18 +2883,14 @@ Terminal.prototype.resize = function(x, y) {
     i = this.lines.length;
     while (i--) {
       while (this.lines[i].length < x) {
-        this.lineCache[i] = this.lineCache[i] || []
-        const toAdd = this.lineCache[i].pop() || ch
-        this.lines[i].push(toAdd);
+        this.lines[i].push(ch);
       }
     }
   } else { // (j > x)
     i = this.lines.length;
     while (i--) {
       while (this.lines[i].length > x) {
-        const popped = this.lines[i].pop()
-        this.lineCache[i] = this.lineCache[i] || []
-        this.lineCache[i].push(popped)
+        this.lines[i].pop();
       }
     }
   }

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -3098,6 +3098,7 @@ Terminal.prototype.clear = function() {
   for (var i = 1; i < this.rows; i++) {
     this.lines.push(this.blankLine());
   }
+  this.lineCache = [this.lineCache.pop()] // only leave last line
   this.refresh(0, this.rows - 1);
   this.emit('scroll', this.ydisp);
 };

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -235,6 +235,11 @@ function Terminal(options) {
     this.lines.push(this.blankLine());
   }
 
+  /**
+   * An array of lines, corresponding to this.lines to cache characters in case of a resize
+   */
+  this.lineCache = this.lines.map(l => this.blankLine())
+
   this.tabs;
   this.setupStops();
 
@@ -2861,6 +2866,7 @@ Terminal.prototype.error = function() {
  * @param {number} x The number of columns to resize to.
  * @param {number} y The number of rows to resize to.
  */
+
 Terminal.prototype.resize = function(x, y) {
   var line
   , el
@@ -2883,14 +2889,18 @@ Terminal.prototype.resize = function(x, y) {
     i = this.lines.length;
     while (i--) {
       while (this.lines[i].length < x) {
-        this.lines[i].push(ch);
+        this.lineCache[i] = this.lineCache[i] || []
+        const toAdd = this.lineCache[i].pop() || ch
+        this.lines[i].push(toAdd);
       }
     }
   } else { // (j > x)
     i = this.lines.length;
     while (i--) {
       while (this.lines[i].length > x) {
-        this.lines[i].pop();
+        const popped = this.lines[i].pop()
+        this.lineCache[i] = this.lineCache[i] || []
+        this.lineCache[i].push(popped)
       }
     }
   }

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2886,13 +2886,6 @@ Terminal.prototype.resize = function(x, y) {
         this.lines[i].push(ch);
       }
     }
-  } else { // (j > x)
-    i = this.lines.length;
-    while (i--) {
-      while (this.lines[i].length > x) {
-        this.lines[i].pop();
-      }
-    }
   }
   this.setupStops(j);
   this.cols = x;


### PR DESCRIPTION
This is a quick fix for: https://github.com/sourcelair/xterm.js/issues/325

Rather than wrapping text, it just caches it temporarily and re-inserts it.
While not ideal, I think this is better than the current behaviour (just losing the text).
This is critical for one of our current projects, so if this is an acceptable (temporary?) fix, I'd be happy to write tests for it and make further changes to other integrated features (I'm new to this code base, so my apologies if I missed anything - would be happy to have anything pointed out to me).

Thanks!