### PR TITLE
Normalize line endings on paste

### DIFF
--- a/src/handlers/Clipboard.test.ts
+++ b/src/handlers/Clipboard.test.ts
@@ -16,3 +16,14 @@ describe('evaluateCopiedTextProcessing', function () {
     assert.equal(processedText.indexOf(nonBreakingSpace), -1);
   });
 });
+
+describe('evaluatePastedTextProcessing', function () {
+  it('should replace carriage return + line feed with line feed on windows', function () {
+    const pastedText = 'foo\r\nbar\r\n',
+          processedText = Clipboard.prepareTextForTerminal(pastedText, false),
+          windowsProcessedText = Clipboard.prepareTextForTerminal(pastedText, true);
+
+    assert.equal(processedText, 'foo\r\nbar\r\n');
+    assert.equal(windowsProcessedText, 'foo\nbar\n');
+  });
+});

--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -39,6 +39,17 @@ export function prepareTextForClipboard(text: string): string {
 }
 
 /**
+ * Prepares text to be pasted into the terminal by normalizing the line endings
+ * @param text The pasted text that needs processing before inserting into the terminal
+ */
+export function prepareTextForTerminal(text: string, isMSWindows: boolean): string {
+  if (isMSWindows) {
+    return text.replace(/\r?\n/g, '\n');
+  }
+  return text;
+}
+
+/**
  * Binds copy functionality to the given terminal.
  * @param {ClipboardEvent} ev The original copy event to be handled
  */
@@ -68,6 +79,7 @@ export function pasteHandler(ev: ClipboardEvent, term: ITerminal) {
   let text: string;
 
   let dispatchPaste = function(text) {
+    text = prepareTextForTerminal(text, term.browser.isMSWindows);
     term.handler(text);
     term.textarea.value = '';
     return term.cancel(ev);


### PR DESCRIPTION
Enables pasting multi-line text into the terminal.

cc @EisenbergEffect, @yangl900, @DuncanmaMSFT

Fixes #660