### PR TITLE
Don't apply the 32 delta when in sgr mode - fix #394

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -785,7 +785,7 @@ Terminal.prototype.bindMouse = function() {
       pos.x -= 32;
       pos.y -= 32;
       self.send('\x1b[<'
-                + ((button & 3) === 3 ? button & ~3 : button)
+                + (((button & 3) === 3 ? button & ~3 : button) - 32)
                 + ';'
                 + pos.x
                 + ';'


### PR DESCRIPTION
Cf #394 - "Mouse buttons are wrong with extended coordinates"