### PR TITLE
Prevent Webpack warning in 2.9.0

### DIFF
--- a/src/addons/search/search.ts
+++ b/src/addons/search/search.ts
@@ -20,8 +20,7 @@ declare var window: any;
     /**
      * CommonJS environment
      */
-    const xterm = '../../xterm';
-    module.exports = addon(require(xterm));
+    module.exports = addon(require('../../xterm'));
   } else if (typeof define == 'function') {
     /**
      * Require.js is available


### PR DESCRIPTION
This warning came along with the upgrade to `2.9.0`:

```
WARNING in ../~/xterm/lib/addons/search/search.js
10:31-45 Critical dependency: the request of a dependency is an expression
```

We have a `require('xterm')` in our code, using WebPack 2.7.0.   This change prevents the warning.