### PR TITLE
Fixed characterHeight calculation, which could cause overflowing

### DIFF
--- a/src/addons/fit/fit.js
+++ b/src/addons/fit/fit.js
@@ -56,7 +56,7 @@
     subjectRow.innerHTML = 'W'; // Common character for measuring width, although on monospace
     characterWidth = subjectRow.getBoundingClientRect().width;
     subjectRow.style.display = ''; // Revert style before calculating height, since they differ.
-    characterHeight = parseFloat(term.rowContainer.style.lineHeight);
+    characterHeight = subjectRow.getBoundingClientRect().height;
     subjectRow.innerHTML = contentBuffer;
 
     rows = parseInt(availableHeight / characterHeight);

--- a/src/addons/fit/fit.js
+++ b/src/addons/fit/fit.js
@@ -56,7 +56,7 @@
     subjectRow.innerHTML = 'W'; // Common character for measuring width, although on monospace
     characterWidth = subjectRow.getBoundingClientRect().width;
     subjectRow.style.display = ''; // Revert style before calculating height, since they differ.
-    characterHeight = parseInt(subjectRow.offsetHeight);
+    characterHeight = parseFloat(term.rowContainer.style.lineHeight);
     subjectRow.innerHTML = contentBuffer;
 
     rows = parseInt(availableHeight / characterHeight);


### PR DESCRIPTION
The previous calculation was simply using the height of the letter
W, but wasn't taking into account that each row has a lineHeight,
which might be greater. If the lineHeight is .4px off, after many
rows, it will cause the proposedGeometry to have an extra row,
potentially causing hidden rows (based on layout).