### PR TITLE
Fix many vt tests

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -123,6 +123,9 @@ export class InputHandler implements IInputHandler {
       this._terminal.y--;
       this._terminal.scroll();
     }
+    if (this._terminal.x >= this._terminal.cols) {
+      this._terminal.x--;
+    }
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -220,6 +220,9 @@ export class InputHandler implements IInputHandler {
     if (this._terminal.y >= this._terminal.rows) {
       this._terminal.y = this._terminal.rows - 1;
     }
+    if (this._terminal.x >= this._terminal.cols) {
+      this._terminal.x--;
+    }
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -246,6 +246,9 @@ export class InputHandler implements IInputHandler {
     if (param < 1) {
       param = 1;
     }
+    if (this._terminal.x >= this._terminal.cols) {
+      this._terminal.x--;
+    }
     this._terminal.x -= param;
     if (this._terminal.x < 0) {
       this._terminal.x = 0;

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -701,6 +701,9 @@ export class InputHandler implements IInputHandler {
     if (this._terminal.y >= this._terminal.rows) {
       this._terminal.y = this._terminal.rows - 1;
     }
+    if (this._terminal.x >= this._terminal.cols) {
+      this._terminal.x--;
+    }
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -123,6 +123,7 @@ export class InputHandler implements IInputHandler {
       this._terminal.y--;
       this._terminal.scroll();
     }
+    // If the end of the line is hit, prevent this action from wrapping around to the next line.
     if (this._terminal.x >= this._terminal.cols) {
       this._terminal.x--;
     }
@@ -220,6 +221,7 @@ export class InputHandler implements IInputHandler {
     if (this._terminal.y >= this._terminal.rows) {
       this._terminal.y = this._terminal.rows - 1;
     }
+    // If the end of the line is hit, prevent this action from wrapping around to the next line.
     if (this._terminal.x >= this._terminal.cols) {
       this._terminal.x--;
     }
@@ -249,6 +251,7 @@ export class InputHandler implements IInputHandler {
     if (param < 1) {
       param = 1;
     }
+    // If the end of the line is hit, prevent this action from wrapping around to the next line.
     if (this._terminal.x >= this._terminal.cols) {
       this._terminal.x--;
     }
@@ -701,6 +704,7 @@ export class InputHandler implements IInputHandler {
     if (this._terminal.y >= this._terminal.rows) {
       this._terminal.y = this._terminal.rows - 1;
     }
+    // If the end of the line is hit, prevent this action from wrapping around to the next line.
     if (this._terminal.x >= this._terminal.cols) {
       this._terminal.x--;
     }

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -60,7 +60,6 @@ export class InputHandler implements IInputHandler {
             this._terminal.scroll();
           }
         } else {
-          this._terminal.x = this._terminal.cols - 1;
           if (ch_width === 2)  // FIXME: check for xterm behavior
             return;
         }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -74,6 +74,7 @@ escapedStateHandler['%'] = (parser, terminal) => {
   parser.setState(ParserState.NORMAL);
   parser.skipNextChar();
 };
+escapedStateHandler[C0.CAN] = (parser) => parser.setState(ParserState.NORMAL);
 
 const csiParamStateHandler: {[key: string]: (parser: Parser) => void} = {};
 csiParamStateHandler['?'] = (parser) => parser.setPrefix('?');
@@ -94,8 +95,9 @@ csiParamStateHandler['"'] = (parser) => parser.setPostfix('"');
 csiParamStateHandler[' '] = (parser) => parser.setPostfix(' ');
 csiParamStateHandler['\''] = (parser) => parser.setPostfix('\'');
 csiParamStateHandler[';'] = (parser) => parser.finalizeParam();
+csiParamStateHandler[C0.CAN] = (parser) => parser.setState(ParserState.NORMAL);
 
-const csiStateHandler: {[key: string]: (handler: IInputHandler, params: number[], prefix: string, postfix: string) => void} = {};
+const csiStateHandler: {[key: string]: (handler: IInputHandler, params: number[], prefix: string, postfix: string, parser: Parser) => void} = {};
 csiStateHandler['@'] = (handler, params, prefix) => handler.insertChars(params);
 csiStateHandler['A'] = (handler, params, prefix) => handler.cursorUp(params);
 csiStateHandler['B'] = (handler, params, prefix) => handler.cursorDown(params);
@@ -144,6 +146,7 @@ csiStateHandler['q'] = (handler, params, prefix, postfix) => {
 csiStateHandler['r'] = (handler, params) => handler.setScrollRegion(params);
 csiStateHandler['s'] = (handler, params) => handler.saveCursor(params);
 csiStateHandler['u'] = (handler, params) => handler.restoreCursor(params);
+csiStateHandler[C0.CAN] = (handler, params, prefix, postfix, parser) => parser.setState(ParserState.NORMAL);
 
 // TODO: Many codes/charsets appear to not be supported
 // See: http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
@@ -477,7 +480,7 @@ export class Parser {
 
         case ParserState.CSI:
           if (ch in csiStateHandler) {
-            csiStateHandler[ch](this._inputHandler, this._terminal.params, this._terminal.prefix, this._terminal.postfix);
+            csiStateHandler[ch](this._inputHandler, this._terminal.params, this._terminal.prefix, this._terminal.postfix, this);
           } else {
             this._terminal.error('Unknown CSI code: %s.', ch);
           }

--- a/src/test/escape-sequences-test.js
+++ b/src/test/escape-sequences-test.js
@@ -102,7 +102,12 @@ describe('xterm output comparison', function() {
         var from_emulator = terminalToString(xterm);
         console.log = CONSOLE_LOG;
         var expected = fs.readFileSync(filename.split('.')[0] + '.text', 'utf8');
-        if (from_emulator != expected) {
+        // Some of the tests have whitespace on the right of lines, we trim all the linex
+        // from xterm.js so ignore this for now at least.
+        var expectedRightTrimmed = expected.split('\n').map(function (l) {
+          return l.replace(/\s+$/, '');
+        }).join('\n');
+        if (from_emulator != expectedRightTrimmed) {
           // uncomment to get noisy output
           throw new Error(formatError(in_file, from_emulator, expected));
         //   throw new Error('mismatch');

--- a/src/test/escape-sequences-test.js
+++ b/src/test/escape-sequences-test.js
@@ -76,6 +76,9 @@ describe('xterm output comparison', function() {
   beforeEach(function () {
     xterm = new Terminal(COLS, ROWS);
     xterm.refresh = function() {};
+    xterm.viewport = {
+      syncScrollArea: function() {}
+    };
   });
 
   // omit stack trace for escape sequence files

--- a/src/test/escape-sequences-test.js
+++ b/src/test/escape-sequences-test.js
@@ -85,11 +85,16 @@ describe('xterm output comparison', function() {
   Error.stackTraceLimit = 0;
   var files = glob.sync('**/escape_sequence_files/*.in');
   // only successful tests for now
-  var successful = [0, 2, 6, 12, 13, 18, 20, 22, 27, 28, 50];
+  var skip = [
+    10, 16, 17, 19, 32, 33, 34, 35, 36, 39,
+    40, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+    51, 52, 54, 55, 56, 57, 58, 59, 60, 61,
+    63, 68
+  ];
   for (var i = 0; i < files.length; i++) {
-    // if (i !== 1) continue;
-  //for (var a in successful) {
-    // var i = successful[a];
+    if (skip.indexOf(i) >= 0) {
+      continue;
+    }
     (function(filename) {
       it(filename.split('/').slice(-1)[0], function () {
         pty_reset();

--- a/src/test/escape-sequences-test.js
+++ b/src/test/escape-sequences-test.js
@@ -56,7 +56,7 @@ function formatError(in_, out_, expected) {
 function terminalToString(term) {
   var result = '';
   var line_s = '';
-  for (var line=0; line<term.rows; ++line) {
+  for (var line = term.ybase; line < term.ybase + term.rows; line++) {
     line_s = '';
     for (var cell=0; cell<term.cols; ++cell) {
       line_s += term.lines.get(line)[cell][1];
@@ -82,10 +82,12 @@ describe('xterm output comparison', function() {
   Error.stackTraceLimit = 0;
   var files = glob.sync('**/escape_sequence_files/*.in');
   // only successful tests for now
-  var successful = [0, 2, 6, 12, 13, 18, 20, 22, 27, 28];
-  for (var a in successful) {
-    var i = successful[a];
-    (function(filename){
+  var successful = [0, 2, 6, 12, 13, 18, 20, 22, 27, 28, 50];
+  for (var i = 0; i < files.length; i++) {
+    // if (i !== 1) continue;
+  //for (var a in successful) {
+    // var i = successful[a];
+    (function(filename) {
       it(filename.split('/').slice(-1)[0], function () {
         pty_reset();
         var in_file = fs.readFileSync(filename, 'utf8');
@@ -102,8 +104,8 @@ describe('xterm output comparison', function() {
         var expected = fs.readFileSync(filename.split('.')[0] + '.text', 'utf8');
         if (from_emulator != expected) {
           // uncomment to get noisy output
-          //throw new Error(formatError(in_file, from_emulator, expected));
-          throw new Error('mismatch');
+          throw new Error(formatError(in_file, from_emulator, expected));
+        //   throw new Error('mismatch');
         }
       });
     })(files[i]);

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -595,8 +595,9 @@ describe('xterm.js', function() {
         xterm.x = xterm.cols - 1;
         xterm.wraparoundMode = false;
         xterm.write('a' + high + String.fromCharCode(i));
-        expect(xterm.lines.get(0)[xterm.cols-1][1]).eql(high + String.fromCharCode(i));
-        expect(xterm.lines.get(0)[xterm.cols-1][1].length).eql(2);
+        // auto wraparound mode should cut off the rest of the line
+        expect(xterm.lines.get(0)[xterm.cols-1][1]).eql('a');
+        expect(xterm.lines.get(0)[xterm.cols-1][1].length).eql(1);
         expect(xterm.lines.get(1)[1][1]).eql(' ');
         xterm.reset();
       }

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2303,6 +2303,7 @@ Terminal.prototype.index = function() {
     this.y--;
     this.scroll();
   }
+  // If the end of the line is hit, prevent this action from wrapping around to the next line.
   if (this.x >= this.cols) {
     this.x--;
   }

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2303,6 +2303,9 @@ Terminal.prototype.index = function() {
     this.y--;
     this.scroll();
   }
+  if (this.x >= this.cols) {
+    this.x--;
+  }
 };
 
 


### PR DESCRIPTION
This PR fixes many of the tests in escape-sequence-tests.js, see the commits for details on the individual changes. Previously 10 tests were passing, now 30+ are.

The major fixes:

- `CAN` has been implemented which cancels any escape sequence, the corresponding test does not work still due to complex ignore logic in xterm that we don't have parity with
- Index, LF/VT/FF, CUB, CUD, VPR behavior was change to stay at the end of the column if it was otherwise going to go to wraparound
- When wraparound mode is disabled output will be cut off the end, no longer will the last character always be displayed in the last column
- There was an error which cause causing our tests to compare only the first page of the buffer, not the viewport.
- Expected output was trimmed as we don't care, at least not currently (we trim all output from xterm.js anyway).

There is a failing test:

```
1) xterm.js unicode - surrogates 2 characters per cell over line end without autowrap:

      AssertionError: expected 'a' to deeply equal '𐀀'
      + expected - actual

      -a
      +𐀀
```

This is likely because it relied on the previous wraparound disabled logic which I believe was wrong. @jerch thoughts since you added it?