### PR TITLE
Fix demo: wrong pid on windows #567

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -69,7 +69,7 @@ app.ws('/terminals/:pid', function (ws, req) {
     term.write(msg);
   });
   ws.on('close', function () {
-    process.kill(term.pid);
+    term.kill();
     console.log('Closed terminal ' + term.pid);
     // Clean things up
     delete terminals[term.pid];


### PR DESCRIPTION
Looks like [pid on windows is wrong](http://unix.stackexchange.com/questions/258955/what-does-esrch-mean). There is [such issue in pty.js repo](https://github.com/chjj/pty.js/issues/61) maybe it is still not fixed in `node-pty`. Anyway changing the way of killing process works for me.

```sh
> xterm@2.3.2 start C:\Users\coderaiser\Documents\GitHub\xterm.js
> node demo/app

App listening to http://127.0.0.1:3000
Created terminal with PID: 928
Connected to terminal 928
internal/process.js:173
      throw errnoException(err, 'kill');
      ^

Error: kill ESRCH
    at exports._errnoException (util.js:1022:11)
    at process.kill (internal/process.js:173:13)
    at WebSocket.<anonymous> (C:\Users\coderaiser\Documents\GitHub\xterm.js\demo\app.js:72:13)
    at emitTwo (events.js:111:20)
    at WebSocket.emit (events.js:191:7)
    at WebSocket.cleanupWebsocketResources (C:\Users\coderaiser\Documents\GitHub\xterm.js\node_modules\ws\lib\WebSocket.js:950:8)
    at emitOne (events.js:101:20)
    at Socket.emit (events.js:188:7)
    at emitErrorNT (net.js:1281:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)

npm ERR! Windows_NT 10.0.14393
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "start"
npm ERR! node v7.2.0
npm ERR! npm  v3.10.9
npm ERR! code ELIFECYCLE
npm ERR! xterm@2.3.2 start: `node demo/app`
npm ERR! Exit status 1
```