### PR TITLE
remove import file extension

### DIFF
--- a/src/utils/CharMeasure.ts
+++ b/src/utils/CharMeasure.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { EventEmitter } from '../EventEmitter.js';
+import { EventEmitter } from '../EventEmitter';
 import { ICharMeasure, ITerminal, ITerminalOptions } from '../Interfaces';
 
 /**


### PR DESCRIPTION
Really no reason to have this, and it breaks the build when importing src/