### PR TITLE
Update MacOS base image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   steps:
   - task: NodeTool@0
     inputs:


### PR DESCRIPTION
Spotted the following message in the azure ci logs: 
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583