### PR TITLE
Use a fixed size to account for the scrollbar

### DIFF
--- a/src/addons/fit/fit.js
+++ b/src/addons/fit/fit.js
@@ -34,7 +34,7 @@
   exports.proposeGeometry = function (term) {
     var parentElementStyle = window.getComputedStyle(term.element.parentElement),
         parentElementHeight = parseInt(parentElementStyle.getPropertyValue('height')),
-        parentElementWidth = parseInt(parentElementStyle.getPropertyValue('width')),
+        parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width')) - 17),
         elementStyle = window.getComputedStyle(term.element),
         elementPaddingVer = parseInt(elementStyle.getPropertyValue('padding-top')) + parseInt(elementStyle.getPropertyValue('padding-bottom')),
         elementPaddingHor = parseInt(elementStyle.getPropertyValue('padding-right')) + parseInt(elementStyle.getPropertyValue('padding-left')),
@@ -57,7 +57,7 @@
     subjectRow.innerHTML = contentBuffer;
 
     rows = parseInt(availableHeight / characterHeight);
-    cols = parseInt(availableWidth / characterWidth) - 1;
+    cols = parseInt(availableWidth / characterWidth);
 
     geometry = {cols: cols, rows: rows};
     return geometry;


### PR DESCRIPTION
The current fit algorithm removes one column, which I assume is to account for the scrollbar. It's unfortunately not enough, since the size of a character might be less than the size of the scrollbar, in which case a visual artifact occurs.

![image](https://cloud.githubusercontent.com/assets/1037931/21073760/c43a20d4-bee7-11e6-9c69-ef8d91864676.png)

This commit solves this by removing a fixed amount of pixels from the available pixels. The amount itself (17) is the scrollbar size on various browsers. A better implementation would probably try to compute it dynamically, but I felt like using a static value could a good start (especially since apparently noone reported this issue until now).