### PR TITLE
Add proper typing for search results change event

### DIFF
--- a/addons/addon-search/src/SearchAddon.ts
+++ b/addons/addon-search/src/SearchAddon.ts
@@ -5,7 +5,7 @@
 
 import type { Terminal, IDisposable, ITerminalAddon, IDecoration } from '@xterm/xterm';
 import type { SearchAddon as ISearchApi } from '@xterm/addon-search';
-import { Emitter } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
 import { combinedDisposable, Disposable, dispose, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 
 export interface ISearchOptions {
@@ -29,6 +29,11 @@ interface ISearchDecorationOptions {
 export interface ISearchPosition {
   startCol: number;
   startRow: number;
+}
+
+export interface ISearchResultChangeEvent {
+  resultIndex: number;
+  resultCount: number;
 }
 
 export interface ISearchAddonOptions {
@@ -86,8 +91,8 @@ export class SearchAddon extends Disposable implements ITerminalAddon , ISearchA
   private _linesCacheTimeoutId = 0;
   private _linesCacheDisposables = new MutableDisposable();
 
-  private readonly _onDidChangeResults = this._register(new Emitter<{ resultIndex: number, resultCount: number }>());
-  public readonly onDidChangeResults = this._onDidChangeResults.event;
+  private readonly _onDidChangeResults = this._register(new Emitter<ISearchResultChangeEvent>());
+  public get onDidChangeResults(): Event<ISearchResultChangeEvent> { return this._onDidChangeResults.event; }
 
   constructor(options?: Partial<ISearchAddonOptions>) {
     super();

--- a/addons/addon-search/test/SearchAddon.test.ts
+++ b/addons/addon-search/test/SearchAddon.test.ts
@@ -19,8 +19,8 @@ test.afterAll(async () => await ctx.page.close());
 test.describe('Search Tests', () => {
 
   test.beforeEach(async () => {
+    await ctx.proxy.reset();
     await ctx.page.evaluate(`
-      window.term.reset()
       window.search?.dispose();
       window.search = new SearchAddon();
       window.term.loadAddon(window.search);

--- a/addons/addon-search/typings/addon-search.d.ts
+++ b/addons/addon-search/typings/addon-search.d.ts
@@ -76,6 +76,21 @@ declare module '@xterm/addon-search' {
   }
 
   /**
+   * Event data fired when search results change.
+   */
+  export interface ISearchResultChangeEvent {
+    /**
+     * The index of the currently active result, -1 when the threshold of matches is exceeded.
+     */
+    resultIndex: number;
+
+    /**
+     * The total number of search results found.
+     */
+    resultCount: number;
+  }
+
+  /**
    * Options for the search addon.
    */
   export interface ISearchAddonOptions {
@@ -139,8 +154,7 @@ declare module '@xterm/addon-search' {
     /**
      * When decorations are enabled, fires when
      * the search results change.
-     * @returns -1 for resultIndex when the threshold of matches is exceeded.
      */
-    readonly onDidChangeResults: IEvent<{ resultIndex: number, resultCount: number }>;
+    readonly onDidChangeResults: IEvent<ISearchResultChangeEvent>;
   }
 }


### PR DESCRIPTION
- Export ISearchResultChangeEvent interface in addon-search
- Use proper Event<T> typing instead of inline object
- Improve API consistency and type safety for consumers