### PR TITLE
Fix ansi bright text being bold without bold flag

### DIFF
--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -234,7 +234,10 @@ export abstract class BaseRenderLayer implements IRenderLayer {
       }
     }
     const isAscii = code < 256;
-    const isBasicColor = (colorIndex > 1 && fg < 16);
+    // A color is basic if it is one of the standard normal or bold weight
+    // colors of the characters held in the char atlas. Note that this excludes
+    // the normal weight light color characters
+    const isBasicColor = (colorIndex > 1 && fg < 16) && (fg < 8 || bold);
     const isDefaultColor = fg >= 256;
     const isDefaultBackground = bg >= 256;
     if (this._charAtlas && isAscii && (isBasicColor || isDefaultColor) && isDefaultBackground) {


### PR DESCRIPTION
Fixes #1047 

Demo:

<img width="606" alt="screen shot 2017-10-10 at 10 39 14 pm" src="https://user-images.githubusercontent.com/2193314/31423846-df517af2-ae0b-11e7-86f5-87bb20c166ae.png">

gnome-terminal:

<img width="726" alt="screen shot 2017-10-10 at 10 39 33 pm" src="https://user-images.githubusercontent.com/2193314/31423855-ee07e41e-ae0b-11e7-8c82-410905a114ad.png">
