### PR TITLE
Fix exception when resizing both dimensions

### DIFF
--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -144,5 +144,16 @@ describe('Buffer', () => {
         });
       });
     });
+
+    describe('row and column increased', () => {
+      it('should resize properly', () => {
+        buffer.fillViewportRows();
+        buffer.resize(INIT_COLS + 5, INIT_ROWS + 5);
+        assert.equal(buffer.lines.length, INIT_ROWS + 5);
+        for (let i = 0; i < INIT_ROWS + 5; i++) {
+          assert.equal(buffer.lines.get(i).length, INIT_COLS + 5);
+        }
+      });
+    });
   });
 });

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -89,8 +89,10 @@ export class Buffer implements IBuffer {
     if (this._terminal.cols < newCols) {
       const ch: CharData = [this._terminal.defAttr, ' ', 1]; // does xterm use the default attr?
       for (let i = 0; i < this._lines.length; i++) {
+        // TODO: This should be removed, with tests setup for the case that was
+        // causing the underlying bug, see https://github.com/sourcelair/xterm.js/issues/824
         if (this._lines.get(i) === undefined) {
-          this._lines.set(i, this._terminal.blankLine());
+          this._lines.set(i, this._terminal.blankLine(undefined, undefined, newCols));
         }
         while (this._lines.get(i).length < newCols) {
           this._lines.get(i).push(ch);
@@ -115,7 +117,7 @@ export class Buffer implements IBuffer {
           } else {
             // Add a blank line if there is no buffer left at the top to scroll to, or if there
             // are blank lines after the cursor
-            this._lines.push(this._terminal.blankLine());
+            this._lines.push(this._terminal.blankLine(undefined, undefined, newCols));
           }
         }
       }

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -46,7 +46,7 @@ export interface ITerminal extends IEventEmitter {
   log(text: string): void;
   reset(): void;
   showCursor(): void;
-  blankLine(cur?: boolean, isWrapped?: boolean): LineData;
+  blankLine(cur?: boolean, isWrapped?: boolean, cols?: number): LineData;
 }
 
 /**

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -2093,8 +2093,10 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
    * Return the data array of a blank line
    * @param {boolean} cur First bunch of data for each "blank" character.
    * @param {boolean} isWrapped Whether the new line is wrapped from the previous line.
+   * @param {boolean} cols The number of columns in the terminal, if this is not
+   * set, the terminal's current column count would be used.
    */
-  public blankLine(cur?: boolean, isWrapped?: boolean): LineData {
+  public blankLine(cur?: boolean, isWrapped?: boolean, cols?: number): LineData {
     const attr = cur ? this.eraseAttr() : this.defAttr;
 
     const ch: CharData = [attr, ' ', 1]; // width defaults to 1 halfwidth character
@@ -2106,7 +2108,8 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
       (<any>line).isWrapped = isWrapped;
     }
 
-    for (let i = 0; i < this.cols; i++) {
+    cols = cols || this.cols;
+    for (let i = 0; i < cols; i++) {
       line[i] = ch;
     }
 

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -52,9 +52,10 @@ export class MockTerminal implements ITerminal {
   showCursor(): void {
     throw new Error('Method not implemented.');
   }
-  blankLine(cur?: boolean, isWrapped?: boolean): LineData {
+  blankLine(cur?: boolean, isWrapped?: boolean, cols?: number): LineData {
     const line: LineData = [];
-    for (let i = 0; i < this.cols; i++) {
+    cols = cols || this.cols;
+    for (let i = 0; i < cols; i++) {
       line.push([0, ' ', 1]);
     }
     return line;


### PR DESCRIPTION
Pulling https://github.com/sourcelair/xterm.js/pull/873 into v3, fixing conflicts. I didn't see much benefit moving blankLine into Buffer as suggested in #873.

Fixes #860