### PR TITLE
Let blink animation support style inheritance

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -87,13 +87,10 @@
 }
 
 @keyframes xterm-cursor-blink {
-    0% {
-        background-color: #fff;
-        color: #000;
-    }
+    0% { }
     50% {
         background-color: transparent;
-        color: #FFF;
+        color: inherit;
     }
 }
 


### PR DESCRIPTION
With this change, blinking cursor will use the same font and background
color that set before, so that changing the style of cursor automatically applies to the animation.

Example:

In demo, change the background color to some light color and foreground color to some dark color, then enable blink:
~~~css
#terminal-container .terminal {
    background-color: #ccc;
    color: #333;
    padding: 2px;
}

#terminal-container .xterm-viewport {
    background-color: #ccc;
}

#terminal-container .terminal:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
    background-color: #333;
    color: #ccc;
}

#terminal-container .terminal:not(.focus) .terminal-cursor {
    outline: 1px solid #333;
    outline-offset: -1px;
    background-color: transparent;
}
~~~

cursorBlink off:

<img width="405" alt="screen shot 2017-02-14 at 1 49 52 pm" src="https://cloud.githubusercontent.com/assets/4104205/22943704/82558cd6-f2bc-11e6-8b30-0998c084470a.png">

Expected (and actual with this PR):

![](http://g.recordit.co/vcu8Pr9rMX.gif)

Actual (without this PR):

![](http://g.recordit.co/TDllqZWt2Q.gif)
