### PR TITLE
Clean up npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,26 +10,12 @@
   "repository": "https://github.com/sourcelair/xterm.js",
   "license": "MIT",
   "files": [
-    "dist/*.css",
-    "dist/**/*.css",
-    "dist/*.js",
-    "dist/*.js.map",
-    "dist/**/*.js",
-    "dist/**/*.js.map",
     "lib/*.css",
     "lib/**/*.css",
     "lib/*.js",
     "lib/*.js.map",
     "lib/**/*.js",
-    "lib/**/*.js.map",
-    "src/*.css",
-    "src/**/*.css",
-    "src/*.js",
-    "src/*.js.map",
-    "src/*.ts",
-    "src/**/*.js",
-    "src/**/*.js.map",
-    "src/**/*.ts"
+    "lib/**/*.js.map"
   ],
   "devDependencies": {
     "@types/chai": "^3.4.34",
@@ -57,6 +43,6 @@
     "test": "mocha --recursive ./lib",
     "build:docs": "jsdoc -c jsdoc.json",
     "build": "./bin/build",
-    "prepublish": "tsc"
+    "prepublish": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,26 @@
   "repository": "https://github.com/sourcelair/xterm.js",
   "license": "MIT",
   "files": [
+    "dist/*.css",
+    "dist/**/*.css",
+    "dist/*.js",
+    "dist/*.js.map",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
     "lib/*.css",
     "lib/**/*.css",
     "lib/*.js",
     "lib/*.js.map",
     "lib/**/*.js",
-    "lib/**/*.js.map"
+    "lib/**/*.js.map",
+    "src/*.css",
+    "src/**/*.css",
+    "src/*.js",
+    "src/*.js.map",
+    "src/*.ts",
+    "src/**/*.js",
+    "src/**/*.js.map",
+    "src/**/*.ts"
   ],
   "devDependencies": {
     "@types/chai": "^3.4.34",


### PR DESCRIPTION
Make sure the full build script is run before publishing, ensuring that CSS files are copied, for example