### PR TITLE
Fix CSI Ps M to delete the correct line

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -467,7 +467,7 @@ export class InputHandler implements IInputHandler {
     while (param--) {
       // test: echo -e '\e[44m\e[1M\e[0m'
       // blankLine(true) - xterm/linux behavior
-      this._terminal.buffer.lines.splice(row - 1, 1);
+      this._terminal.buffer.lines.splice(row, 1);
       this._terminal.buffer.lines.splice(j, 0, this._terminal.blankLine(true));
     }
 


### PR DESCRIPTION
Fixes #947 

This fixes an issue in the v3 branch where CSI Ps M was clearing the wrong line. This bug was introduced by https://github.com/sourcelair/xterm.js/commit/a57f55dcbf7962662d8ba3e6da75bbea96eb331b#diff-5eb84354a70d0df188b3bbb5566120bbL493

