### PR TITLE
Fix cursor style on blurred terminals

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -86,7 +86,7 @@
     text-decoration: none;
 }
 
-.terminal:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
+.terminal.focus:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
     background-color: #fff;
     color: #000;
 }


### PR DESCRIPTION
After #492 the hollow cursor style implemented in #82 broke. It displayed a filled cursor in blurred terminals, when no explicit cursor style was set (`underline` or `bar`).

This PR applies the "generic" cursor styling only when the terminal is focused.

This means that a blurred terminal will always display a hollow "block" cursor from now on.

I think that this is the best experience possible in the blurred state, since it's the same for all cursor styles and it's quite hard to think of a way to apply "blurred" state on cursor styles that are just a line (`underline` or `bar`)