### PR TITLE
Prevent line data from being discarded on resize.

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1805,14 +1805,8 @@ Terminal.prototype.resize = function(x, y) {
         this.lines.get(i).push(ch);
       }
     }
-  } else { // (j > x)
-    i = this.lines.length;
-    while (i--) {
-      while (this.lines.get(i).length > x) {
-        this.lines.get(i).pop();
-      }
-    }
   }
+
   this.cols = x;
   this.setupStops(this.cols);
 


### PR DESCRIPTION
One of the core issues I'm trying to address in this PR https://github.com/sourcelair/xterm.js/pull/609 is that xterm.js will discard line data when resizing to smaller widths. As the discussion around reflow behaviour and architecture is still ongoing and may be for some time yet, I'm submitting this PR as an interim fix.
This PR prevents the character discard and uses behaviour similar to hyperterm.

![linepreserve](https://cloud.githubusercontent.com/assets/15064535/24079375/70caea52-0c7e-11e7-9425-ce93ad17c821.gif)
