### PR TITLE
Properly mark initial viewport lines as wrapped

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -56,8 +56,13 @@ export class InputHandler implements IInputHandler {
           this._terminal.x = 0;
           this._terminal.y++;
           if (this._terminal.y > this._terminal.scrollBottom) {
+            // Insert a new line, scroll and mark as a wrapped line
             this._terminal.y--;
             this._terminal.scroll(true);
+          } else {
+            // The line already exists (eg. the initial viewport), mark it as a
+            // wrapped line
+            this._terminal.lines.get(this._terminal.y).isWrapped = true;
           }
         } else {
           if (ch_width === 2)  // FIXME: check for xterm behavior


### PR DESCRIPTION
Fixes #767

---

@parisk this is a good candidate for a 2.8.1.