### PR TITLE
Clear selection on input

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2234,6 +2234,11 @@ Terminal.prototype.handler = function(data) {
     return;
   }
 
+  // Clear the selection
+  if (this.hasSelection()) {
+    this.clearSelection();
+  }
+
   // Input is being sent to the terminal, the terminal should focus the prompt.
   if (this.ybase !== this.ydisp) {
     this.scrollToBottom();

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2234,9 +2234,9 @@ Terminal.prototype.handler = function(data) {
     return;
   }
 
-  // Clear the selection
-  if (this.hasSelection()) {
-    this.clearSelection();
+  // Clear the selection if the selection manager is available and has an active selection
+  if (this.selectionManager && this.selectionManager.hasSelection) {
+    this.selectionManager.clearSelection();
   }
 
   // Input is being sent to the terminal, the terminal should focus the prompt.


### PR DESCRIPTION
Fixes #777

This PR clears the active selection (if existent) once the user produces input that will be sent to the baking tty.