### PR TITLE
Fix issue when resizing hidden terminals

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1973,6 +1973,10 @@ Terminal.prototype.error = function() {
  * @param {number} y The number of rows to resize to.
  */
 Terminal.prototype.resize = function(x, y) {
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    return;
+  }
+
   var line
   , el
   , i


### PR DESCRIPTION
Whilst using the 'fit' addon, if you run `Terminal.fit()` whilst the terminal is hidden (with `display: none` for example), then the terminal will become unusable.
The solution I'm proposing is to exit the `Terminal.resize()` function if either the x or y parameter is a NaN value. 