### PR TITLE
Workaround IME composition bug in Chrome v55 and v56

### DIFF
--- a/src/CompositionHelper.ts
+++ b/src/CompositionHelper.ts
@@ -10,6 +10,7 @@ interface IPosition {
 }
 
 const isChromev55v56 = (
+  typeof navigator === 'object' &&
   (navigator.userAgent.indexOf('Chrome/55.') >= 0 || navigator.userAgent.indexOf('Chrome/56.') >= 0)
   /* Edge likes to impersonate Chrome sometimes */
   && navigator.userAgent.indexOf('Edge/') === -1

--- a/src/CompositionHelper.ts
+++ b/src/CompositionHelper.ts
@@ -75,7 +75,7 @@ export class CompositionHelper {
    * @param {CompositionEvent} ev The event.
    */
   public compositionupdate(ev: CompositionEvent) {
-    if (isChromev55v56 || isEdgeOrIE) {
+    if (isChromev55v56 || (isEdgeOrIE && ev.locale === 'ja')) {
       // See https://github.com/Microsoft/monaco-editor/issues/320
       // where compositionupdate .data is broken in Chrome v55 and v56
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=677050#c9

--- a/src/CompositionHelper.ts
+++ b/src/CompositionHelper.ts
@@ -92,7 +92,13 @@ export class CompositionHelper {
    * the handler.
    */
   public compositionend() {
-    this.finalizeComposition(true);
+    if (isChromev55v56) {
+      setTimeout(() => {
+        this.finalizeComposition(true);
+      }, 0);
+    } else {
+      this.finalizeComposition(true);
+    }
   }
 
   /**

--- a/src/CompositionHelper.ts
+++ b/src/CompositionHelper.ts
@@ -9,6 +9,11 @@ interface IPosition {
   end: number;
 }
 
+export const isEdgeOrIE = (
+  typeof navigator === 'object' &&
+  (navigator.userAgent.indexOf('Trident') >= 0 || navigator.userAgent.indexOf('Edge/') >= 0)
+)
+
 const isChromev55v56 = (
   typeof navigator === 'object' &&
   (navigator.userAgent.indexOf('Chrome/55.') >= 0 || navigator.userAgent.indexOf('Chrome/56.') >= 0)
@@ -70,7 +75,7 @@ export class CompositionHelper {
    * @param {CompositionEvent} ev The event.
    */
   public compositionupdate(ev: CompositionEvent) {
-    if (isChromev55v56) {
+    if (isChromev55v56 || isEdgeOrIE) {
       // See https://github.com/Microsoft/monaco-editor/issues/320
       // where compositionupdate .data is broken in Chrome v55 and v56
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=677050#c9
@@ -93,7 +98,7 @@ export class CompositionHelper {
    * the handler.
    */
   public compositionend() {
-    if (isChromev55v56) {
+    if (isChromev55v56 || isEdgeOrIE) {
       setTimeout(() => {
         this.finalizeComposition(true);
       }, 0);


### PR DESCRIPTION
Bug in Chrome v55 and v56: compositionupdate .data is broken so in these two versions of Chrome, in composition state, unconfirmed text of CJK IME collapse to one character:

![terminalcjk](https://cloud.githubusercontent.com/assets/876920/24977391/c79d0494-1f81-11e7-9c7d-1f6ce42b91ec.gif)

Electron shipped their latest version with Chrome v56 so anyone who is adopting the latest version of Chrome can run into this IME bug. We already fixed that for editor in VS Code https://github.com/Microsoft/vscode/issues/24557 but we may still want to fix this in xterm.js for Integrated Terminal.