### PR TITLE
Add "Eclipse Orion" to "Real-World Uses".

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**Codevolve**](https://www.codevolve.com "Codevolve"): Online platform for interactive coding and web development courses. Live container-backed terminal uses `xterm.js`.
 - [**RStudio**](https://www.rstudio.com/products/RStudio "RStudio"): RStudio is an integrated development environment (IDE) for R.
 - [**Terminal for Atom**](https://github.com/jsmecham/atom-terminal-tab): A simple terminal for the Atom text editor.
+- [**Eclipse Orion**](https://orionhub.org): A modern, open source software development environment that runs in the cloud. Code, deploy and run in the cloud.
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
Eclipse Orion has switched from `term.js` to `xterm.js` because of better AMD support and the active maintaince.