### PR TITLE
Fix bug with parser state when using vtop

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -181,7 +181,7 @@ export class Parser {
    *
    * @param data The data to parse.
    */
-  public parse(data: string) {
+  public parse(data: string): ParserState {
     let l = data.length, j, cs, ch, code, low;
 
     this._position = 0;
@@ -564,6 +564,7 @@ export class Parser {
           break;
       }
     }
+    return this._state;
   }
 
   /**

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1252,7 +1252,13 @@ Terminal.prototype.innerWrite = function() {
     this.refreshStart = this.y;
     this.refreshEnd = this.y;
 
-    this.parser.parse(data);
+    // HACK: Set the parser state based on it's state at the time of return.
+    // This works around the bug #662 which saw the parser state reset in the
+    // middle of parsing escape sequence in two chunks. For some reason the
+    // state of the parser resets to 0 after exiting parser.parse. This change
+    // just sets the state back based on the correct return statement.
+    var state = this.parser.parse(data);
+    this.parser.setState(state);
 
     this.updateRange(this.y);
     this.refresh(this.refreshStart, this.refreshEnd);


### PR DESCRIPTION
Fixes #662 

---

See the comment in code for an explanation, I couldn't figure out the root cause but after `Parser.parse` finished, the state of it would reset. Interestingly, this works:

```js
var state = this.parser.parse(data);
this.parser.setState(state);
```

Where this does not:

```js
this.parser.setState(this.parser.parse(data));
```