### PR TITLE
Position the textarea at top:0

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -61,7 +61,7 @@
     position: absolute;
     opacity: 0;
     left: -9999em;
-    top: -9999em;
+    top: 0;
     width: 0;
     height: 0;
     z-index: -10;


### PR DESCRIPTION
This prevents the browser from scrolling to the top of the page if the terminal
can be scrolled out of view.

Fixes #357