### PR TITLE
Update documentation with cleaner license declaration

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,13 +1,12 @@
 {
   "source": {
     "include": [
-      "src/xterm.js",
-      "src/handlers/Clipboard.js",
-      "addons/attach/attach.js",
-      "addons/fit/fit.js",
-      "addons/fullscreen/fullscreen.js",
-      "addons/linkify/linkify.js"
-    ]
+      "src/"
+    ],
+    "exclude": [
+      "src/test/"
+    ],
+    "excludePattern": "src/.+\\.test\\.(js|ts)$"
   },
   "opts": {
     "readme": "README.md",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "4.13.4",
     "express-ws": "2.0.0-rc.1",
     "glob": "^7.0.5",
-    "jsdoc": "3.4.0",
+    "jsdoc": "3.4.3",
     "mocha": "2.5.3",
     "nodemon": "1.10.2",
     "pty.js": "0.3.1",

--- a/src/CompositionHelper.ts
+++ b/src/CompositionHelper.ts
@@ -1,6 +1,5 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2014-2016, SourceLair Private Company (www.sourcelair.com (MIT License)
+ * @license MIT
  */
 
 import { ITerminal } from './Interfaces';

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -1,6 +1,5 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2014-2016, SourceLair Private Company (www.sourcelair.com (MIT License)
+ * @license MIT
  */
 
 function EventEmitter() {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -1,6 +1,5 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2014-2016, SourceLair Private Company (www.sourcelair.com (MIT License)
+ * @license MIT
  */
 
 export interface ITerminal {

--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -1,6 +1,5 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2014-2016, SourceLair Private Company (www.sourcelair.com (MIT License)
+ * @license MIT
  */
 
 import { ITerminal } from './Interfaces';

--- a/src/addons/attach/attach.js
+++ b/src/addons/attach/attach.js
@@ -1,9 +1,7 @@
-/*
- * Implements the attach method, that
- * attaches the terminal to a WebSocket stream.
- *
- * The bidirectional argument indicates, whether the terminal should
- * send data to the socket as well and is true, by default.
+/**
+ * Implements the attach method, that attaches the terminal to a WebSocket stream.
+ * @module xterm/addons/attach/attach
+ * @license MIT
  */
 
 (function (attach) {
@@ -26,12 +24,6 @@
 })(function (Xterm) {
   'use strict';
 
-  /**
-   * This module provides methods for attaching a terminal to a WebSocket
-   * stream.
-   *
-   * @module xterm/addons/attach/attach
-   */
   var exports = {};
 
   /**

--- a/src/addons/fit/fit.js
+++ b/src/addons/fit/fit.js
@@ -1,16 +1,16 @@
-/*
- *  Fit terminal columns and rows to the dimensions of its
- *  DOM element.
+/**
+ * Fit terminal columns and rows to the dimensions of its DOM element.
  *
- *  Approach:
- *    - Rows: Truncate the division of the terminal parent element height
- *            by the terminal row height
+ * ## Approach
+ * - Rows: Truncate the division of the terminal parent element height by the terminal row height.
  *
- *    - Columns: Truncate the division of the terminal parent element width by
- *               the terminal character width (apply display: inline at the
- *               terminal row and truncate its width with the current number
- *               of columns)
+ * - Columns: Truncate the division of the terminal parent element width by the terminal character
+ * width (apply display: inline at the terminal row and truncate its width with the current
+ * number of columns).
+ * @module xterm/addons/fit/fit
+ * @license MIT
  */
+
 (function (fit) {
   if (typeof exports === 'object' && typeof module === 'object') {
     /*
@@ -29,11 +29,6 @@
     fit(window.Terminal);
   }
 })(function (Xterm) {
-  /**
-   * This module provides methods for fitting a terminal's size to a parent container.
-   *
-   * @module xterm/addons/fit/fit
-   */
   var exports = {};
 
   exports.proposeGeometry = function (term) {

--- a/src/addons/fullscreen/fullscreen.js
+++ b/src/addons/fullscreen/fullscreen.js
@@ -1,14 +1,7 @@
-/*
+/**
  * Fullscreen addon for xterm.js
- *
- * Implements the toggleFullscreen function.
- *
- * If the `fullscreen` argument has been supplied, then
- * if it is true, the fullscreen mode gets turned on,
- * if it is false or null, the fullscreen mode gets turned off.
- *
- * If the `fullscreen` argument has not been supplied, the
- * fullscreen mode is being toggled.
+ * @module xterm/addons/fullscreen/fullscreen
+ * @license MIT
  */
 (function (fullscreen) {
   if (typeof exports === 'object' && typeof module === 'object') {
@@ -30,6 +23,11 @@
 })(function (Xterm) {
   var exports = {};
 
+  /**
+   * Toggle the given terminal's fullscreen mode.
+   * @param {Xterm} term - The terminal to toggle full screen mode
+   * @param {boolean} fullscreen - Toggle fullscreen on (true) or off (false)
+   */
   exports.toggleFullScreen = function (term, fullscreen) {
     var fn;
 

--- a/src/addons/linkify/linkify.js
+++ b/src/addons/linkify/linkify.js
@@ -1,3 +1,9 @@
+/**
+ * Methods for turning URL subscrings in the terminal's content into links (`a` DOM elements).
+ * @module xterm/addons/linkify/linkify
+ * @license MIT
+ */
+
 (function (linkify) {
   if (typeof exports === 'object' && typeof module === 'object') {
     /*
@@ -18,12 +24,6 @@
 })(function (Xterm) {
   'use strict';
 
-  /**
-   * This module provides methods for convertings valid URL substrings
-   * into HTML anchor elements (links), inside a terminal view.
-   *
-   * @module xterm/addons/linkify/linkify
-   */
   var exports = {},
       protocolClause = '(https?:\\/\\/)',
       domainCharacterSet = '[\\da-z\\.-]+',

--- a/src/addons/terminado/terminado.js
+++ b/src/addons/terminado/terminado.js
@@ -1,9 +1,8 @@
-/*
- * Implements the attach method that
- * attaches the terminal to a Terminado WebSocket stream.
+/**
+ * This module provides methods for attaching a terminal to a terminado WebSocket stream.
  *
- * The bidirectional argument indicates, whether the terminal should
- * send data to the socket as well and is true, by default.
+ * @module xterm/addons/terminado/terminado
+ * @license MIT
  */
 
 (function (attach) {
@@ -26,12 +25,6 @@
 })(function (Xterm) {
   'use strict';
 
-  /**
-   * This module provides methods for attaching a terminal to a WebSocket
-   * stream.
-   *
-   * @module xterm/addons/attach/attach
-   */
   var exports = {};
 
   /**

--- a/src/handlers/Clipboard.js
+++ b/src/handlers/Clipboard.js
@@ -1,12 +1,8 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2016, SourceLair Private Company <www.sourcelair.com> (MIT License)
- */
-
-/**
- * Clipboard handler module. This module contains methods for handling all
- * clipboard-related events appropriately in the terminal.
+ * Clipboard handler module: exports methods for handling all clipboard-related events in the
+ * terminal.
  * @module xterm/handlers/Clipboard
+ * @license MIT
  */
 
 /**

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -1,12 +1,7 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2016, SourceLair Private Company <www.sourcelair.com> (MIT License)
- */
-
-/**
- * Browser utilities module. This module contains attributes and methods to help with
- * identifying the current browser and platform.
+ * Attributes and methods to help with identifying the current browser and platform.
  * @module xterm/utils/Browser
+ * @license MIT
  */
 
 import { contains } from './Generic.js';

--- a/src/utils/Generic.js
+++ b/src/utils/Generic.js
@@ -1,12 +1,7 @@
 /**
- * xterm.js: xterm, in the browser
- * Copyright (c) 2016, SourceLair Private Company <www.sourcelair.com> (MIT License)
- */
-
-/**
- * Generic utilities module. This module contains generic methods that can be helpful at
- * different parts of the code base.
+ * Generic utilities module with methods that can be helpful at different parts of the code base.
  * @module xterm/utils/Generic
+ * @license MIT
  */
 
 /**

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1,27 +1,5 @@
 /**
  * xterm.js: xterm, in the browser
- * Copyright (c) 2014-2014, SourceLair Private Company <www.sourcelair.com> (MIT License)
- * Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
- * https://github.com/chjj/term.js
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
  * Originally forked from (with the author's permission):
  *   Fabrice Bellard's javascript vt100 for jslinux:
  *   http://bellard.org/jslinux/
@@ -29,6 +7,7 @@
  *   The original design remains. The terminal itself
  *   has been extended to include xterm CSI codes, among
  *   other features.
+ * @license MIT
  */
 
 import { CompositionHelper } from './CompositionHelper.js';


### PR DESCRIPTION
Updated all "file headers" to use JSDoc's [`@license`](http://usejsdoc.org/tags-license.html) and [`@module`](http://usejsdoc.org/tags-module.html)  tags appropriately.

I was not able to follow the exact paradigm of #366 as it would not render appropriately.

With this new way we just mention that every file is MIT license, and we keep only the LICENSE file in the root directory for the complete license reference.

Closes #366