### PR TITLE
Prevent webpack from loading non-js files

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -688,10 +688,10 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
     // TODO: Improve return type and documentation
     if (typeof exports === 'object' && typeof module === 'object') {
       // CommonJS
-      return require('./addons/' + addon + '/' + addon);
+      return require('./addons/' + addon + '/' + addon + '.js');
     } else if (typeof define === 'function') {
       // RequireJS
-      return (<any>require)(['./addons/' + addon + '/' + addon], callback);
+      return (<any>require)(['./addons/' + addon + '/' + addon + '.js'], callback);
     } else {
       console.error('Cannot load a module without a CommonJS or RequireJS environment.');
       return false;


### PR DESCRIPTION
Fixes  #877

Webpack is guessing what files to bundle and attempts to load source maps. Explicity specifying the js extension fixes this.