### PR TITLE
Apple iPad - Smart Keyboard Arrows

### DIFF
--- a/src/xterm.js
+++ b/src/xterm.js
@@ -1511,6 +1511,36 @@ Terminal.prototype.evaluateKeyEscapeSequence = function(ev) {
   };
   var modifiers = ev.shiftKey << 0 | ev.altKey << 1 | ev.ctrlKey << 2 | ev.metaKey << 3;
   switch (ev.keyCode) {
+    case 0:
+      if (ev.key === "UIKeyInputUpArrow") {
+        if (this.applicationCursor) {
+          result.key = C0.ESC + 'OA';
+        } else {
+          result.key = C0.ESC + '[A';
+        }
+      }
+      else if (ev.key === "UIKeyInputLeftArrow") {
+        if (this.applicationCursor) {
+          result.key = C0.ESC + 'OD';
+        } else {
+          result.key = C0.ESC + '[D';
+        }
+      }
+      else if (ev.key === "UIKeyInputRightArrow") {
+        if (this.applicationCursor) {
+          result.key = C0.ESC + 'OC';
+        } else {
+          result.key = C0.ESC + '[C';
+        }
+      }
+      else if (ev.key === "UIKeyInputDownArrow") {
+        if (this.applicationCursor) {
+          result.key = C0.ESC + 'OB';
+        } else {
+          result.key = C0.ESC + '[B';
+        }
+      }
+      break;
     case 8:
       // backspace
       if (ev.shiftKey) {


### PR DESCRIPTION
Hi! It was a pleasant surprise to find out that xterm.js mostly works out of the box with Apple's Smart Keyboard using iPad iOS 11. However, the arrows don't work. Let me know if the main code is not a place for such platform specific mappings. 🍻 

- Arrows trigger `keydown` event
- `keyCode == 0`, always.
- The actual key pressed is identified via `key` strings:
    - `UIKeyInputUpArrow`
    - `UIKeyInputLeftArrow`
    - `UIKeyInputRightArrow`
    - `UIKeyInputDownArrow`

I'm not sure how Android does it and if this is truly iPad specific or not. I'm also not sure if this truly should be part of the main xterm code, or just handled separately via addon/application layer when useragent is identified as iPad. 