### PR TITLE
Rendering improvements

### DIFF
--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -242,7 +242,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
       const charAtlasCellWidth = this._scaledCharWidth + CHAR_ATLAS_CELL_SPACING;
       const charAtlasCellHeight = this._scaledCharHeight + CHAR_ATLAS_CELL_SPACING;
       this._ctx.drawImage(this._charAtlas,
-          code * charAtlasCellWidth, colorIndex * charAtlasCellHeight, this._scaledCharWidth, this._scaledCharHeight,
+          code * charAtlasCellWidth, colorIndex * charAtlasCellHeight, charAtlasCellWidth, this._scaledCharHeight,
           x * this._scaledCharWidth, y * this._scaledLineHeight + this._scaledLineDrawY, this._scaledCharWidth, this._scaledCharHeight);
     } else {
       this._drawUncachedChar(terminal, char, width, fg, x, y, bold);
@@ -285,7 +285,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     // can bleed into other cells. This code will clip the following fillText,
     // ensuring that its contents don't go beyond the cell bounds.
     this._ctx.beginPath();
-    this._ctx.rect(x * this._scaledCharWidth, y * this._scaledLineHeight + this._scaledLineDrawY, width * this._scaledCharWidth, this._scaledCharHeight);
+    this._ctx.rect(0, y * this._scaledLineHeight + this._scaledLineDrawY, terminal.cols * this._scaledCharWidth, this._scaledCharHeight);
     this._ctx.clip();
 
     // Draw the character

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -224,11 +224,6 @@ export abstract class BaseRenderLayer implements IRenderLayer {
    * @param bold Whether the text is bold.
    */
   protected drawChar(terminal: ITerminal, char: string, code: number, width: number, x: number, y: number, fg: number, bg: number, bold: boolean): void {
-    // Clear the cell next to this character if it's wide
-    if (width === 2) {
-      this.clearCells(x + 1, y, 1, 1);
-    }
-
     let colorIndex = 0;
     if (fg < 256) {
       colorIndex = fg + 2;

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -31,7 +31,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     this._canvas = document.createElement('canvas');
     this._canvas.id = `xterm-${id}-layer`;
     this._canvas.style.zIndex = zIndex.toString();
-    this._ctx = this._canvas.getContext('2d', {_alpha});
+    this._ctx = this._canvas.getContext('2d', {alpha: _alpha});
     this._ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
     // Draw the background if this is an opaque layer
     if (!_alpha) {

--- a/src/renderer/ColorManager.ts
+++ b/src/renderer/ColorManager.ts
@@ -86,7 +86,7 @@ export class ColorManager implements IColorManager {
    */
   public setTheme(theme: ITheme): void {
     this.colors.foreground = theme.foreground || DEFAULT_FOREGROUND;
-    this.colors.background = theme.background || DEFAULT_BACKGROUND;
+    this.colors.background = this._validateColor(theme.background, DEFAULT_BACKGROUND);
     this.colors.cursor = theme.cursor || DEFAULT_CURSOR;
     this.colors.cursorAccent = theme.cursorAccent || DEFAULT_CURSOR_ACCENT;
     this.colors.selection = theme.selection || DEFAULT_SELECTION;
@@ -106,5 +106,18 @@ export class ColorManager implements IColorManager {
     this.colors.ansi[13] = theme.brightMagenta || DEFAULT_ANSI_COLORS[13];
     this.colors.ansi[14] = theme.brightCyan || DEFAULT_ANSI_COLORS[14];
     this.colors.ansi[15] = theme.brightWhite || DEFAULT_ANSI_COLORS[15];
+  }
+
+  private _validateColor(color: string, fallback: string): string {
+    if (color.length === 7 && color.charAt(0) === '#') {
+      return color;
+    }
+    if (color.length === 4 && color.charAt(0) === '#') {
+      const r = color.charAt(1);
+      const g = color.charAt(2);
+      const b = color.charAt(3);
+      return `#${r}${r}${g}${g}${b}${b}`;
+    }
+    return fallback;
   }
 }

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -59,6 +59,11 @@ export class TextRenderLayer extends BaseRenderLayer {
       const row = y + terminal.buffer.ydisp;
       const line = terminal.buffer.lines.get(row);
 
+      this.clearCells(0, y, terminal.cols, 1);
+      // for (let x = 0; x < terminal.cols; x++) {
+      //   this._state.cache[x][y] = null;
+      // }
+
       for (let x = 0; x < terminal.cols; x++) {
         const charData = line[x];
         const code: number = <number>charData[CHAR_DATA_CODE_INDEX];
@@ -69,7 +74,7 @@ export class TextRenderLayer extends BaseRenderLayer {
         // The character to the left is a wide character, drawing is owned by
         // the char at x-1
         if (width === 0) {
-          this._state.cache[x][y] = null;
+          // this._state.cache[x][y] = null;
           continue;
         }
 
@@ -86,19 +91,19 @@ export class TextRenderLayer extends BaseRenderLayer {
         }
 
         // Skip rendering if the character is identical
-        const state = this._state.cache[x][y];
-        if (state && state[CHAR_DATA_CHAR_INDEX] === char && state[CHAR_DATA_ATTR_INDEX] === attr) {
-          // Skip render, contents are identical
-          this._state.cache[x][y] = charData;
-          continue;
-        }
+        // const state = this._state.cache[x][y];
+        // if (state && state[CHAR_DATA_CHAR_INDEX] === char && state[CHAR_DATA_ATTR_INDEX] === attr) {
+        //   // Skip render, contents are identical
+        //   this._state.cache[x][y] = charData;
+        //   continue;
+        // }
 
         // Clear the old character was not a space with the default background
-        const wasInverted = !!(state && state[CHAR_DATA_ATTR_INDEX] && state[CHAR_DATA_ATTR_INDEX] >> 18 & FLAGS.INVERSE);
-        if (state && !(state[CHAR_DATA_CODE_INDEX] === 32 /*' '*/ && (state[CHAR_DATA_ATTR_INDEX] & 0x1ff) >= 256 && !wasInverted)) {
-          this._clearChar(x, y);
-        }
-        this._state.cache[x][y] = charData;
+        // const wasInverted = !!(state && state[CHAR_DATA_ATTR_INDEX] && state[CHAR_DATA_ATTR_INDEX] >> 18 & FLAGS.INVERSE);
+        // if (state && !(state[CHAR_DATA_CODE_INDEX] === 32 /*' '*/ && (state[CHAR_DATA_ATTR_INDEX] & 0x1ff) >= 256 && !wasInverted)) {
+        //   this._clearChar(x, y);
+        // }
+        // this._state.cache[x][y] = charData;
 
         const flags = attr >> 18;
         let bg = attr & 0x1ff;
@@ -120,14 +125,14 @@ export class TextRenderLayer extends BaseRenderLayer {
           // space is added. Without this, the first half of `b` would never
           // get removed, and `a` would not re-render because it thinks it's
           // already in the correct state.
-          this._state.cache[x][y] = OVERLAP_OWNED_CHAR_DATA;
+          // this._state.cache[x][y] = OVERLAP_OWNED_CHAR_DATA;
           if (x < line.length - 1 && line[x + 1][CHAR_DATA_CODE_INDEX] === 32 /*' '*/) {
             width = 2;
-            this._clearChar(x + 1, y);
+            // this._clearChar(x + 1, y);
             // The overlapping char's char data will force a clear and render when the
             // overlapping char is no longer to the left of the character and also when
             // the space changes to another character.
-            this._state.cache[x + 1][y] = OVERLAP_OWNED_CHAR_DATA;
+            // this._state.cache[x + 1][y] = OVERLAP_OWNED_CHAR_DATA;
           }
         }
 
@@ -148,7 +153,7 @@ export class TextRenderLayer extends BaseRenderLayer {
 
         // Clear the cell next to this character if it's wide
         if (width === 2) {
-          this.clearCells(x + 1, y, 1, 1);
+          // this.clearCells(x + 1, y, 1, 1);
         }
 
         // Draw background

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -121,7 +121,7 @@ export class TextRenderLayer extends BaseRenderLayer {
           // get removed, and `a` would not re-render because it thinks it's
           // already in the correct state.
           this._state.cache[x][y] = OVERLAP_OWNED_CHAR_DATA;
-          if (x < line.length && line[x + 1][CHAR_DATA_CODE_INDEX] === 32 /*' '*/) {
+          if (x < line.length - 1 && line[x + 1][CHAR_DATA_CODE_INDEX] === 32 /*' '*/) {
             width = 2;
             this._clearChar(x + 1, y);
             // The overlapping char's char data will force a clear and render when the

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -146,6 +146,11 @@ export class TextRenderLayer extends BaseRenderLayer {
           }
         }
 
+        // Clear the cell next to this character if it's wide
+        if (width === 2) {
+          this.clearCells(x + 1, y, 1, 1);
+        }
+
         // Draw background
         if (bg < 256) {
           this._ctx.save();


### PR DESCRIPTION
Fixes #1032 
Fixes #1031
Fixes #1035
Fixes #1036
Fixes #1032
Fixes #1037

---

See individual commits for what was actually done. It turns out drawing the entire line like this is fairly fast, typically ranging from 0.5ms to 4ms on my macbook. The boost in stability/accuracy that this change brings is a must for now. It would be good to go back to intelligently diffing before drawing eventually (when we're certain the characters aren't overlapping).