### PR TITLE
Treat \u279C arrow as ambiguous width char (like emoji)

### DIFF
--- a/src/renderer/ForegroundRenderLayer.ts
+++ b/src/renderer/ForegroundRenderLayer.ts
@@ -159,6 +159,11 @@ export class ForegroundRenderLayer extends BaseRenderLayer {
    * @param char The character to search.
    */
   private _isEmoji(char: string): boolean {
+    // Check special ambiguous width characters
+    if (char === '➜') {
+      return true;
+    }
+    // Check emoji unicode range
     return char.search(/([\uD800-\uDBFF][\uDC00-\uDFFF])/g) >= 0;
   }
 

--- a/src/renderer/ForegroundRenderLayer.ts
+++ b/src/renderer/ForegroundRenderLayer.ts
@@ -159,6 +159,7 @@ export class ForegroundRenderLayer extends BaseRenderLayer {
    * @param char The character to search.
    */
   private _isEmoji(char: string): boolean {
+    // TODO: We need a generic solution for handling characters like this
     // Check special ambiguous width characters
     if (char === '➜') {
       return true;


### PR DESCRIPTION
Fixes #974

---

Works fine now when a space is next to it:

<img width="270" alt="screen shot 2017-09-12 at 7 24 09 pm" src="https://user-images.githubusercontent.com/2193314/30356822-fe71cc84-97ef-11e7-841a-b7cd83988421.png">
