### PR TITLE
Rate limit Viewport.refresh

### DIFF
--- a/src/Viewport.test.ts
+++ b/src/Viewport.test.ts
@@ -1,6 +1,11 @@
 import { assert } from 'chai';
 import { Viewport } from './Viewport';
 
+class MockWindow {
+  // Disable refreshLoop in test
+  public requestAnimationFrame() { }
+}
+
 describe('Viewport', () => {
   var terminal;
   var viewportElement;
@@ -11,6 +16,7 @@ describe('Viewport', () => {
   const CHARACTER_HEIGHT = 10;
 
   beforeEach(() => {
+    (<any>global).window = new MockWindow();
     terminal = {
       lines: [],
       rows: 0,
@@ -73,10 +79,14 @@ describe('Viewport', () => {
       terminal.rows = 1;
       assert.equal(scrollAreaElement.style.height, 0 * CHARACTER_HEIGHT + 'px');
       viewport.syncScrollArea();
+      assert.ok(viewport.isRefreshQueued);
+      viewport.refresh();
       assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
       assert.equal(scrollAreaElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
       terminal.lines.push('');
       viewport.syncScrollArea();
+      assert.ok(viewport.isRefreshQueued);
+      viewport.refresh();
       assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
       assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
     });

--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -40,6 +40,9 @@ export class Viewport {
     this.refreshLoop();
   }
 
+  /**
+   * Queues a refresh to be done on next animation frame.
+   */
   private refreshLoop(): void {
     if (this.isRefreshQueued) {
       this.refresh();


### PR DESCRIPTION
This prevents 1000 scroll events from firing when the buffer is not full

Fixes #444 

---

Notes:

- There is still lag when running long commands such as `yes`, this will be fixed by providing a pause/catch up mechanism as part of https://github.com/sourcelair/xterm.js/issues/425
- I didn't bother with the size caching stuff as it's being replaced in #440

The following before/after timelines were taken with this change on top of the refresh queue PR https://github.com/sourcelair/xterm.js/pull/438:

Before:

![image](https://cloud.githubusercontent.com/assets/2193314/21619878/8b751ca0-d1a6-11e6-893f-a7a7df9695e7.png)

After:

![image](https://cloud.githubusercontent.com/assets/2193314/21619869/833166c0-d1a6-11e6-803b-01b409324235.png)
