### PR TITLE
Perform initial viewport sync after CharMeasure is ready

### DIFF
--- a/src/Viewport.test.ts
+++ b/src/Viewport.test.ts
@@ -41,13 +41,17 @@ describe('Viewport', () => {
   });
 
   describe('refresh', () => {
-    it('should set the line-height of the terminal', () => {
-      assert.equal(viewportElement.style.lineHeight, CHARACTER_HEIGHT + 'px');
-      assert.equal(terminal.rowContainer.style.lineHeight, CHARACTER_HEIGHT + 'px');
-      charMeasure.height = 1;
-      viewport.refresh();
-      assert.equal(viewportElement.style.lineHeight, '1px');
-      assert.equal(terminal.rowContainer.style.lineHeight, '1px');
+    it('should set the line-height of the terminal', done => {
+      // Allow CharMeasure to be initialized
+      setTimeout(() => {
+        assert.equal(viewportElement.style.lineHeight, CHARACTER_HEIGHT + 'px');
+        assert.equal(terminal.rowContainer.style.lineHeight, CHARACTER_HEIGHT + 'px');
+        charMeasure.height = 1;
+        viewport.refresh();
+        assert.equal(viewportElement.style.lineHeight, '1px');
+        assert.equal(terminal.rowContainer.style.lineHeight, '1px');
+        done();
+      }, 0);
     });
     it('should set the height of the viewport when the line-height changed', () => {
       terminal.lines.push('');
@@ -62,17 +66,21 @@ describe('Viewport', () => {
   });
 
   describe('syncScrollArea', () => {
-    it('should sync the scroll area', () => {
-      terminal.lines.push('');
-      terminal.rows = 1;
-      assert.equal(scrollAreaElement.style.height, 0 * CHARACTER_HEIGHT + 'px');
-      viewport.syncScrollArea();
-      assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
-      assert.equal(scrollAreaElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
-      terminal.lines.push('');
-      viewport.syncScrollArea();
-      assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
-      assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
+    it('should sync the scroll area', done => {
+      // Allow CharMeasure to be initialized
+      setTimeout(() => {
+        terminal.lines.push('');
+        terminal.rows = 1;
+        assert.equal(scrollAreaElement.style.height, 0 * CHARACTER_HEIGHT + 'px');
+        viewport.syncScrollArea();
+        assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+        assert.equal(scrollAreaElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+        terminal.lines.push('');
+        viewport.syncScrollArea();
+        assert.equal(viewportElement.style.height, 1 * CHARACTER_HEIGHT + 'px');
+        assert.equal(scrollAreaElement.style.height, 2 * CHARACTER_HEIGHT + 'px');
+        done();
+      }, 0);
     });
   });
 });

--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -35,7 +35,8 @@ export class Viewport {
     this.terminal.on('resize', this.syncScrollArea.bind(this));
     this.viewportElement.addEventListener('scroll', this.onScroll.bind(this));
 
-    this.syncScrollArea();
+    // Perform this async to ensure the CharMeasure is ready.
+    setTimeout(() => this.syncScrollArea(), 0);
   }
 
   /**


### PR DESCRIPTION
Fixes #539 

---

@parisk I recommend putting this in for 2.3.2 as otherwise the background won't be the right size until after resize is called.