### PR TITLE
Guard public selection api

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1437,7 +1437,7 @@ Terminal.prototype.deregisterLinkMatcher = function(matcherId) {
  * Gets whether the terminal has an active selection.
  */
 Terminal.prototype.hasSelection = function() {
-  return this.selectionManager.hasSelection;
+  return !!(this.selectionManager && this.selectionManager.hasSelection);
 };
 
 /**
@@ -1445,21 +1445,25 @@ Terminal.prototype.hasSelection = function() {
  * behavior outside of xterm.js.
  */
 Terminal.prototype.getSelection = function() {
-  return this.selectionManager.selectionText;
+  return this.selectionManager ? this.selectionManager.selectionText : '';
 };
 
 /**
  * Clears the current terminal selection.
  */
 Terminal.prototype.clearSelection = function() {
-  this.selectionManager.clearSelection();
+  if (this.selectionManager) {
+    this.selectionManager.clearSelection();
+  }
 };
 
 /**
  * Selects all text within the terminal.
  */
 Terminal.prototype.selectAll = function() {
-  this.selectionManager.selectAll();
+  if (this.selectionManager) {
+    this.selectionManager.selectAll();
+  }
 };
 
 /**

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1437,7 +1437,7 @@ Terminal.prototype.deregisterLinkMatcher = function(matcherId) {
  * Gets whether the terminal has an active selection.
  */
 Terminal.prototype.hasSelection = function() {
-  return !!(this.selectionManager && this.selectionManager.hasSelection);
+  return this.selectionManager ? this.selectionManager.hasSelection : false;
 };
 
 /**


### PR DESCRIPTION
Fixes #796 by soft-failing if selection manager is not yet available (term.open not yet called). I believe this is better than throwing an error. This behaviour lines up with the behaviour of the linkifier, that only throws for sensitive api calls (like registering a link matcher for example), but otherwise soft-fails too.