### PR TITLE
Added Spyder IDE Terminal as a xterm case-use application

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**Codenvy**](http://www.codenvy.com): Cloud workspaces for development teams.
 - [**CoderPad**](https://coderpad.io): Online interviewing platform for programmers. Run code in many programming languages, with results displayed by `xterm.js`.
 - [**WebSSH2**](https://github.com/billchurch/WebSSH2): A web based SSH2 client using `xterm.js`, socket.io, and ssh2.
+- [**Spyder Terminal**](https://github.com/spyder-ide/spyder-terminal): A full fledged system terminal embedded on Spyder IDE. 
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
At Spyder IDE organization we've implemented a embed version of xterm.js inside a Qt Widget, this project, named [Spyder Terminal](https://github.com/spyder-ide/spyder-terminal) allows users to interact with a terminal inside the IDE

![captura de pantalla de 2017-03-18 15-54-00](https://cloud.githubusercontent.com/assets/1878982/24076709/a7a4bc98-0c05-11e7-8d7e-7d13c00b8b28.png)
