### PR TITLE
Fix issue with strings in wrapped spans being duplicated

### DIFF
--- a/src/Linkifier.test.ts
+++ b/src/Linkifier.test.ts
@@ -119,6 +119,12 @@ describe('Linkifier', () => {
       it('should match a link immediately after a link at the end of a text node', done => {
         assertLinkifiesRow('<span>foo bar</span>baz', /bar|baz/, '<span>foo <a>bar</a></span><a>baz</a>', done);
       });
+      it('should not duplicate text after a unicode character (wrapped in a span)', done => {
+        // This is a regression test for an issue that came about when using
+        // an oh-my-zsh theme that added the large blue diamond unicode
+        // character (U+1F537) which caused the path to be duplicated. See #642.
+        assertLinkifiesRow('echo \'<span class="xterm-normal-char">🔷</span>foo\'', /foo/, 'echo \'<span class="xterm-normal-char">🔷</span><a>foo</a>\'', done);
+      });
     });
 
     describe('validationCallback', () => {


### PR DESCRIPTION
This was happening because the linkifier assumed that top-level spans
in the terminal would only contain single text nodes

Fixes #642