### PR TITLE
Add "Terminal for Atom" to Real-World Uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**Cloud Commander**](https://cloudcmd.io "Cloud Commander"): Orthodox web file manager with console and editor.
 - [**Codevolve**](https://www.codevolve.com "Codevolve"): Online platform for interactive coding and web development courses. Live container-backed terminal uses `xterm.js`.
 - [**RStudio**](https://www.rstudio.com/products/RStudio "RStudio"): RStudio is an integrated development environment (IDE) for R.
+- [**Terminal for Atom**](https://github.com/jsmecham/atom-terminal-tab): A simple terminal for the Atom text editor.
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
I've just released the first version of an Xterm.js-based terminal for Atom that takes full advantage of Docks and Panes.