### PR TITLE
Remove excess library.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ const sorcery = require('sorcery');
 const source = require('vinyl-source-stream');
 const sourcemaps = require('gulp-sourcemaps');
 const ts = require('gulp-typescript');
-const tsify = require('tsify');
 
 
 let buildDir = process.env.BUILD_DIR || 'build';
@@ -53,7 +52,6 @@ gulp.task('browserify', ['tsc'], function() {
     packageCache: {}
   };
   let bundleStream = browserify(browserifyOptions)
-        .plugin(tsify)
         .bundle()
         .pipe(source('xterm.js'))
         .pipe(buffer())

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "nodemon": "1.10.2",
     "sleep": "^3.0.1",
     "sorcery": "^0.10.0",
-    "tsify": "^3.0.0",
     "tslint": "^4.0.2",
     "typescript": "^2.0.3",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
Tsify lib used for browserify typescript sources. But folder /lib consist of js files has already compiled from TypeScript sources (by gulp task "tsc"). So Tsify library does nothing in this case.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>