### PR TITLE
Apple iPad - Smart Keyboard Arrows - v3

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1415,6 +1415,36 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
     };
     const modifiers = (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0) | (ev.metaKey ? 8 : 0);
     switch (ev.keyCode) {
+      case 0:
+        if (ev.key === "UIKeyInputUpArrow") {
+          if (this.applicationCursor) {
+            result.key = C0.ESC + 'OA';
+          } else {
+            result.key = C0.ESC + '[A';
+          }
+        }
+        else if (ev.key === "UIKeyInputLeftArrow") {
+          if (this.applicationCursor) {
+            result.key = C0.ESC + 'OD';
+          } else {
+            result.key = C0.ESC + '[D';
+          }
+        }
+        else if (ev.key === "UIKeyInputRightArrow") {
+          if (this.applicationCursor) {
+            result.key = C0.ESC + 'OC';
+          } else {
+            result.key = C0.ESC + '[C';
+          }
+        }
+        else if (ev.key === "UIKeyInputDownArrow") {
+          if (this.applicationCursor) {
+            result.key = C0.ESC + 'OB';
+          } else {
+            result.key = C0.ESC + '[B';
+          }
+        }
+        break;
       case 8:
         // backspace
         if (ev.shiftKey) {

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1416,28 +1416,28 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
     const modifiers = (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0) | (ev.metaKey ? 8 : 0);
     switch (ev.keyCode) {
       case 0:
-        if (ev.key === "UIKeyInputUpArrow") {
+        if (ev.key === 'UIKeyInputUpArrow') {
           if (this.applicationCursor) {
             result.key = C0.ESC + 'OA';
           } else {
             result.key = C0.ESC + '[A';
           }
         }
-        else if (ev.key === "UIKeyInputLeftArrow") {
+        else if (ev.key === 'UIKeyInputLeftArrow') {
           if (this.applicationCursor) {
             result.key = C0.ESC + 'OD';
           } else {
             result.key = C0.ESC + '[D';
           }
         }
-        else if (ev.key === "UIKeyInputRightArrow") {
+        else if (ev.key === 'UIKeyInputRightArrow') {
           if (this.applicationCursor) {
             result.key = C0.ESC + 'OC';
           } else {
             result.key = C0.ESC + '[C';
           }
         }
-        else if (ev.key === "UIKeyInputDownArrow") {
+        else if (ev.key === 'UIKeyInputDownArrow') {
           if (this.applicationCursor) {
             result.key = C0.ESC + 'OB';
           } else {


### PR DESCRIPTION
A duplicate of #1064 against the v3 branch. Please test and provide feedback.

- Arrows trigger `keydown` event
- `keyCode == 0`, always.
- The actual key pressed is identified via `key` strings:
    - `UIKeyInputUpArrow`
    - `UIKeyInputLeftArrow`
    - `UIKeyInputRightArrow`
    - `UIKeyInputDownArrow`

