### PR TITLE
Don't select colon, quotes or brackets when double clicking

### DIFF
--- a/src/SelectionManager.test.ts
+++ b/src/SelectionManager.test.ts
@@ -142,6 +142,41 @@ describe('SelectionManager', () => {
       selectionManager.selectWordAt([14, 0]);
       assert.equal(selectionManager.selectionText, 'foo');
     });
+    it('should select up to non-path characters that are commonly adjacent to paths', () => {
+      buffer.push(stringToRow(':ab:(cd)[ef]{gh}'));
+      selectionManager.selectWordAt([0, 0]);
+      assert.equal(selectionManager.selectionText, ':ab');
+      selectionManager.selectWordAt([1, 0]);
+      assert.equal(selectionManager.selectionText, 'ab');
+      selectionManager.selectWordAt([2, 0]);
+      assert.equal(selectionManager.selectionText, 'ab');
+      selectionManager.selectWordAt([3, 0]);
+      assert.equal(selectionManager.selectionText, 'ab:');
+      selectionManager.selectWordAt([4, 0]);
+      assert.equal(selectionManager.selectionText, '(cd');
+      selectionManager.selectWordAt([5, 0]);
+      assert.equal(selectionManager.selectionText, 'cd');
+      selectionManager.selectWordAt([6, 0]);
+      assert.equal(selectionManager.selectionText, 'cd');
+      selectionManager.selectWordAt([7, 0]);
+      assert.equal(selectionManager.selectionText, 'cd)');
+      selectionManager.selectWordAt([8, 0]);
+      assert.equal(selectionManager.selectionText, '[ef');
+      selectionManager.selectWordAt([9, 0]);
+      assert.equal(selectionManager.selectionText, 'ef');
+      selectionManager.selectWordAt([10, 0]);
+      assert.equal(selectionManager.selectionText, 'ef');
+      selectionManager.selectWordAt([11, 0]);
+      assert.equal(selectionManager.selectionText, 'ef]');
+      selectionManager.selectWordAt([12, 0]);
+      assert.equal(selectionManager.selectionText, '{gh');
+      selectionManager.selectWordAt([13, 0]);
+      assert.equal(selectionManager.selectionText, 'gh');
+      selectionManager.selectWordAt([14, 0]);
+      assert.equal(selectionManager.selectionText, 'gh');
+      selectionManager.selectWordAt([15, 0]);
+      assert.equal(selectionManager.selectionText, 'gh}');
+    });
   });
 
   describe('_selectLineAt', () => {

--- a/src/SelectionManager.test.ts
+++ b/src/SelectionManager.test.ts
@@ -143,7 +143,7 @@ describe('SelectionManager', () => {
       assert.equal(selectionManager.selectionText, 'foo');
     });
     it('should select up to non-path characters that are commonly adjacent to paths', () => {
-      buffer.push(stringToRow(':ab:(cd)[ef]{gh}'));
+      buffer.push(stringToRow(':ab:(cd)[ef]{gh}\'ij"'));
       selectionManager.selectWordAt([0, 0]);
       assert.equal(selectionManager.selectionText, ':ab');
       selectionManager.selectWordAt([1, 0]);
@@ -176,6 +176,14 @@ describe('SelectionManager', () => {
       assert.equal(selectionManager.selectionText, 'gh');
       selectionManager.selectWordAt([15, 0]);
       assert.equal(selectionManager.selectionText, 'gh}');
+      selectionManager.selectWordAt([16, 0]);
+      assert.equal(selectionManager.selectionText, '\'ij');
+      selectionManager.selectWordAt([17, 0]);
+      assert.equal(selectionManager.selectionText, 'ij');
+      selectionManager.selectWordAt([18, 0]);
+      assert.equal(selectionManager.selectionText, 'ij');
+      selectionManager.selectWordAt([19, 0]);
+      assert.equal(selectionManager.selectionText, 'ij"');
     });
   });
 

--- a/src/SelectionManager.ts
+++ b/src/SelectionManager.ts
@@ -37,6 +37,12 @@ const CLEAR_MOUSE_DOWN_TIME = 400;
  */
 const CLEAR_MOUSE_DISTANCE = 10;
 
+/**
+ * A string containing all characters that are considered word separated by the
+ * double click to select work logic.
+ */
+const WORD_SEPARATORS = ' ()[]{}:';
+
 // TODO: Move these constants elsewhere, they belong in a buffer or buffer
 //       data/line class.
 const LINE_DATA_CHAR_INDEX = 1;
@@ -610,7 +616,7 @@ export class SelectionManager extends EventEmitter {
         endCol++;
       }
       // Expand the string in both directions until a space is hit
-      while (startIndex > 0 && line.charAt(startIndex - 1) !== ' ') {
+      while (startIndex > 0 && !this._isCharWordSeparator(line.charAt(startIndex - 1))) {
         if (bufferLine[startCol - 1][LINE_DATA_WIDTH_INDEX] === 0) {
           // If the next character is a wide char, record it and skip the column
           leftWideCharCount++;
@@ -619,7 +625,7 @@ export class SelectionManager extends EventEmitter {
         startIndex--;
         startCol--;
       }
-      while (endIndex + 1 < line.length && line.charAt(endIndex + 1) !== ' ') {
+      while (endIndex + 1 < line.length && !this._isCharWordSeparator(line.charAt(endIndex + 1))) {
         if (bufferLine[endCol + 1][LINE_DATA_WIDTH_INDEX] === 2) {
           // If the next character is a wide char, record it and skip the column
           rightWideCharCount++;
@@ -633,6 +639,15 @@ export class SelectionManager extends EventEmitter {
     // Record the resulting selection
     this._model.selectionStart = [startIndex + charOffset - leftWideCharCount, coords[1]];
     this._model.selectionStartLength = Math.min(endIndex - startIndex + leftWideCharCount + rightWideCharCount + 1/*include endIndex char*/, this._terminal.cols);
+  }
+
+  /**
+   * Gets whether the character is considered a word separator by the select
+   * word logic.
+   * @param char The character to check.
+   */
+  private _isCharWordSeparator(char: string): boolean {
+    return WORD_SEPARATORS.indexOf(char) >= 0;
   }
 
   /**

--- a/src/SelectionManager.ts
+++ b/src/SelectionManager.ts
@@ -41,7 +41,7 @@ const CLEAR_MOUSE_DISTANCE = 10;
  * A string containing all characters that are considered word separated by the
  * double click to select work logic.
  */
-const WORD_SEPARATORS = ' ()[]{}:';
+const WORD_SEPARATORS = ' ()[]{}:\'"';
 
 // TODO: Move these constants elsewhere, they belong in a buffer or buffer
 //       data/line class.


### PR DESCRIPTION
Fixes #713