### PR TITLE
Always build TypeScript in `lib/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules/
 *.swp
 .lock-wscript
-out/
 lib/
 Makefile.gyp
 *.Makefile

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
 node_modules/
 *.swp
 .lock-wscript
-out/
+lib/*.test.js
+lib/*.test.js.map
+lib/test/
 Makefile.gyp
 *.Makefile
 *.target.gyp.mk

--- a/bin/build
+++ b/bin/build
@@ -9,14 +9,14 @@ BUILD_DIR=${BUILD_DIR:=build}
 mkdir -p $BUILD_DIR
 
 
-# Clean out/* to prevent confusion if files were deleted in src/
-rm -rf out/*
+# Clean lib/* to prevent confusion if files were deleted in src/
+rm -rf lib/*
 
-# Build all TypeScript files (including tests) to out/
+# Build all TypeScript files (including tests) to lib/
 tsc
 
 # Concat all xterm.js files into a single file and output as a UMD to $BUILD_DIR/xterm.js
-browserify ./out/xterm.js --standalone Terminal --debug --outfile ./$BUILD_DIR/xterm.js
+browserify ./lib/xterm.js --standalone Terminal --debug --outfile ./$BUILD_DIR/xterm.js
 cat ./$BUILD_DIR/xterm.js | exorcist ./$BUILD_DIR/xterm.js.map -b ./$BUILD_DIR > ./$BUILD_DIR/xterm.temp.js
 rm ./$BUILD_DIR/xterm.js
 mv ./$BUILD_DIR/xterm.temp.js ./$BUILD_DIR/xterm.js
@@ -29,7 +29,7 @@ cd src
 find . -name '*.css' | cpio -pdm ../$BUILD_DIR
 cd ..
 
-# Copy addons from out/ to $BUILD_DIR/
-cd out/addons
+# Copy addons from lib/ to $BUILD_DIR/
+cd lib/addons
 find . -name '*.js' | cpio -pdm ../../$BUILD_DIR/addons
 cd ../..

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "test": "mocha --recursive ./lib",
     "build:docs": "jsdoc -c jsdoc.json",
     "build": "./bin/build",
-    "prepublish": "tsc --outDir lib"
+    "prepublish": "tsc"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es5",
     "rootDir": "src",
     "allowJs": true,
-    "outDir": "out",
+    "outDir": "lib",
     "sourceMap": true
   },
   "exclude": [


### PR DESCRIPTION
Now that we publish `lib` to npm after #398, I do not think that there is any reason to keep the `out` directory.

Also this will make it easier for people that clone the bare repo to work (or else they will have to run the "prepublish" script).