### PR TITLE
Restore the "paste" terminal event

### DIFF
--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -82,6 +82,8 @@ export function pasteHandler(ev: ClipboardEvent, term: ITerminal) {
     text = prepareTextForTerminal(text, term.browser.isMSWindows);
     term.handler(text);
     term.textarea.value = '';
+    term.emit('paste', text);
+
     return term.cancel(ev);
   };
 


### PR DESCRIPTION
Restores the `paste` terminal event (which is also used in the demo).

Fixes #671.