### PR TITLE
Bring back the `build` directory for temporary builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ docs/
 npm-debug.log
 /.idea/
 .env
-dist/*
+build/

--- a/bin/build
+++ b/bin/build
@@ -3,7 +3,7 @@
 set -e
 
 # $BUILD_DIR should default to "build"
-export BUILD_DIR=${BUILD_DIR:=build}
+BUILD_DIR=${BUILD_DIR:=build}
 
 # Create the build directory
 mkdir -p $BUILD_DIR

--- a/bin/build
+++ b/bin/build
@@ -1,26 +1,31 @@
 #! /usr/bin/env bash
 
+set -e
+
+# $BUILD_DIR should default to "build"
+export BUILD_DIR=${BUILD_DIR:=build}
+
 # Clean out/* to prevent confusion if files were deleted in src/
 rm -rf out/*
 
 # Build all TypeScript files (including tests) to out/
 tsc
 
-# Concat all xterm.js files into a single file and output as a UMD to dist/xterm.js
-browserify ./out/xterm.js --standalone Terminal --debug --outfile ./dist/xterm.js
-cat ./dist/xterm.js | exorcist ./dist/xterm.js.map -b ./dist > ./dist/xterm.temp.js
-rm ./dist/xterm.js
-mv ./dist/xterm.temp.js ./dist/xterm.js
+# Concat all xterm.js files into a single file and output as a UMD to $BUILD_DIR/xterm.js
+browserify ./out/xterm.js --standalone Terminal --debug --outfile ./$BUILD_DIR/xterm.js
+cat ./$BUILD_DIR/xterm.js | exorcist ./$BUILD_DIR/xterm.js.map -b ./$BUILD_DIR > ./$BUILD_DIR/xterm.temp.js
+rm ./$BUILD_DIR/xterm.js
+mv ./$BUILD_DIR/xterm.temp.js ./$BUILD_DIR/xterm.js
 
-# Resolve the chain of sourcemaps so that ./dist/xterm.js.map points at ./src
-sorcery -i dist/xterm.js
+# Resolve the chain of sourcemaps so that ./$BUILD_DIR/xterm.js.map points at ./src
+sorcery -i $BUILD_DIR/xterm.js
 
-# Copy all CSS files from src/ to dist/
+# Copy all CSS files from src/ to $BUILD_DIR/
 cd src
-find . -name '*.css' | cpio -pdm ../dist
+find . -name '*.css' | cpio -pdm ../$BUILD_DIR
 cd ..
 
-# Copy addons from out/ to dist/
+# Copy addons from out/ to $BUILD_DIR/
 cd out/addons
-find . -name '*.js' | cpio -pdm ../../dist/addons
+find . -name '*.js' | cpio -pdm ../../$BUILD_DIR/addons
 cd ../..

--- a/bin/build
+++ b/bin/build
@@ -5,6 +5,10 @@ set -e
 # $BUILD_DIR should default to "build"
 export BUILD_DIR=${BUILD_DIR:=build}
 
+# Create the build directory
+mkdir -p $BUILD_DIR
+
+
 # Clean out/* to prevent confusion if files were deleted in src/
 rm -rf out/*
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -7,7 +7,7 @@ var pty = require('pty.js');
 var terminals = {},
     logs = {};
 
-app.use('/dist', express.static(__dirname + '/../dist'));
+app.use('/build', express.static(__dirname + '/../build'));
 
 app.get('/', function(req, res){
   res.sendFile(__dirname + '/index.html');

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,14 +2,14 @@
 <html>
     <head>
         <title>xterm.js demo</title>
-        <link rel="stylesheet" href="/dist/xterm.css" />
-        <link rel="stylesheet" href="/dist/addons/fullscreen/fullscreen.css" />
+        <link rel="stylesheet" href="/build/xterm.css" />
+        <link rel="stylesheet" href="/build/addons/fullscreen/fullscreen.css" />
         <link rel="stylesheet" href="style.css" />
       	<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
-        <script src="/dist/xterm.js" ></script>
-        <script src="/dist/addons/attach/attach.js" ></script>
-        <script src="/dist/addons/fit/fit.js" ></script>
-        <script src="/dist/addons/fullscreen/fullscreen.js" ></script>
+        <script src="/build/xterm.js" ></script>
+        <script src="/build/addons/attach/attach.js" ></script>
+        <script src="/build/addons/fit/fit.js" ></script>
+        <script src="/build/addons/fullscreen/fullscreen.js" ></script>
     </head>
     <body>
         <h1>xterm.js: xterm, in the browser</h1>


### PR DESCRIPTION
Fix #375