### PR TITLE
Fix module build, add TS declaration files, fix search addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ var xterm = new Terminal();
 xterm.fit();
 ```
 
+## CommonJS
+
+Importing xterm.js in a CommonJS environment (eg. [Electron](https://electron.atom.io/)) can be done like so:
+
+```ts
+// JavaScript
+var Terminal = require('xterm').Terminal;
+
+// TypeScript
+import { Terminal } from 'xterm';
+```
+
 ## Releases
 
 Xterm.js follows a monthly release cycle roughly.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,10 @@ gulp.task('tsc', function () {
   // Build all TypeScript files (including tests) to ${outDir}/, based on the configuration defined in
   // `tsconfig.json`.
   let tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
-  let tsc = tsResult.js.pipe(sourcemaps.write('.', {includeContent: false, sourceRoot: ''})).pipe(gulp.dest(outDir));
+  let tsc = merge(
+    tsResult.js.pipe(sourcemaps.write('.', {includeContent: false, sourceRoot: ''})).pipe(gulp.dest(outDir)),
+    tsResult.dts.pipe(sourcemaps.write('.', {includeContent: false, sourceRoot: ''})).pipe(gulp.dest(outDir))
+  );
 
   fs.emptyDirSync(`${outDir}/addons/search`);
   let tsResultSearchAddon = tsProjectSearchAddon.src().pipe(sourcemaps.init()).pipe(tsProjectSearchAddon());

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test",
     ".gitignore"
   ],
-  "main": "lib/xterm.js",
+  "main": "lib/Terminal.js",
+  "types": "lib/Terminal.d.ts",
   "repository": "https://github.com/sourcelair/xterm.js",
   "license": "MIT",
   "files": [
@@ -21,8 +22,10 @@
     "dist/**/*.js.map",
     "lib/*.css",
     "lib/**/*.css",
+    "lib/*.d.ts",
     "lib/*.js",
     "lib/*.js.map",
+    "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
     "src/*.css",

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -148,7 +148,7 @@ csiStateHandler['s'] = (handler, params) => handler.saveCursor(params);
 csiStateHandler['u'] = (handler, params) => handler.restoreCursor(params);
 csiStateHandler[C0.CAN] = (handler, params, prefix, postfix, parser) => parser.setState(ParserState.NORMAL);
 
-enum ParserState {
+export enum ParserState {
   NORMAL = 0,
   ESCAPED = 1,
   CSI_PARAM = 2,

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -8,6 +8,15 @@
  *   has been extended to include xterm CSI codes, among
  *   other features.
  * @license MIT
+ *
+ * Terminal Emulation References:
+ *   http://vt100.net/
+ *   http://invisible-island.net/xterm/ctlseqs/ctlseqs.txt
+ *   http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+ *   http://invisible-island.net/vttest/
+ *   http://www.inwap.com/pdp10/ansicode.txt
+ *   http://linux.die.net/man/4/console_codes
+ *   http://linux.die.net/man/7/urxvt
  */
 
 import { BufferSet } from './BufferSet';

--- a/src/addons/attach/attach.js
+++ b/src/addons/attach/attach.js
@@ -9,7 +9,7 @@
     /*
      * CommonJS environment
      */
-    module.exports = attach(require('../../xterm'));
+    module.exports = attach(require('../../Terminal').Terminal);
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
@@ -21,7 +21,7 @@
      */
     attach(window.Terminal);
   }
-})(function (Xterm) {
+})(function (Terminal) {
   'use strict';
 
   var exports = {};
@@ -29,7 +29,7 @@
   /**
    * Attaches the given terminal to the given socket.
    *
-   * @param {Xterm} term - The terminal to be attached to the given socket.
+   * @param {Terminal} term - The terminal to be attached to the given socket.
    * @param {WebSocket} socket - The socket to attach the current terminal.
    * @param {boolean} bidirectional - Whether the terminal should send data
    *                                  to the socket as well.
@@ -82,7 +82,7 @@
   /**
    * Detaches the given terminal from the given socket
    *
-   * @param {Xterm} term - The terminal to be detached from the given socket.
+   * @param {Terminal} term - The terminal to be detached from the given socket.
    * @param {WebSocket} socket - The socket from which to detach the current
    *                             terminal.
    */
@@ -108,7 +108,7 @@
    *                             should happen instantly or at a maximum
    *                             frequency of 1 rendering per 10ms.
    */
-  Xterm.prototype.attach = function (socket, bidirectional, buffered) {
+  Terminal.prototype.attach = function (socket, bidirectional, buffered) {
     return exports.attach(this, socket, bidirectional, buffered);
   };
 
@@ -118,7 +118,7 @@
    * @param {WebSocket} socket - The socket from which to detach the current
    *                             terminal.
    */
-  Xterm.prototype.detach = function (socket) {
+  Terminal.prototype.detach = function (socket) {
     return exports.detach(this, socket);
   };
 

--- a/src/addons/fit/fit.js
+++ b/src/addons/fit/fit.js
@@ -16,7 +16,7 @@
     /*
      * CommonJS environment
      */
-    module.exports = fit(require('../../xterm'));
+    module.exports = fit(require('../../Terminal').Terminal);
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
@@ -28,7 +28,7 @@
      */
     fit(window.Terminal);
   }
-})(function (Xterm) {
+})(function (Terminal) {
   var exports = {};
 
   exports.proposeGeometry = function (term) {
@@ -74,11 +74,11 @@
     }
   };
 
-  Xterm.prototype.proposeGeometry = function () {
+  Terminal.prototype.proposeGeometry = function () {
     return exports.proposeGeometry(this);
   };
 
-  Xterm.prototype.fit = function () {
+  Terminal.prototype.fit = function () {
     return exports.fit(this);
   };
 

--- a/src/addons/fullscreen/fullscreen.js
+++ b/src/addons/fullscreen/fullscreen.js
@@ -8,7 +8,7 @@
     /*
      * CommonJS environment
      */
-    module.exports = fullscreen(require('../../xterm'));
+    module.exports = fullscreen(require('../../Terminal').Terminal);
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
@@ -20,12 +20,12 @@
      */
     fullscreen(window.Terminal);
   }
-})(function (Xterm) {
+})(function (Terminal) {
   var exports = {};
 
   /**
    * Toggle the given terminal's fullscreen mode.
-   * @param {Xterm} term - The terminal to toggle full screen mode
+   * @param {Terminal} term - The terminal to toggle full screen mode
    * @param {boolean} fullscreen - Toggle fullscreen on (true) or off (false)
    */
   exports.toggleFullScreen = function (term, fullscreen) {
@@ -42,7 +42,7 @@
     term.element.classList[fn]('fullscreen');
   };
 
-  Xterm.prototype.toggleFullscreen = function (fullscreen) {
+  Terminal.prototype.toggleFullscreen = function (fullscreen) {
     exports.toggleFullScreen(this, fullscreen);
   };
 

--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -15,7 +15,7 @@ interface ISearchResult {
  * A class that knows how to search the terminal and how to display the results.
  */
 export class SearchHelper {
-  constructor(private _terminal: any, private _translateBufferLineToString: any) {
+  constructor(private _terminal: any) {
     // TODO: Search for multiple instances on 1 line
     // TODO: Don't use the actual selection, instead use a "find selection" so multiple instances can be highlighted
     // TODO: Highlight other instances in the viewport
@@ -111,8 +111,7 @@ export class SearchHelper {
    * @return The search result if it was found.
    */
   private _findInLine(term: string, y: number): ISearchResult {
-    const bufferLine = this._terminal.buffer.lines.get(y);
-    const lowerStringLine = this._translateBufferLineToString(bufferLine, true).toLowerCase();
+    const lowerStringLine = this._terminal.buffer.translateBufferLineToString(y, true).toLowerCase();
     const lowerTerm = term.toLowerCase();
     const searchIndex = lowerStringLine.indexOf(lowerTerm);
     if (searchIndex >= 0) {

--- a/src/addons/search/search.ts
+++ b/src/addons/search/search.ts
@@ -36,7 +36,7 @@ declare var window: any;
    */
   Terminal.prototype.findNext = function(term: string): boolean {
     if (!this._searchHelper) {
-      this.searchHelper = new SearchHelper(this, Terminal.translateBufferLineToString);
+      this.searchHelper = new SearchHelper(this);
     }
     return (<SearchHelper>this.searchHelper).findNext(term);
   };
@@ -49,7 +49,7 @@ declare var window: any;
    */
   Terminal.prototype.findPrevious = function(term: string): boolean {
     if (!this._searchHelper) {
-      this.searchHelper = new SearchHelper(this, Terminal.translateBufferLineToString);
+      this.searchHelper = new SearchHelper(this);
     }
     return (<SearchHelper>this.searchHelper).findPrevious(term);
   };

--- a/src/addons/search/search.ts
+++ b/src/addons/search/search.ts
@@ -20,7 +20,7 @@ declare var window: any;
     /**
      * CommonJS environment
      */
-    module.exports = addon(require('../../xterm'));
+    module.exports = addon(require('../../Terminal').Terminal);
   } else if (typeof define === 'function') {
     /**
      * Require.js is available

--- a/src/addons/terminado/terminado.js
+++ b/src/addons/terminado/terminado.js
@@ -10,7 +10,7 @@
     /*
      * CommonJS environment
      */
-    module.exports = attach(require('../../xterm'));
+    module.exports = attach(require('../../Terminal').Terminal);
   } else if (typeof define == 'function') {
     /*
      * Require.js is available
@@ -22,7 +22,7 @@
      */
     attach(window.Terminal);
   }
-})(function (Xterm) {
+})(function (Terminal) {
   'use strict';
 
   var exports = {};
@@ -30,7 +30,7 @@
   /**
    * Attaches the given terminal to the given socket.
    *
-   * @param {Xterm} term - The terminal to be attached to the given socket.
+   * @param {Terminal} term - The terminal to be attached to the given socket.
    * @param {WebSocket} socket - The socket to attach the current terminal.
    * @param {boolean} bidirectional - Whether the terminal should send data
    *                                  to the socket as well.
@@ -117,7 +117,7 @@
    *                             should happen instantly or at a maximum
    *                             frequency of 1 rendering per 10ms.
    */
-  Xterm.prototype.terminadoAttach = function (socket, bidirectional, buffered) {
+  Terminal.prototype.terminadoAttach = function (socket, bidirectional, buffered) {
     return exports.terminadoAttach(this, socket, bidirectional, buffered);
   };
 
@@ -127,7 +127,7 @@
    * @param {WebSocket} socket - The socket from which to detach the current
    *                             terminal.
    */
-  Xterm.prototype.terminadoDetach = function (socket) {
+  Terminal.prototype.terminadoDetach = function (socket) {
     return exports.terminadoDetach(this, socket);
   };
 

--- a/src/handlers/Clipboard.test.ts
+++ b/src/handlers/Clipboard.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import * as Terminal from '../xterm';
+import * as Terminal from '../Terminal';
 import * as Clipboard from './Clipboard';
 
 describe('evaluatePastedTextProcessing', () => {

--- a/src/xterm.ts
+++ b/src/xterm.ts
@@ -1,18 +1,9 @@
 /**
  * @license MIT
+ *
+ * This file is the entry point for browserify.
  */
 
 import { Terminal } from './Terminal';
-
-/**
- * Terminal Emulation References:
- *   http://vt100.net/
- *   http://invisible-island.net/xterm/ctlseqs/ctlseqs.txt
- *   http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
- *   http://invisible-island.net/vttest/
- *   http://www.inwap.com/pdp10/ansicode.txt
- *   http://linux.die.net/man/4/console_codes
- *   http://linux.die.net/man/7/urxvt
- */
 
 module.exports = Terminal;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,10 @@
     "module": "commonjs",
     "target": "es5",
     "rootDir": "src",
-    "allowJs": true,
     "outDir": "lib",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   },
   "include": [
     "src/**/*"

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-  "name": "xterm",
-  "globalDependencies": {
-    "node": "registry:env/node#6.0.0+20160918225031"
-  }
-}


### PR DESCRIPTION
This introduces a breaking change to importing the project, the README file has been updated to reflect this. It's now exporting an [ES6-style module](https://stackoverflow.com/a/35706271/1156119) which can be imported without the use of `require`. This was done because I couldn't get the build to work without making this change and because it's moving towards the future. You can still require using regular JavaScript, but there's a `Terminal` object on the default export.

`src/xterm.ts` still lives on but it is only the entrypoint for browserify now. This is mentioned in the header.

Fixes #865
Fixes #866 
Fixes #867

---

Verified core lib and search addon works in demo on Chrome.

Verified core lib and search addon in VS Code:

```ts
// Old (legacy import):
import Terminal = require('xterm');

// New:
import { Terminal } from 'xterm';
```

Verified TS Server picks up declarations/typings using a simple TS file:

![image](https://user-images.githubusercontent.com/2193314/29061603-653b3e5c-7bd3-11e7-9d42-62fe12e30acd.png)