### PR TITLE
Implement configurable tab stop width

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -17,13 +17,13 @@
         <div>
           <h2>Options</h2>
           <p>
-            <label>cursorBlink <input type="checkbox" id="option-cursor-blink"></label>
+            <label><input type="checkbox" id="option-cursor-blink"> cursorBlink</label>
           </p>
           <p>
             <label>scrollback <input type="number" id="option-scrollback" value="1000" /></label>
           </p>
           <p>
-            <label>tabStopWidth <input type="number" id="option-tabstopwidth" value="4" /></label>
+            <label>tabStopWidth <input type="number" id="option-tabstopwidth" value="8" /></label>
           </p>
           <div>
           	<h3>Size</h3>

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,10 +17,13 @@
         <div>
           <h2>Options</h2>
           <p>
-            <label><input type="checkbox" id="option-cursor-blink"> cursorBlink</label>
+            <label>cursorBlink <input type="checkbox" id="option-cursor-blink"></label>
           </p>
           <p>
-            <label>Scrollback <input type="number" id="option-scrollback" value="1000" /></label>
+            <label>scrollback <input type="number" id="option-scrollback" value="1000" /></label>
+          </p>
+          <p>
+            <label>tabStopWidth <input type="number" id="option-tabstopwidth" value="4" /></label>
           </p>
           <div>
           	<h3>Size</h3>

--- a/demo/main.js
+++ b/demo/main.js
@@ -16,8 +16,8 @@ var terminalContainer = document.getElementById('terminal-container'),
     rowsElement = document.getElementById('rows');
 
 function setTerminalSize () {
-  var cols = parseInt(colsElement.value),
-      rows = parseInt(rowsElement.value),
+  var cols = parseInt(colsElement.value, 10),
+      rows = parseInt(rowsElement.value, 10),
       width = (cols * charWidth).toString() + 'px',
       height = (rows * charHeight).toString() + 'px';
 
@@ -36,7 +36,7 @@ optionElements.scrollback.addEventListener('change', function () {
   term.setOption('scrollback', parseInt(optionElements.scrollback.value, 10));
 });
 optionElements.tabstopwidth.addEventListener('change', function () {
-  term.setOption('tabStopWidth', parseInt(optionElements.tabstopwidth.value));
+  term.setOption('tabStopWidth', parseInt(optionElements.tabstopwidth.value, 10));
 });
 
 createTerminal();
@@ -49,7 +49,7 @@ function createTerminal() {
   term = new Terminal({
     cursorBlink: optionElements.cursorBlink.checked,
     scrollback: parseInt(optionElements.scrollback.value, 10),
-    tabStopWidth: parseInt(optionElements.tabstopwidth.value)
+    tabStopWidth: parseInt(optionElements.tabstopwidth.value, 10)
   });
   term.on('resize', function (size) {
     if (!pid) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -37,7 +37,6 @@ optionElements.scrollback.addEventListener('change', function () {
 });
 optionElements.tabstopwidth.addEventListener('change', function () {
   term.setOption('tabStopWidth', parseInt(optionElements.tabstopwidth.value));
-  term.setupStops();
 });
 
 createTerminal();

--- a/demo/main.js
+++ b/demo/main.js
@@ -9,7 +9,8 @@ var term,
 var terminalContainer = document.getElementById('terminal-container'),
     optionElements = {
       cursorBlink: document.querySelector('#option-cursor-blink'),
-      scrollback: document.querySelector('#option-scrollback')
+      scrollback: document.querySelector('#option-scrollback'),
+      tabstopwidth: document.querySelector('#option-tabstopwidth')
     },
     colsElement = document.getElementById('cols'),
     rowsElement = document.getElementById('rows');
@@ -32,7 +33,11 @@ optionElements.cursorBlink.addEventListener('change', function () {
   term.setOption('cursorBlink', optionElements.cursorBlink.checked);
 });
 optionElements.scrollback.addEventListener('change', function () {
-  terminal.setOption('scrollback', parseInt(optionElements.scrollback.value, 10));
+  term.setOption('scrollback', parseInt(optionElements.scrollback.value, 10));
+});
+optionElements.tabstopwidth.addEventListener('change', function () {
+  term.setOption('tabStopWidth', parseInt(optionElements.tabstopwidth.value));
+  term.setupStops();
 });
 
 createTerminal();
@@ -44,7 +49,8 @@ function createTerminal() {
   }
   term = new Terminal({
     cursorBlink: optionElements.cursorBlink.checked,
-    scrollback: parseInt(optionElements.scrollback.value, 10)
+    scrollback: parseInt(optionElements.scrollback.value, 10),
+    tabStopWidth: parseInt(optionElements.tabstopwidth.value)
   });
   term.on('resize', function (size) {
     if (!pid) {

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -434,6 +434,7 @@ Terminal.prototype.setOption = function(key, value) {
       this.element.classList.toggle(`xterm-cursor-style-underline`, value === 'underline');
       this.element.classList.toggle(`xterm-cursor-style-bar`, value === 'bar');
       break;
+    case 'tabStopWidth': this.setupStops(); break;
   }
 };
 

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -360,7 +360,8 @@ Terminal.defaults = {
   screenKeys: false,
   debug: false,
   cancelEvents: false,
-  disableStdin: false
+  disableStdin: false,
+  tabStopWidth: 8
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -2118,7 +2119,7 @@ Terminal.prototype.setupStops = function(i) {
     i = 0;
   }
 
-  for (; i < this.cols; i += 8) {
+  for (; i < this.cols; i += this.getOption('tabStopWidth')) {
     this.tabs[i] = true;
   }
 };


### PR DESCRIPTION
This PR introduces configurable tab stop width.

## Current issues
- [x] No way to call `term.setupStops()` after setting the option, without a hack into the private API. A private `_optionChanged` event could definitely solve this. Ideas @Tyriar?
- [ ] There is no easy way to re-render already printed tab stops. In order to achieve this we will have to separate the data from the presentation layer and re-render the whole thing, which is a big issue.

Documentation PR: xtermjs/xtermjs.org#13

Closes #488.