### PR TITLE
Implement getState method

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -68,7 +68,7 @@ function createTerminal() {
   protocol = (location.protocol === 'https:') ? 'wss://' : 'ws://';
   socketURL = protocol + location.hostname + ((location.port) ? (':' + location.port) : '') + '/terminals/';
 
-  term.open(terminalContainer);
+  term.open(terminalContainer, true);
   term.fit();
 
   var initialGeometry = term.proposeGeometry(),

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -305,8 +305,20 @@ Terminal.prototype.getState = function() {
     'cursorBlink', 'disableStdin', 'scrollback', 'tabStopWidth', 'useFlowControl'
   ];
 
+  let normalBuffer = this.lines._array;
+  let altBuffer = null;
+
+  // This means that the alt buffer is active
+  if (this.normal) {
+    altBuffer = normalBuffer;
+    normalBuffer = this.normal.lines._array;
+  }
+
   let state = {
-    buffer: this.lines._array,
+    buffers: {
+      normal: normalBuffer,
+      alt: altBuffer
+    },
     cursor: this._getCursor(),
     geometry: this.geometry,
     mode: this._getMode(),

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -306,6 +306,7 @@ Terminal.prototype.getState = function() {
   ];
 
   let state = {
+    buffer: this.lines._array,
     cursor: this._getCursor(),
     geometry: this.geometry,
     mode: this._getMode(),


### PR DESCRIPTION
This is a PoC for a `getState` terminal method that will return the serialized current state of the terminal.

## Things to include in state

- [x] Geometry
- [x] Mode
- [x] Buffer
- [x] Alt buffer
- [x] Cursor position
- [x] Cursor style
- [x] Options
- [ ] Version

## To do

- [x] Add all members in state
- [ ] Implement tests for `getState`

## State size
It seems that the serialized state of the terminal can get kinda big, relatively easily. This happens because of the (verbose) way we are storing the buffers.

Maybe we should entertain the idea of keeping less information in memory and computing some things on the fly instead, considering buffers.

### Example
1. Open the xterm.js demo
2. Run `less typings.json` in the terminal
3. Then use `term.getState()` in the browser's dev tools to retrieve the state
4. The resulting state is almost 250KBs and 25k+ lines of prettified JSON data

### Screenshot
![image](https://cloud.githubusercontent.com/assets/1188592/26521301/1b3cf48c-42dd-11e7-8a6d-c0c558073db4.png)


This PR should eventually close #595.