### PR TITLE
Fix non-IME character input in Safari (both mobile and desktop)

### DIFF
--- a/src/utils/Browser.ts
+++ b/src/utils/Browser.ts
@@ -7,11 +7,16 @@
 import { contains } from './Generic';
 
 const isNode = (typeof navigator === 'undefined') ? true : false;
+const g = (isNode) ? global : (<any>window);
 const userAgent = (isNode) ? 'node' : navigator.userAgent;
 const platform = (isNode) ? 'node' : navigator.platform;
 
 export const isFirefox = !!~userAgent.indexOf('Firefox');
 export const isMSIE = !!~userAgent.indexOf('MSIE') || !!~userAgent.indexOf('Trident');
+export const isSafari = (isNode) ? false : (/constructor/i.test(g.HTMLElement)
+                                            || ((p) => {
+                                                 return p.toString() === "[object SafariRemoteNotification]";
+                                               })(!g['safari'] || g['safari'].pushNotification));
 
 // Find the users platform. We use this to interpret the meta key
 // and ISO third level shifts.

--- a/src/utils/Browser.ts
+++ b/src/utils/Browser.ts
@@ -15,7 +15,7 @@ export const isFirefox = !!~userAgent.indexOf('Firefox');
 export const isMSIE = !!~userAgent.indexOf('MSIE') || !!~userAgent.indexOf('Trident');
 export const isSafari = (isNode) ? false : (/constructor/i.test(g.HTMLElement)
                                             || ((p) => {
-                                                 return p.toString() === "[object SafariRemoteNotification]";
+                                                 return p.toString() === '[object SafariRemoteNotification]';
                                                })(!g['safari'] || g['safari'].pushNotification));
 
 // Find the users platform. We use this to interpret the meta key

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -335,16 +335,6 @@ Terminal.vcolors = (function() {
 })();
 
 /**
- * Browser compatibility flags.
- */
-
-// Check if we are running on Safari
-// (ref: http://stackoverflow.com/questions/9847580)
-Terminal.isSafari =  /constructor/i.test(window.HTMLElement)
-                 || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })
-                    (!window['safari'] || safari.pushNotification);
-
-/**
  * Options
  */
 
@@ -546,11 +536,11 @@ Terminal.bindKeys = function(term) {
     term.keyDown(ev);
   }, true);
 
-  var keyPressEventName = (Terminal.isSafari) ? 'textInput' : 'keypress';
+  var keyPressEventName = (term.browser.isSafari) ? 'textInput' : 'keypress';
   on(term.textarea, keyPressEventName, function(ev) {
     term.keyPress(ev);
     // Truncate the textarea's value, since it is not needed
-    term.textarea.value = '';
+    this.value = '';
   }, true);
 
   on(term.textarea, 'compositionstart', term.compositionHelper.compositionstart.bind(term.compositionHelper));
@@ -1646,7 +1636,7 @@ Terminal.prototype.keyPress = function(ev) {
     return false;
   }
 
-  if (Terminal.isSafari) {
+  if (this.browser.isSafari) {
     key = ev.data;
   } else {
     if (ev.charCode) {


### PR DESCRIPTION
Regarding my comment to #346, I propose a PR to fix it.

I have some updates to my comment as well:

 * I found that duplicate keystrokes in my Firefox was a bogus error and it never happened again.
 * Also, broken Korean IME input in Chrome was actually related to the shell's locale and inputrc settings<sup>[(1)](#fn1)</sup> and not a bug in xterm.js.

<sup><a name="fn1">(1)</a></sup> I had to uncomment `set convert-meta off` in `/etc/inputrc` inside my tested Ubuntu container connected via xterm.js, and run `locale-gen en_US.UTF-8` with setting `LANG` environment variable. In docker containers, base images often omit default locale settings to keep the image sizes small.

So, with my patch, I confirmed that both IME and non-IME input works well with latest versions of Chrome/Safari/Firefox on macOS, Safari on iOS, and Edge on Windows 10.

Known problem:

 * When typing fast (repeating to press another key before release the previous one), sometimes keystrokes are duplicate. But on normal typing, this almost doesn't happen. It seems to be a Safari bug in handling keyboard events.

Here follows the commit log:

 * Safari does not fire keypress events but textInput events when typing
   individual English characters.

 * Chrome and IE 9 also support textInput event but they also support
   keypress event -- let's favor the more widely adopted name, keypress,
   if they provide equivalent functionality.

 * Modern practices favor feature detection instead of browser
   detection, but I resorted to the latter via `Terminal.isSafari` flag.
   It's difficult to use feature detection for textInput event as there
   is no "ontextinput" attribute and Safari also provides "onkeypress"
   event handler though it is not fired as expected.