### PR TITLE
changed escape sequence for alt-arrow to work on bash on os x

### DIFF
--- a/src/test/test.js
+++ b/src/test/test.js
@@ -286,14 +286,33 @@ describe('xterm.js', function() {
     it('should return \\x1b[5B for ctrl+down', function() {
       assert.equal(xterm.evaluateKeyEscapeSequence({ ctrlKey: true, keyCode: 40 }).key, '\x1b[1;5B'); // CSI 5 B
     });
-    // Evalueate alt + arrow key movement, which is a feature of terminal emulators but not VT100
-    // http://unix.stackexchange.com/a/108106
-    it('should return \\x1b[5D for alt+left', function() {
-      assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 37 }).key, '\x1b[1;5D'); // CSI 5 D
+
+    describe('On non-macOS platforms', function() {
+      beforeEach(function() {
+        xterm.browser.isMac = false;
+      });
+      // Evalueate alt + arrow key movement, which is a feature of terminal emulators but not VT100
+      // http://unix.stackexchange.com/a/108106
+      it('should return \\x1b[5D for alt+left', function() {
+        assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 37 }).key, '\x1b[1;5D'); // CSI 5 D
+      });
+      it('should return \\x1b[5C for alt+right', function() {
+        assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 39 }).key, '\x1b[1;5C'); // CSI 5 C
+      });
     });
-    it('should return \\x1b[5C for alt+right', function() {
-      assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 39 }).key, '\x1b[1;5C'); // CSI 5 C
+
+    describe('On macOS platforms', function() {
+      beforeEach(function() {
+        xterm.browser.isMac = true;
+      });
+      it('should return \\x1bb for alt+left', function() {
+        assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 37 }).key, '\x1bb'); // CSI 5 D
+      });
+      it('should return \\x1bf for alt+right', function() {
+        assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 39 }).key, '\x1bf'); // CSI 5 C
+      });
     });
+
     it('should return \\x1b[5A for alt+up', function() {
       assert.equal(xterm.evaluateKeyEscapeSequence({ altKey: true, keyCode: 38 }).key, '\x1b[1;5A'); // CSI 5 A
     });

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2501,7 +2501,7 @@ Terminal.prototype.evaluateKeyEscapeSequence = function(ev) {
         // HACK: Make Alt + left-arrow behave like Ctrl + left-arrow: move one word backwards
         // http://unix.stackexchange.com/a/108106
         if (result.key == '\x1b[1;3D') {
-          result.key = '\x1b[1;5D';
+          result.key = '\x1bb';
         }
       } else if (this.applicationCursor) {
         result.key = '\x1bOD';
@@ -2516,7 +2516,7 @@ Terminal.prototype.evaluateKeyEscapeSequence = function(ev) {
         // HACK: Make Alt + right-arrow behave like Ctrl + right-arrow: move one word forward
         // http://unix.stackexchange.com/a/108106
         if (result.key == '\x1b[1;3C') {
-          result.key = '\x1b[1;5C';
+          result.key = '\x1bf';
         }
       } else if (this.applicationCursor) {
         result.key = '\x1bOC';

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2500,8 +2500,9 @@ Terminal.prototype.evaluateKeyEscapeSequence = function(ev) {
         result.key = '\x1b[1;' + (modifiers + 1) + 'D';
         // HACK: Make Alt + left-arrow behave like Ctrl + left-arrow: move one word backwards
         // http://unix.stackexchange.com/a/108106
+        // macOS uses different escape sequences than linux
         if (result.key == '\x1b[1;3D') {
-          result.key = '\x1bb';
+          result.key = (this.browser.isMac) ? '\x1bb' : '\x1b[1;5D';
         }
       } else if (this.applicationCursor) {
         result.key = '\x1bOD';
@@ -2515,8 +2516,9 @@ Terminal.prototype.evaluateKeyEscapeSequence = function(ev) {
         result.key = '\x1b[1;' + (modifiers + 1) + 'C';
         // HACK: Make Alt + right-arrow behave like Ctrl + right-arrow: move one word forward
         // http://unix.stackexchange.com/a/108106
+        // macOS uses different escape sequences than linux
         if (result.key == '\x1b[1;3C') {
-          result.key = '\x1bf';
+          result.key = (this.browser.isMac) ? '\x1bf' : '\x1b[1;5C';
         }
       } else if (this.applicationCursor) {
         result.key = '\x1bOC';


### PR DESCRIPTION
These are the escape sequences that make alt-arrow work on os x bash. 

I have just started poking around the code base and am not super familiar with it. Any guidance on how to make this cross platform / cross shell would be appreciated. 