### PR TITLE
Delete unused timer variables

### DIFF
--- a/src/addons/attach/attach.js
+++ b/src/addons/attach/attach.js
@@ -44,8 +44,6 @@
     term._flushBuffer = function () {
       term.write(term._attachSocketBuffer);
       term._attachSocketBuffer = null;
-      clearTimeout(term._attachSocketBufferTimer);
-      term._attachSocketBufferTimer = null;
     };
 
     term._pushToBuffer = function (data) {

--- a/src/addons/terminado/terminado.js
+++ b/src/addons/terminado/terminado.js
@@ -45,8 +45,6 @@
     term._flushBuffer = function () {
       term.write(term._attachSocketBuffer);
       term._attachSocketBuffer = null;
-      clearTimeout(term._attachSocketBufferTimer);
-      term._attachSocketBufferTimer = null;
     };
 
     term._pushToBuffer = function (data) {


### PR DESCRIPTION
These variables I think are vestiges from when these addons cleared a timer as a way of staggering updates. Now they simply check the data variable itself.