### PR TITLE
Retain the color of a character for underline and bar cursor styles

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -89,52 +89,39 @@
     text-decoration: none;
 }
 
-.terminal.focus:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
-    background-color: #fff;
-    color: #000;
+.terminal .terminal-cursor {
+    position: relative;
 }
 
 .terminal:not(.focus) .terminal-cursor {
     outline: 1px solid #fff;
     outline-offset: -1px;
-    background-color: transparent;
 }
 
-.terminal:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar).focus.xterm-cursor-blink-on .terminal-cursor {
-    background-color: transparent;
-    color: inherit;
+.terminal.xterm-cursor-style-block.focus:not(.xterm-cursor-blink-on) .terminal-cursor {
+    background-color: #fff;
+    color: #000;
 }
 
-.terminal.xterm-cursor-style-bar .terminal-cursor,
-.terminal.xterm-cursor-style-underline .terminal-cursor {
-    position: relative;
-}
-.terminal.xterm-cursor-style-bar .terminal-cursor::before,
-.terminal.xterm-cursor-style-underline .terminal-cursor::before {
-    content: "";
-    display: block;
+.terminal.focus.xterm-cursor-style-bar:not(.xterm-cursor-blink-on) .terminal-cursor::before,
+.terminal.focus.xterm-cursor-style-underline:not(.xterm-cursor-blink-on) .terminal-cursor::before {
+    content: '';
     position: absolute;
     background-color: #fff;
 }
-.terminal.xterm-cursor-style-bar .terminal-cursor::before {
+
+.terminal.focus.xterm-cursor-style-bar:not(.xterm-cursor-blink-on) .terminal-cursor::before {
     top: 0;
-    bottom: 0;
     left: 0;
+    bottom: 0;
     width: 1px;
 }
-.terminal.xterm-cursor-style-underline .terminal-cursor::before {
+
+.terminal.focus.xterm-cursor-style-underline:not(.xterm-cursor-blink-on) .terminal-cursor::before {
     bottom: 0;
     left: 0;
     right: 0;
     height: 1px;
-}
-.terminal.xterm-cursor-style-bar.focus.xterm-cursor-blink.xterm-cursor-blink-on .terminal-cursor::before,
-.terminal.xterm-cursor-style-underline.focus.xterm-cursor-blink.xterm-cursor-blink-on .terminal-cursor::before {
-    background-color: transparent;
-}
-.terminal.xterm-cursor-style-bar.focus.xterm-cursor-blink .terminal-cursor::before,
-.terminal.xterm-cursor-style-underline.focus.xterm-cursor-blink .terminal-cursor::before {
-    background-color: #fff;
 }
 
 .terminal .composition-view {
@@ -215,6 +202,10 @@
 
 .terminal .xterm-blink {
     text-decoration: blink;
+}
+
+.terminal .xterm-blink.xterm-underline {
+    text-decoration: blink underline;
 }
 
 .terminal .xterm-hidden {

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -429,7 +429,7 @@ Terminal.prototype.setOption = function(key, value) {
   switch (key) {
     case 'cursorBlink': this.setCursorBlinking(value); break;
     case 'cursorStyle':
-      // Style 'block' applies with no class
+      this.element.classList.toggle(`xterm-cursor-style-block`, value === 'block');
       this.element.classList.toggle(`xterm-cursor-style-underline`, value === 'underline');
       this.element.classList.toggle(`xterm-cursor-style-bar`, value === 'bar');
       break;
@@ -639,6 +639,7 @@ Terminal.prototype.open = function(parent, focus) {
   this.element.classList.add('terminal');
   this.element.classList.add('xterm');
   this.element.classList.add('xterm-theme-' + this.theme);
+  this.element.classList.add(`xterm-cursor-style-${this.options.cursorStyle}`);
   this.setCursorBlinking(this.options.cursorBlink);
 
   this.element.setAttribute('tabindex', 0);
@@ -1025,6 +1026,9 @@ Terminal.prototype.bindMouse = function() {
   }
 
   on(el, 'mousedown', function(ev) {
+    // prevent the focus on the textarea from getting lost
+    ev.preventDefault();
+
     if (!self.mouseEvents) return;
 
     // send the button


### PR DESCRIPTION
Fixes #774
Fixes #789
Fixes #790
Fixes #820
Related #783

⚠️ **Warning**
I had to change the cursor related `css` to get this feature in, and to resolve styling related issues. Consumers that have overwritten the default styles may have to adopt their stylesheet.

🚀 **Improvements**
The`.terminal` element will always have a class with the cursor style, previously, only `bar` and `underline` cursors had a class.

🐞 **Fixes**
- #774, #783: `bar` and `underline` cursors now render correctly and do not alter the foreground color of the text, 
- #774: `blink` is now working correctly if the block cursor is over a background, 
- #789: `focus` class is kept when interacting with programs that support mouse pointer integration
- #790: The cursor style passed through options is now respected
- #820: Allow blink and underline flags to be rendered in parallel

🎮 **Testing**
I found it very useful to `nvim README.md` in the xterm.js demo because the Markdown syntax highlighter of `nvim` will create almost all visual test cases (background, foreground, underline, bold).