### PR TITLE
Use the Menlo font when possible

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -38,7 +38,7 @@
 .terminal {
     background-color: #000;
     color: #fff;
-    font-family: courier-new, courier, monospace;
+    font-family: Menlo, courier-new, courier, monospace;
     font-feature-settings: "liga" 0;
     position: relative;
 }


### PR DESCRIPTION
This font seems to work better than the alternatives on OSX.

Before:
<img width="732" src="https://cloud.githubusercontent.com/assets/1037931/26584536/02ee87e0-4541-11e7-9204-13b58d2fd71c.png">

After:
<img width="1039" src="https://cloud.githubusercontent.com/assets/1037931/26584542/0868dd24-4541-11e7-8335-0fe978cb0b18.png">
