### PR TITLE
Add search.exclude setting for vscode workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "**/dist": true,
+        "**/build": true,
+        "**/lib": true
+    }
+}


### PR DESCRIPTION
Adds some simple vscode `search.exclude` settings for the workspace