### PR TITLE
Fix issues with scroll and reverseIndex

### DIFF
--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -94,11 +94,6 @@ export class Buffer implements IBuffer {
    * @param newRows The new number of rows.
    */
   public resize(newCols: number, newRows: number): void {
-    // Don't resize the buffer if it's empty and hasn't been used yet.
-    if (this._lines.length === 0) {
-      return;
-    }
-
     // Increase max length if needed before adjustments to allow space to fill
     // as required.
     const newMaxLength = this._getCorrectBufferLength(newRows);
@@ -106,83 +101,88 @@ export class Buffer implements IBuffer {
       this._lines.maxLength = newMaxLength;
     }
 
-    // Deal with columns increasing (we don't do anything when columns reduce)
-    if (this._terminal.cols < newCols) {
-      const ch: CharData = [this._terminal.defAttr, ' ', 1]; // does xterm use the default attr?
-      for (let i = 0; i < this._lines.length; i++) {
-        // TODO: This should be removed, with tests setup for the case that was
-        // causing the underlying bug, see https://github.com/sourcelair/xterm.js/issues/824
-        if (this._lines.get(i) === undefined) {
-          this._lines.set(i, this._terminal.blankLine(undefined, undefined, newCols));
-        }
-        while (this._lines.get(i).length < newCols) {
-          this._lines.get(i).push(ch);
+    // The following adjustments should only happen if the buffer has been
+    // initialized/filled.
+    if (this._lines.length > 0) {
+      // Deal with columns increasing (we don't do anything when columns reduce)
+      if (this._terminal.cols < newCols) {
+        const ch: CharData = [this._terminal.defAttr, ' ', 1]; // does xterm use the default attr?
+        for (let i = 0; i < this._lines.length; i++) {
+          // TODO: This should be removed, with tests setup for the case that was
+          // causing the underlying bug, see https://github.com/sourcelair/xterm.js/issues/824
+          if (this._lines.get(i) === undefined) {
+            this._lines.set(i, this._terminal.blankLine(undefined, undefined, newCols));
+          }
+          while (this._lines.get(i).length < newCols) {
+            this._lines.get(i).push(ch);
+          }
         }
       }
-    }
 
-    // Resize rows in both directions as needed
-    let addToY = 0;
-    if (this._terminal.rows < newRows) {
-      for (let y = this._terminal.rows; y < newRows; y++) {
-        if (this._lines.length < newRows + this.ybase) {
-          if (this.ybase > 0 && this._lines.length <= this.ybase + this.y + addToY + 1) {
-            // There is room above the buffer and there are no empty elements below the line,
-            // scroll up
-            this.ybase--;
-            addToY++;
-            if (this.ydisp > 0) {
-              // Viewport is at the top of the buffer, must increase downwards
-              this.ydisp--;
+      // Resize rows in both directions as needed
+      let addToY = 0;
+      if (this._terminal.rows < newRows) {
+        for (let y = this._terminal.rows; y < newRows; y++) {
+          if (this._lines.length < newRows + this.ybase) {
+            if (this.ybase > 0 && this._lines.length <= this.ybase + this.y + addToY + 1) {
+              // There is room above the buffer and there are no empty elements below the line,
+              // scroll up
+              this.ybase--;
+              addToY++;
+              if (this.ydisp > 0) {
+                // Viewport is at the top of the buffer, must increase downwards
+                this.ydisp--;
+              }
+            } else {
+              // Add a blank line if there is no buffer left at the top to scroll to, or if there
+              // are blank lines after the cursor
+              this._lines.push(this._terminal.blankLine(undefined, undefined, newCols));
             }
-          } else {
-            // Add a blank line if there is no buffer left at the top to scroll to, or if there
-            // are blank lines after the cursor
-            this._lines.push(this._terminal.blankLine(undefined, undefined, newCols));
+          }
+        }
+      } else { // (this._terminal.rows >= newRows)
+        for (let y = this._terminal.rows; y > newRows; y--) {
+          if (this._lines.length > newRows + this.ybase) {
+            if (this._lines.length > this.ybase + this.y + 1) {
+              // The line is a blank line below the cursor, remove it
+              this._lines.pop();
+            } else {
+              // The line is the cursor, scroll down
+              this.ybase++;
+              this.ydisp++;
+            }
           }
         }
       }
-    } else { // (this._terminal.rows >= newRows)
-      for (let y = this._terminal.rows; y > newRows; y--) {
-        if (this._lines.length > newRows + this.ybase) {
-          if (this._lines.length > this.ybase + this.y + 1) {
-            // The line is a blank line below the cursor, remove it
-            this._lines.pop();
-          } else {
-            // The line is the cursor, scroll down
-            this.ybase++;
-            this.ydisp++;
-          }
+
+      // Reduce max length if needed after adjustments, this is done after as it
+      // would otherwise cut data from the bottom of the buffer.
+      if (newMaxLength < this._lines.maxLength) {
+        // Trim from the top of the buffer and adjust ybase and ydisp.
+        const amountToTrim = this._lines.length - newMaxLength;
+        if (amountToTrim > 0) {
+          this._lines.trimStart(amountToTrim);
+          this.ybase = Math.max(this.ybase - amountToTrim, 0);
+          this.ydisp = Math.max(this.ydisp - amountToTrim, 0);
         }
+        this._lines.maxLength = newMaxLength;
       }
-    }
 
-    // Reduce max length if needed after adjustments, this is done after as it
-    // would otherwise cut data from the bottom of the buffer.
-    if (newMaxLength < this._lines.maxLength) {
-      // Trim from the top of the buffer and adjust ybase and ydisp.
-      const amountToTrim = this._lines.length - newMaxLength;
-      if (amountToTrim > 0) {
-        this._lines.trimStart(amountToTrim);
-        this.ybase = Math.max(this.ybase - amountToTrim, 0);
-        this.ydisp = Math.max(this.ydisp - amountToTrim, 0);
+      // Make sure that the cursor stays on screen
+      if (this.y >= newRows) {
+        this.y = newRows - 1;
       }
-      this._lines.maxLength = newMaxLength;
+      if (addToY) {
+        this.y += addToY;
+      }
+
+      if (this.x >= newCols) {
+        this.x = newCols - 1;
+      }
+
+      this.scrollTop = 0;
     }
 
-    // Make sure that the cursor stays on screen
-    if (this.y >= newRows) {
-      this.y = newRows - 1;
-    }
-    if (addToY) {
-      this.y += addToY;
-    }
-
-    if (this.x >= newCols) {
-      this.x = newCols - 1;
-    }
-
-    this.scrollTop = 0;
     this.scrollBottom = newRows - 1;
   }
 

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -46,6 +46,10 @@ export class Buffer implements IBuffer {
     return this._lines;
   }
 
+  public get hasScrollback(): boolean {
+    return this._hasScrollback && this.lines.maxLength > this._terminal.rows;
+  }
+
   /**
    * Gets the correct buffer length based on the rows provided, the terminal's
    * scrollback and whether this buffer is flagged to have scrollback or not.

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -78,10 +78,9 @@ export class Buffer implements IBuffer {
     this.ybase = 0;
     this.y = 0;
     this.x = 0;
-    this.scrollBottom = 0;
-    this.scrollTop = 0;
     this.tabs = {};
     this._lines = new CircularList<LineData>(this._getCorrectBufferLength(this._terminal.rows));
+    this.scrollTop = 0;
     this.scrollBottom = this._terminal.rows - 1;
   }
 

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -464,13 +464,10 @@ export class InputHandler implements IInputHandler {
     let j: number;
     j = this._terminal.rows - 1 - this._terminal.buffer.scrollBottom;
     j = this._terminal.rows - 1 + this._terminal.buffer.ybase - j;
-    console.log('deleteLines', params);
     while (param--) {
       // test: echo -e '\e[44m\e[1M\e[0m'
       // blankLine(true) - xterm/linux behavior
-      console.log('splice delete row: ' + (row - 1) + '(' + this._terminal.buffer.lines.get(row - 1)[0][1] + ')');
       this._terminal.buffer.lines.splice(row - 1, 1);
-      console.log('splice add blank row: ' + (j) + '(' + this._terminal.buffer.lines.get(j)[0][1] + ')');
       this._terminal.buffer.lines.splice(j, 0, this._terminal.blankLine(true));
     }
 

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -464,10 +464,13 @@ export class InputHandler implements IInputHandler {
     let j: number;
     j = this._terminal.rows - 1 - this._terminal.buffer.scrollBottom;
     j = this._terminal.rows - 1 + this._terminal.buffer.ybase - j;
+    console.log('deleteLines', params);
     while (param--) {
       // test: echo -e '\e[44m\e[1M\e[0m'
       // blankLine(true) - xterm/linux behavior
+      console.log('splice delete row: ' + (row - 1) + '(' + this._terminal.buffer.lines.get(row - 1)[0][1] + ')');
       this._terminal.buffer.lines.splice(row - 1, 1);
+      console.log('splice add blank row: ' + (j) + '(' + this._terminal.buffer.lines.get(j)[0][1] + ')');
       this._terminal.buffer.lines.splice(j, 0, this._terminal.blankLine(true));
     }
 

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1163,133 +1163,44 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
 
   /**
    * Scroll the terminal down 1 row, creating a blank line.
-   * @param {boolean} isWrapped Whether the new line is wrapped from the previous
-   * line.
+   * @param isWrapped Whether the new line is wrapped from the previous line.
    */
   public scroll(isWrapped?: boolean): void {
-    // The problem is caused when scrollback = 0. This section was written
-    // around the assumption that there would be buffer to trim when necessary.
-
-
-    // shiftElements should be used here
-
-    // If scrollTop is set (non-zero), we should shiftElements
-    // scrollBottom defines the position at which the new element is inserted
-
-    // Note that both scrollBottom and scrollTop need to be handled individually
-    // because they can be set to terminal.rows or 0 respectively
-
-    // Don't mess with ybase temporarily, asking for trouble
-
-    // This should work with minimal effort utilizing the CiruclarList
-
-    // TODO: Need to hold onto top given the if?
     const newLine = this.blankLine(undefined, isWrapped);
     const topRow = this.buffer.ybase + this.buffer.scrollTop;
     let bottomRow = this.buffer.ybase + this.buffer.scrollBottom;
 
-
-
-// TODO: There's a problem with ybase going beyond scrollback?
-
-
-    console.log('bottomRow', bottomRow);
-    console.log('this.buffer.scrollTop: ' + this.buffer.scrollTop);
     if (this.buffer.scrollTop === 0) {
+      // Determine whether the buffer is going to be trimmed after insertion.
       const willBufferBeTrimmed = this.buffer.lines.length === this.buffer.lines.maxLength;
 
-      // Remove the line first if there is no scrollback so the list is not
-      // trimmed
-      if (!this.buffer.hasScrollback) {
-        this.buffer.lines.splice(topRow, 1);
-        // Adjust bottomRow to make up for the deleted row
-        // bottomRow--;
-      }
-
+      // Insert the line using the fastest method
       if (bottomRow === this.buffer.lines.length - 1) {
-        // Pushing when possible is faster than splicing
         this.buffer.lines.push(newLine);
-        console.log('push');
       } else {
-        // Insert a row *below* the bottomRow, pushing the top row into the scrollback
-        if (!this.buffer.hasScrollback) {
-          // A line is deleted in this case so bottomRow is pushed up
-          this.buffer.lines.splice(bottomRow, 0, newLine);
-        } else {
-          this.buffer.lines.splice(bottomRow + 1, 0, newLine);
-        }
-        console.log('splice');
+        this.buffer.lines.splice(bottomRow + 1, 0, newLine);
       }
 
       // Only adjust ybase and ydisp when the buffer is not trimmed
       if (!willBufferBeTrimmed) {
-        console.log('increment ydisp/ybase');
         this.buffer.ybase++;
         this.buffer.ydisp++;
       }
-
-      console.log('this.buffer.ybase: ' + this.buffer.ybase);
-      console.log('this.buffer.ydisp: ' + this.buffer.ydisp);
-
     } else {
+      // scrollTop is non-zero which means no line will be going to the
+      // scrollback, instead we can just shift them in-place.
       const scrollRegionHeight = bottomRow - topRow + 1/*as it's zero-based*/;
-
-      console.log('shiftElements');
-      console.log('topRow: ' + topRow + '(' + this.buffer.lines.get(topRow)[0][1] + ')');
-      console.log('scrollRegionHeight: ' + scrollRegionHeight);
-
       this.buffer.lines.shiftElements(topRow + 1, scrollRegionHeight - 1, -1);
       this.buffer.lines.set(bottomRow, newLine);
     }
 
+    // Move the viewport to the bottom of the buffer unless the user is
+    // scrolling.
     if (!this.userScrolling) {
       this.buffer.ydisp = this.buffer.ybase;
     }
 
-
-    // Make room for the new row in lines
-    // const bufferNeedsTrimming = this.buffer.lines.length === this.buffer.lines.maxLength;
-    // if (bufferNeedsTrimming) {
-    //   this.buffer.lines.trimStart(1);
-    //   this.buffer.ybase--;
-    //   this.buffer.ydisp = Math.max(this.buffer.ydisp - 1, 0);
-    // }
-
-    // this.buffer.ybase++;
-
-    // // Scroll the viewport down to the bottom if the user is not scrolling
-    // if (!this.userScrolling) {
-    //   this.buffer.ydisp = this.buffer.ybase;
-    // }
-
-    // // last line
-    // let row = this.buffer.ybase + this.rows - 1;
-
-    // // subtract the bottom scroll region
-    // row -= this.rows - 1 - this.buffer.scrollBottom;
-
-    // // Same as this?
-    // // row = this.buffer.ybase + this.buffer.scrollBottom;
-
-    // if (row === this.buffer.lines.length) {
-    //   // Optimization: pushing is faster than splicing when they amount to the same behavior
-    //   this.buffer.lines.push(this.blankLine(undefined, isWrapped));
-    // } else {
-    //   // add our new line
-    //   this.buffer.lines.splice(row, 0, this.blankLine(undefined, isWrapped));
-    // }
-
-    // if (this.buffer.scrollTop !== 0) {
-    //   if (this.buffer.ybase !== 0) {
-    //     this.buffer.ybase--;
-    //     if (!this.userScrolling) {
-    //       this.buffer.ydisp = this.buffer.ybase;
-    //     }
-    //   }
-    //   this.buffer.lines.splice(this.buffer.ybase + this.buffer.scrollTop, 1);
-    // }
-
-    // this.maxRange();
+    // Flag rows that need updating
     this.updateRange(this.buffer.scrollTop);
     this.updateRange(this.buffer.scrollBottom);
 


### PR DESCRIPTION
So there are two issues this fixes, both were issues when scrollback = 0.

1. `reverseIndex` was always shifting `Terminal.rows` elements, when it should have only be shifting the size of the viewport. This means that items from the top of the scrollback were being pulled in.
2. The `scroll` function wasn't working when scrollback = 0 because we were trimming the list at the start, resulting in a loss of data. Instead of trying to fix the bug I decided to reimplement and add a bunch of tests to make sure it's working correctly. The old logic was pretty confusing and the trimming part was tacked on when I introduced the `CircularList`.

Fixes #922

---

Another fix is included in this which fixes the alt buffer's dimensions getting out of sync with the terminal before it's initialized/filled.

Fixes #924