### PR TITLE
Migrate Clipboard handler to TypeScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.js]
+[*.{j,t}s]
 max_line_length = 100
 
 [*.css]

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -2,12 +2,26 @@
  * @license MIT
  */
 
+export interface IBrowser {
+  isNode: boolean;
+  userAgent: string;
+  platform: string;
+  isFirefox: boolean;
+  isMSIE: boolean;
+  isMac: boolean;
+  isIpad: boolean;
+  isIphone: boolean;
+  isMSWindows: boolean;
+}
+
 export interface ITerminal {
   element: HTMLElement;
   rowContainer: HTMLElement;
+  textarea: HTMLTextAreaElement;
   ydisp: number;
   lines: string[];
   rows: number;
+  browser: IBrowser;
 
   /**
    * Emit the 'data' event and populate the given data.
@@ -16,4 +30,5 @@ export interface ITerminal {
   handler(data: string);
   on(event: string, callback: () => void);
   scrollDisp(disp: number, suppressScrollEvent: boolean);
+  cancel(ev: Event, force?: boolean);
 }

--- a/src/handlers/Clipboard.test.ts
+++ b/src/handlers/Clipboard.test.ts
@@ -1,6 +1,6 @@
-var assert = require('chai').assert;
-var Terminal = require('../xterm');
-var Clipboard = require('../handlers/Clipboard');
+import { assert } from 'chai';
+import * as Terminal from '../xterm';
+import * as Clipboard from './Clipboard';
 
 
 describe('evaluateCopiedTextProcessing', function () {

--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -14,6 +14,15 @@ interface IClipboardEvent extends ClipboardEvent {
   clientY: number;
 }
 
+interface IWindow extends Window {
+  clipboardData?: {
+    getData(format: string): string;
+    setData(format: string, data: string);
+  };
+}
+
+declare var window: IWindow;
+
 /**
  * Prepares text copied from terminal selection, to be saved in the clipboard by:
  *   1. stripping all trailing white spaces
@@ -21,7 +30,7 @@ interface IClipboardEvent extends ClipboardEvent {
  * @param {string} text The copied text that needs processing for storing in clipboard
  * @returns {string}
  */
-export function prepareTextForClipboard(text: string) {
+export function prepareTextForClipboard(text: string): string {
   let space = String.fromCharCode(32),
       nonBreakingSpace = String.fromCharCode(160),
       allNonBreakingSpaces = new RegExp(nonBreakingSpace, 'g'),
@@ -43,12 +52,11 @@ export function prepareTextForClipboard(text: string) {
 export function copyHandler(ev: IClipboardEvent, term: ITerminal) {
   // We cast `window` to `any` type, because TypeScript has not declared the `clipboardData`
   // property that we use below for Internet Explorer.
-  let w = <any>window,
-      copiedText = w.getSelection().toString(),
+  let copiedText = window.getSelection().toString(),
       text = prepareTextForClipboard(copiedText);
 
   if (term.browser.isMSIE) {
-    w.clipboardData.setData('Text', text);
+    window.clipboardData.setData('Text', text);
   } else {
     ev.clipboardData.setData('text/plain', text);
   }
@@ -64,8 +72,7 @@ export function copyHandler(ev: IClipboardEvent, term: ITerminal) {
 export function pasteHandler(ev: IClipboardEvent, term: ITerminal) {
   ev.stopPropagation();
 
-  let w = <any>window,
-      text: string;
+  let text: string;
 
   let dispatchPaste = function(text) {
     term.handler(text);
@@ -74,8 +81,8 @@ export function pasteHandler(ev: IClipboardEvent, term: ITerminal) {
   };
 
   if (term.browser.isMSIE) {
-    if (w.clipboardData) {
-      text = w.clipboardData.getData('Text');
+    if (window.clipboardData) {
+      text = window.clipboardData.getData('Text');
       dispatchPaste(text);
     }
   } else {


### PR DESCRIPTION
Also apply JavaScript rules in [`.editorconfig`](https://github.com/sourcelair/xterm.js/blob/824a9c6dbf12dd29685b63bee8899601308fe89c/.editorconfig) in TypeScript files as well.

Part of #335