### PR TITLE
Add disableStdin option

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -326,7 +326,8 @@ Terminal.defaults = {
   scrollback: 1000,
   screenKeys: false,
   debug: false,
-  cancelEvents: false
+  cancelEvents: false,
+  disableStdin: false
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -3134,6 +3135,11 @@ Terminal.prototype.is = function(term) {
  * @param {string} data The data to populate in the event.
  */
 Terminal.prototype.handler = function(data) {
+  // Prevents all events to pty process if stdin is disabled
+  if (this.options.disableStdin) {
+    return;
+  }
+
   // Input is being sent to the terminal, the terminal should focus the prompt.
   if (this.ybase !== this.ydisp) {
     this.scrollToBottom();


### PR DESCRIPTION
Fixes #452 

---

Testing done:

1. Launch demo
2. In dev tools `term.setOption('disableStdin', true);`
3. Check input doesn't work but scrolling does
2. In dev tools `term.setOption('disableStdin', false);`
3. Check everything works