### PR TITLE
Fix missing Number.isNaN in IE

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1715,7 +1715,7 @@ Terminal.prototype.error = function() {
  * @param {number} y The number of rows to resize to.
  */
 Terminal.prototype.resize = function(x, y) {
-  if (Number.isNaN(x) || Number.isNaN(y)) {
+  if (isNaN(x) || isNaN(y)) {
     return;
   }
 


### PR DESCRIPTION
See https://github.com/sourcelair/xterm.js/pull/525#issuecomment-278497452

I think we should commit this fix as 2.3.1 ASAP!