### PR TITLE
Fix 'Autowrap Mode' after 'Soft Terminal reset' command.

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1394,7 +1394,7 @@ export class InputHandler implements IInputHandler {
     this._terminal.cursorHidden = false;
     this._terminal.insertMode = false;
     this._terminal.originMode = false;
-    this._terminal.wraparoundMode = false; // autowrap
+    this._terminal.wraparoundMode = true;  // defaults: xterm - true, vt100 - false
     this._terminal.applicationKeypad = false; // ?
     this._terminal.viewport.syncScrollArea();
     this._terminal.applicationCursor = false;


### PR DESCRIPTION
Enable "[Autowrap Mode](http://www.vt100.net/docs/vt510-rm/DECAWM.html)" after "Soft Terminal Reset" command function "\[!p" http://www.vt100.net/docs/vt510-rm/DECSTR.html for XTERM.
What issues does this PR fix or reference? 
https://github.com/sourcelair/xterm.js/issues/540