### PR TITLE
Normalize tsconfig outDir

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,8 +25,8 @@ let outDir = tsProject.config.compilerOptions.outDir;
 
 // Under some environments like TravisCI, this comes out at absolute which can
 // break the build. This ensures that the outDir is absolute.
-if (outDir.indexOf(__dirname) !== 0) {
-  outDir = `${__dirname}/${outDir}`;
+if (path.normalize(outDir).indexOf(__dirname) !== 0) {
+  outDir = `${__dirname}/${path.normalize(outDir)}`;
 }
 
 /**


### PR DESCRIPTION
It was coming out with the wrap path separators on Windows

Fixes #1024