### PR TITLE
No longer focus the terminal by default

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -759,20 +759,6 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
     // Initialize global actions that need to be taken on the document.
     this.initGlobal();
 
-    /**
-     * Automatic focus functionality.
-     * TODO: Default to `false` starting with xterm.js 3.0.
-     */
-    if (typeof focus === 'undefined') {
-      let message = 'You did not pass the `focus` argument in `Terminal.prototype.open()`.\n';
-
-      message += 'The `focus` argument now defaults to `true` but starting with xterm.js 3.0 ';
-      message += 'it will default to `false`.';
-
-      console.warn(message);
-      focus = true;
-    }
-
     if (focus) {
       this.focus();
     }

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -649,9 +649,8 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
    * Opens the terminal within an element.
    *
    * @param {HTMLElement} parent The element to create the terminal within.
-   * @param {boolean} focus Focus the terminal, after it gets instantiated in the DOM
    */
-  private open(parent: HTMLElement, focus?: boolean): void {
+  public open(parent: HTMLElement): void {
     let i = 0;
     let div;
 
@@ -758,10 +757,6 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
 
     // Initialize global actions that need to be taken on the document.
     this.initGlobal();
-
-    if (focus) {
-      this.focus();
-    }
 
     // Listen for mouse events and translate
     // them into terminal mouse protocols.


### PR DESCRIPTION
Fixes #646 

---

@parisk since we're breaking things, what are your thoughts on just removing focus all together as open can be followed by a `term.focus()` call?