### PR TITLE
fix: change build dir to dist

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -3,7 +3,7 @@
 set -e
 
 # $BUILD_DIR should default to "build"
-BUILD_DIR=${BUILD_DIR:=build}
+BUILD_DIR=${BUILD_DIR:=dist}
 
 # Create the build directory
 mkdir -p $BUILD_DIR


### PR DESCRIPTION
I'm not sure whether this is intentional or not, but I think this is just a small oversight?
The docs say the addons are in the dist directory, but they're not - and the build script builds them into the build directory...