### PR TITLE
Remove comments in build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "allowJs": true,
     "outDir": "lib",
-    "sourceMap": true
+    "sourceMap": true,
+    "removeComments": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This reduces `build/xterm.js` from 206.7kB to 127.9kB which should reduce download and parsing time.