### PR TITLE
Added Cloud Commander to real world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**CoderPad**](https://coderpad.io): Online interviewing platform for programmers. Run code in many programming languages, with results displayed by `xterm.js`.
 - [**WebSSH2**](https://github.com/billchurch/WebSSH2): A web based SSH2 client using `xterm.js`, socket.io, and ssh2.
 - [**Spyder Terminal**](https://github.com/spyder-ide/spyder-terminal): A full fledged system terminal embedded on Spyder IDE. 
+- [**Cloud Commander**](https://cloudcmd.io "Cloud Commander"): Orthodox web file manager with console and editor.
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
[Cloud Commander](https://cloudcmd.io) uses `xterm` as an embedded terminal which can be additionally installed and enabled (with help of [gritty](https://github.com/cloudcmd/gritty)). 
![menu](https://cloud.githubusercontent.com/assets/1573141/24502119/109893ca-1555-11e7-818d-2fb85b64ab18.png)

Can be opened with `Shift + ~` and closed with `Shift + Esc`.

![terminal](https://cloud.githubusercontent.com/assets/1573141/24502122/130bc050-1555-11e7-8e47-cd04f6b6c4f5.png)

