### PR TITLE
normalize line endings to \r

### DIFF
--- a/src/handlers/Clipboard.test.ts
+++ b/src/handlers/Clipboard.test.ts
@@ -9,6 +9,6 @@ describe('evaluatePastedTextProcessing', function () {
           windowsProcessedText = Clipboard.prepareTextForTerminal(pastedText, true);
 
     assert.equal(processedText, 'foo\r\nbar\r\n');
-    assert.equal(windowsProcessedText, 'foo\nbar\n');
+    assert.equal(windowsProcessedText, 'foo\rbar\r');
   });
 });

--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -22,7 +22,7 @@ declare var window: IWindow;
  */
 export function prepareTextForTerminal(text: string, isMSWindows: boolean): string {
   if (isMSWindows) {
-    return text.replace(/\r?\n/g, '\n');
+    return text.replace(/\r?\n/g, '\r');
   }
   return text;
 }


### PR DESCRIPTION
fixes #683 

I tested pasting with the following environment / code snippet combinations:

* ubuntu + bash
  ```
  cd \
  src
  ```

* windows + cmd.exe
  ```
  cd ^
  src
  ```

* windows + powershell.exe
  ```
  cd `
  src
  ```
