### PR TITLE
Fix select and middle click to paste selection

### DIFF
--- a/src/SelectionManager.ts
+++ b/src/SelectionManager.ts
@@ -2,10 +2,11 @@
  * @license MIT
  */
 
+import * as Mouse from './utils/Mouse';
+import * as Browser from './utils/Browser';
 import { CharMeasure } from './utils/CharMeasure';
 import { CircularList } from './utils/CircularList';
 import { EventEmitter } from './EventEmitter';
-import * as Mouse from './utils/Mouse';
 import { ITerminal } from './Interfaces';
 import { SelectionModel } from './SelectionModel';
 
@@ -299,16 +300,13 @@ export class SelectionManager extends EventEmitter {
       this._refreshAnimationFrame = window.requestAnimationFrame(() => this._refresh());
     }
 
-    // If the refresh comes from a mouse event then emit a newselection event
-    if (!fromMouseEvent) {
-      return;
-    }
-    // TODO: Only do this when the selection has actually changed
-    // TODO: Ensure we're not doing more work than absolutely necessary, particularly for large selections
-    // TODO: Only do this on Linux
-    const selectionText = this.selectionText;
-    if (selectionText.length) {
-      this.emit('newselection', this.selectionText);
+    // If the platform is Linux and the refresh call comes from a mouse event,
+    // we need to update the selection for middle click to paste selection.
+    if (Browser.isLinux && fromMouseEvent) {
+      const selectionText = this.selectionText;
+      if (selectionText.length) {
+        this.emit('newselection', this.selectionText);
+      }
     }
   }
 
@@ -560,7 +558,7 @@ export class SelectionManager extends EventEmitter {
     if (!previousSelectionEnd ||
         previousSelectionEnd[0] !== this._model.selectionEnd[0] ||
         previousSelectionEnd[1] !== this._model.selectionEnd[1]) {
-      this.refresh();
+      this.refresh(true);
     }
   }
 

--- a/src/SelectionManager.ts
+++ b/src/SelectionManager.ts
@@ -293,9 +293,22 @@ export class SelectionManager extends EventEmitter {
   /**
    * Queues a refresh, redrawing the selection on the next opportunity.
    */
-  public refresh(): void {
+  public refresh(fromMouseEvent?: boolean): void {
+    // Queue the refresh for the renderer
     if (!this._refreshAnimationFrame) {
       this._refreshAnimationFrame = window.requestAnimationFrame(() => this._refresh());
+    }
+
+    // If the refresh comes from a mouse event then emit a newselection event
+    if (!fromMouseEvent) {
+      return;
+    }
+    // TODO: Only do this when the selection has actually changed
+    // TODO: Ensure we're not doing more work than absolutely necessary, particularly for large selections
+    // TODO: Only do this on Linux
+    const selectionText = this.selectionText;
+    if (selectionText.length) {
+      this.emit('newselection', this.selectionText);
     }
   }
 
@@ -392,7 +405,7 @@ export class SelectionManager extends EventEmitter {
     }
 
     this._addMouseDownListeners();
-    this.refresh();
+    this.refresh(true);
   }
 
   /**

--- a/src/SelectionManager.ts
+++ b/src/SelectionManager.ts
@@ -293,8 +293,10 @@ export class SelectionManager extends EventEmitter {
 
   /**
    * Queues a refresh, redrawing the selection on the next opportunity.
+   * @param isNewSelection Whether the selection should be registered as a new
+   * selection on Linux.
    */
-  public refresh(fromMouseEvent?: boolean): void {
+  public refresh(isNewSelection?: boolean): void {
     // Queue the refresh for the renderer
     if (!this._refreshAnimationFrame) {
       this._refreshAnimationFrame = window.requestAnimationFrame(() => this._refresh());
@@ -302,7 +304,7 @@ export class SelectionManager extends EventEmitter {
 
     // If the platform is Linux and the refresh call comes from a mouse event,
     // we need to update the selection for middle click to paste selection.
-    if (Browser.isLinux && fromMouseEvent) {
+    if (Browser.isLinux && isNewSelection) {
       const selectionText = this.selectionText;
       if (selectionText.length) {
         this.emit('newselection', this.selectionText);

--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -80,7 +80,7 @@ export function pasteHandler(ev: ClipboardEvent, term: ITerminal) {
  * @param term The terminal on which to apply the handled paste event
  * @param selectionManager The terminal's selection manager.
  */
-export function rightClickHandler(ev: MouseEvent, textarea: HTMLTextAreaElement, selectionManager: ISelectionManager) {
+export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextAreaElement, selectionManager: ISelectionManager) {
   // Bring textarea at the cursor position
   textarea.style.position = 'fixed';
   textarea.style.width = '20px';

--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -75,12 +75,11 @@ export function pasteHandler(ev: ClipboardEvent, term: ITerminal) {
 }
 
 /**
- * Bind to right-click event and allow right-click copy and paste.
- * @param ev The original right click event to be handled
- * @param term The terminal on which to apply the handled paste event
- * @param selectionManager The terminal's selection manager.
+ * Moves the textarea under the mouse cursor and focuses it.
+ * @param ev The original right click event to be handled.
+ * @param textarea The terminal's textarea.
  */
-export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextAreaElement, selectionManager: ISelectionManager) {
+export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextAreaElement) {
   // Bring textarea at the cursor position
   textarea.style.position = 'fixed';
   textarea.style.width = '20px';
@@ -89,10 +88,7 @@ export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextA
   textarea.style.top = (ev.clientY - 10) + 'px';
   textarea.style.zIndex = '1000';
 
-  // Get textarea ready to copy from the context menu
-  textarea.value = selectionManager.selectionText;
   textarea.focus();
-  textarea.select();
 
   // Reset the terminal textarea's styling
   setTimeout(function () {
@@ -103,4 +99,18 @@ export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextA
     textarea.style.top = null;
     textarea.style.zIndex = null;
   }, 4);
+}
+
+/**
+ * Bind to right-click event and allow right-click copy and paste.
+ * @param ev The original right click event to be handled.
+ * @param textarea The terminal's textarea.
+ * @param selectionManager The terminal's selection manager.
+ */
+export function rightClickHandler(ev: MouseEvent, textarea: HTMLTextAreaElement, selectionManager: ISelectionManager) {
+  moveTextAreaUnderMouseCursor(ev, textarea);
+
+  // Get textarea ready to copy from the context menu
+  textarea.value = selectionManager.selectionText;
+  textarea.select();
 }

--- a/src/utils/Browser.ts
+++ b/src/utils/Browser.ts
@@ -20,3 +20,4 @@ export const isMac = contains(['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'], pla
 export const isIpad = platform === 'iPad';
 export const isIphone = platform === 'iPhone';
 export const isMSWindows = contains(['Windows', 'Win16', 'Win32', 'WinCE'], platform);
+export const isLinux = platform.indexOf('Linux') >= 0;

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -556,7 +556,7 @@ Terminal.prototype.initGlobal = function() {
   if (term.browser.isLinux) {
     // Use auxclick event over mousedown the latter doesn't seem to work. Note
     // that the regular click event doesn't fire for the middle mouse button.
-    on(this.element, 'click', event => {
+    on(this.element, 'auxclick', event => {
       if (event.button === 1) {
         moveTextAreaUnderMouseCursor(event, this.textarea, this.selectionManager);
       }

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -721,6 +721,9 @@ Terminal.prototype.open = function(parent, focus) {
     this.renderer.refreshSelection(data.start, data.end);
   });
   this.selectionManager.on('newselection', text => {
+    // If there's a new selection, put it into the textarea, focus and select it
+    // in order to register it as a selection on the OS. This event is fired
+    // only on Linux to enable middle click to paste selection.
     this.textarea.value = text;
     this.textarea.focus();
     this.textarea.select();

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -13,7 +13,7 @@
 import { CompositionHelper } from './CompositionHelper';
 import { EventEmitter } from './EventEmitter';
 import { Viewport } from './Viewport';
-import { moveTextAreaUnderMouseCursor, pasteHandler, copyHandler } from './handlers/Clipboard';
+import { rightClickHandler, moveTextAreaUnderMouseCursor, pasteHandler, copyHandler } from './handlers/Clipboard';
 import { CircularList } from './utils/CircularList';
 import { C0 } from './EscapeSequences';
 import { InputHandler } from './InputHandler';
@@ -541,12 +541,12 @@ Terminal.prototype.initGlobal = function() {
   if (term.browser.isFirefox) {
     on(this.element, 'mousedown', event => {
       if (ev.button == 2) {
-        moveTextAreaUnderMouseCursor(event, this.textarea, this.selectionManager);
+        rightClickHandler(event, this.textarea, this.selectionManager);
       }
     });
   } else {
     on(this.element, 'contextmenu', event => {
-      moveTextAreaUnderMouseCursor(event, this.textarea, this.selectionManager);
+      rightClickHandler(event, this.textarea, this.selectionManager);
     });
   }
 

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -703,7 +703,14 @@ Terminal.prototype.open = function(parent, focus) {
   this.viewport = new Viewport(this, this.viewportElement, this.viewportScrollArea, this.charMeasure);
   this.renderer = new Renderer(this);
   this.selectionManager = new SelectionManager(this, this.lines, this.rowContainer, this.charMeasure);
-  this.selectionManager.on('refresh', data => this.renderer.refreshSelection(data.start, data.end));
+  this.selectionManager.on('refresh', data => {
+    this.renderer.refreshSelection(data.start, data.end);
+  });
+  this.selectionManager.on('newselection', text => {
+    this.textarea.value = text;
+    this.textarea.focus();
+    this.textarea.select();
+  });
   this.on('scroll', () => this.selectionManager.refresh());
   this.viewportElement.addEventListener('scroll', () => this.selectionManager.refresh());
 


### PR DESCRIPTION
There are two things included in this PR, both of which are only activated when running Linux to avoid unnecessary work on other OS's.

- Making a selection will put the selection into the textarea and select it. This will tell the OS that a selection was made and update the "selection clipboard".
- Middle clicking will move the textarea under the cursor so the browser knows to paste the selection into the terminal. This is the same trick as the right click context menu.

Fixes #699 