### PR TITLE
Cleanup renderer code

### DIFF
--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -16,13 +16,8 @@ import { BaseRenderLayer, INVERTED_DEFAULT_COLOR } from './BaseRenderLayer';
  * when the character changes (a regular space ' ' character may not as it's
  * drawn state is a cleared cell).
  */
-const OVERLAP_OWNED_CHAR_DATA: CharData = [null, '', 0, -1];
-
 export class TextRenderLayer extends BaseRenderLayer {
   private _state: GridCache<CharData>;
-  private _characterWidth: number;
-  private _characterFont: string;
-  private _characterOverlapCache: { [key: string]: boolean } = {};
 
   constructor(container: HTMLElement, zIndex: number, colors: IColorSet) {
     super(container, 'text', zIndex, false, colors);
@@ -34,11 +29,7 @@ export class TextRenderLayer extends BaseRenderLayer {
 
     // Clear the character width cache if the font or width has changed
     const terminalFont = `${terminal.options.fontSize * window.devicePixelRatio}px ${terminal.options.fontFamily}`;
-    if (this._characterWidth !== dim.scaledCharWidth || this._characterFont !== terminalFont) {
-      this._characterWidth = dim.scaledCharWidth;
-      this._characterFont = terminalFont;
-      this._characterOverlapCache = {};
-    }
+		
     // Resizing the canvas discards the contents of the canvas so clear state
     this._state.clear();
     this._state.resize(terminal.cols, terminal.rows);
@@ -60,9 +51,6 @@ export class TextRenderLayer extends BaseRenderLayer {
       const line = terminal.buffer.lines.get(row);
 
       this.clearCells(0, y, terminal.cols, 1);
-      // for (let x = 0; x < terminal.cols; x++) {
-      //   this._state.cache[x][y] = null;
-      // }
 
       for (let x = 0; x < terminal.cols; x++) {
         const charData = line[x];
@@ -78,33 +66,6 @@ export class TextRenderLayer extends BaseRenderLayer {
           continue;
         }
 
-        // If the character is a space and the character to the left is an
-        // overlapping character, skip the character and allow the overlapping
-        // char to take full control over this character's cell.
-        if (code === 32 /*' '*/) {
-          if (x > 0) {
-            const previousChar: CharData = line[x - 1];
-            if (this._isOverlapping(previousChar)) {
-              continue;
-            }
-          }
-        }
-
-        // Skip rendering if the character is identical
-        // const state = this._state.cache[x][y];
-        // if (state && state[CHAR_DATA_CHAR_INDEX] === char && state[CHAR_DATA_ATTR_INDEX] === attr) {
-        //   // Skip render, contents are identical
-        //   this._state.cache[x][y] = charData;
-        //   continue;
-        // }
-
-        // Clear the old character was not a space with the default background
-        // const wasInverted = !!(state && state[CHAR_DATA_ATTR_INDEX] && state[CHAR_DATA_ATTR_INDEX] >> 18 & FLAGS.INVERSE);
-        // if (state && !(state[CHAR_DATA_CODE_INDEX] === 32 /*' '*/ && (state[CHAR_DATA_ATTR_INDEX] & 0x1ff) >= 256 && !wasInverted)) {
-        //   this._clearChar(x, y);
-        // }
-        // this._state.cache[x][y] = charData;
-
         const flags = attr >> 18;
         let bg = attr & 0x1ff;
 
@@ -114,26 +75,6 @@ export class TextRenderLayer extends BaseRenderLayer {
         const isInverted = flags & FLAGS.INVERSE;
         if (!code || (code === 32 /*' '*/ && isDefaultBackground && !isInverted) || isInvisible) {
           continue;
-        }
-
-        // If the character is an overlapping char and the character to the right is a
-        // space, take ownership of the cell to the right.
-        if (width !== 0 && this._isOverlapping(charData)) {
-          // If the character is overlapping, we want to force a re-render on every
-          // frame. This is specifically to work around the case where two
-          // overlaping chars `a` and `b` are adjacent, the cursor is moved to b and a
-          // space is added. Without this, the first half of `b` would never
-          // get removed, and `a` would not re-render because it thinks it's
-          // already in the correct state.
-          // this._state.cache[x][y] = OVERLAP_OWNED_CHAR_DATA;
-          if (x < line.length - 1 && line[x + 1][CHAR_DATA_CODE_INDEX] === 32 /*' '*/) {
-            width = 2;
-            // this._clearChar(x + 1, y);
-            // The overlapping char's char data will force a clear and render when the
-            // overlapping char is no longer to the left of the character and also when
-            // the space changes to another character.
-            // this._state.cache[x + 1][y] = OVERLAP_OWNED_CHAR_DATA;
-          }
         }
 
         let fg = (attr >> 9) & 0x1ff;
@@ -149,11 +90,6 @@ export class TextRenderLayer extends BaseRenderLayer {
           if (bg === 257) {
             bg = INVERTED_DEFAULT_COLOR;
           }
-        }
-
-        // Clear the cell next to this character if it's wide
-        if (width === 2) {
-          // this.clearCells(x + 1, y, 1, 1);
         }
 
         // Draw background
@@ -190,45 +126,6 @@ export class TextRenderLayer extends BaseRenderLayer {
         this._ctx.restore();
       }
     }
-  }
-
-	/**
-	 * Whether a character is overlapping to the next cell.
-	 */
-  private _isOverlapping(charData: CharData): boolean {
-    // Only single cell characters can be overlapping, rendering issues can
-    // occur without this check
-    if (charData[CHAR_DATA_WIDTH_INDEX] !== 1) {
-      return false;
-    }
-
-    // We assume that any ascii character will not overlap
-    const code = charData[CHAR_DATA_CODE_INDEX];
-    if (code < 256) {
-      return false;
-    }
-
-    // Deliver from cache if available
-    const char = charData[CHAR_DATA_CHAR_INDEX];
-    if (this._characterOverlapCache.hasOwnProperty(char)) {
-      return this._characterOverlapCache[char];
-    }
-
-    // Setup the font
-    this._ctx.save();
-    this._ctx.font = this._characterFont;
-
-    // Measure the width of the character, but Math.floor it
-    // because that is what the renderer does when it calculates
-    // the character dimensions we are comparing against
-    const overlaps = Math.floor(this._ctx.measureText(char).width) > this._characterWidth;
-
-    // Restore the original context
-    this._ctx.restore();
-
-    // Cache and return
-    this._characterOverlapCache[char] = overlaps;
-    return overlaps;
   }
 
   /**

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -29,7 +29,7 @@ export class TextRenderLayer extends BaseRenderLayer {
 
     // Clear the character width cache if the font or width has changed
     const terminalFont = `${terminal.options.fontSize * window.devicePixelRatio}px ${terminal.options.fontFamily}`;
-		
+
     // Resizing the canvas discards the contents of the canvas so clear state
     this._state.clear();
     this._state.resize(terminal.cols, terminal.rows);


### PR DESCRIPTION
Since we are now always redrawing the whole line if it was changed, we can remove all the overlapping code that was put in for the optimisations. This yields another very nice effect, because overlapping characters can now overlap to the next cell without us having to worry about a space character after them.

![render](https://user-images.githubusercontent.com/2785983/31338543-fd28b822-acff-11e7-8b9b-ae4d9216b9b7.gif)
