### PR TITLE
Force failing mocha tests to return a exit code of 1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,7 @@ gulp.task('instrument-test', function () {
 gulp.task('mocha', ['instrument-test'], function () {
   return gulp.src([`${outDir}/*test.js`, `${outDir}/**/*test.js`], {read: false})
       .pipe(mocha())
+      .once('error', () => process.exit(1))
       .pipe(istanbul.writeReports());
 });
 


### PR DESCRIPTION
Fixes #651