### PR TITLE
Add null check on Terminal.element

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1045,7 +1045,7 @@ Terminal.prototype.destroy = function() {
   this._events = {};
   this.handler = function() {};
   this.write = function() {};
-  if (this.element.parentNode) {
+  if (this.element && this.element.parentNode) {
     this.element.parentNode.removeChild(this.element);
   }
   //this.emit('close');


### PR DESCRIPTION
Since the Terminal can be used now before being attached, we should check element on destroy.

Related to #266