### PR TITLE
Fix exception when resizing both dimensions

### DIFF
--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -143,5 +143,16 @@ describe('Buffer', () => {
         });
       });
     });
+
+    describe('row and column increased', () => {
+      it('should resize properly', () => {
+        buffer.fillViewportRows();
+        buffer.resize(INIT_COLS + 5, INIT_ROWS + 5);
+        assert.equal(buffer.lines.length, INIT_ROWS + 5);
+        for (let i = 0; i < INIT_ROWS + 5; i++) {
+          assert.equal(buffer.lines.get(i).length, INIT_COLS + 5);
+        }
+      });
+    });
   });
 });

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -85,8 +85,10 @@ export class Buffer implements IBuffer {
     if (this._terminal.cols < newCols) {
       const ch: [number, string, number] = [this._terminal.defAttr, ' ', 1]; // does xterm use the default attr?
       for (let i = 0; i < this._lines.length; i++) {
+        // TODO: This should be removed, with tests setup for the case that was
+        // causing the underlying bug, see https://github.com/sourcelair/xterm.js/issues/824
         if (this._lines.get(i) === undefined) {
-          this._lines.set(i, this._terminal.blankLine());
+          this._lines.set(i, this._terminal.blankLine(undefined, undefined, newCols));
         }
         while (this._lines.get(i).length < newCols) {
           this._lines.get(i).push(ch);
@@ -111,7 +113,7 @@ export class Buffer implements IBuffer {
           } else {
             // Add a blank line if there is no buffer left at the top to scroll to, or if there
             // are blank lines after the cursor
-            this._lines.push(this._terminal.blankLine());
+            this._lines.push(this._terminal.blankLine(undefined, undefined, newCols));
           }
         }
       }

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -48,7 +48,7 @@ export interface ITerminal {
   emit(event: string, data: any);
   reset(): void;
   showCursor(): void;
-  blankLine(cur?: boolean, isWrapped?: boolean);
+  blankLine(cur?: boolean, isWrapped?: boolean, cols?: number);
 }
 
 export interface IBuffer {

--- a/src/utils/TestUtils.ts
+++ b/src/utils/TestUtils.ts
@@ -43,9 +43,10 @@ export class MockTerminal implements ITerminal {
   showCursor(): void {
     throw new Error('Method not implemented.');
   }
-  blankLine(cur?: boolean, isWrapped?: boolean) {
+  blankLine(cur?: boolean, isWrapped?: boolean, cols?: number) {
     const line = [];
-    for (let i = 0; i < this.cols; i++) {
+    cols = cols || this.cols;
+    for (let i = 0; i < cols; i++) {
       line.push([0, ' ', 1]);
     }
     return line;

--- a/src/xterm.js
+++ b/src/xterm.js
@@ -2091,7 +2091,7 @@ Terminal.prototype.eraseLine = function(y) {
  * @param {number} cur First bunch of data for each "blank" character.
  * @param {boolean} isWrapped Whether the new line is wrapped from the previous line.
  */
-Terminal.prototype.blankLine = function(cur, isWrapped) {
+Terminal.prototype.blankLine = function(cur, isWrapped, cols) {
   var attr = cur
   ? this.eraseAttr()
   : this.defAttr;
@@ -2106,7 +2106,8 @@ Terminal.prototype.blankLine = function(cur, isWrapped) {
     line.isWrapped = isWrapped;
   }
 
-  for (; i < this.cols; i++) {
+  cols = cols || this.cols;
+  for (; i < cols; i++) {
     line[i] = ch;
   }
 


### PR DESCRIPTION
This happened because buffers now resize themselves but they were
relying on Terminal to give them a blank line. The blank line was
coming back with the old columns value, causing an NPE.

Fixes #860