### PR TITLE
Fix teleport when exiting out of alt buffer. v2

### DIFF
--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -94,7 +94,12 @@ export class Viewport extends Disposable {
     }));
 
     this._register(this._bufferService.onResize(() => this.queueSync()));
-    this._register(this._bufferService.buffers.onBufferActivate(() => this.queueSync()));
+    this._register(this._bufferService.buffers.onBufferActivate(() => {
+      // Reset _latestYDisp when switching buffers to prevent stale scroll position
+      // from alt buffer contaminating normal buffer scroll position
+      this._latestYDisp = undefined;
+      this.queueSync();
+    }));
     this._register(this._bufferService.onScroll(() => this._sync()));
 
     this._register(this._scrollableElement.onScroll(e => this._handleScroll(e)));
@@ -160,7 +165,6 @@ export class Viewport extends Disposable {
     // If ydisp has been changed by some other component (input/buffer), then stop animating smooth
     // scroll and scroll there immediately.
     if (ydisp !== this._latestYDisp) {
-      this._latestYDisp = ydisp;
       this._scrollableElement.setScrollPosition({
         scrollTop: ydisp * this._renderService.dimensions.css.cell.height
       });


### PR DESCRIPTION
Had people try out: https://github.com/microsoft/vscode/issues/224750#issuecomment-3324948592

Apparently https://github.com/xtermjs/xterm.js/pull/5390 wasn't enough. 
If you really interact scroll around alt buffer, after maxing out in normal buffer, you can sometimes repro this if you get lucky. 

@Tyriar  The teleport issue came back, this time it was more difficult to repro, but I was able to repro.

Steps to repro for me was:
1.  fill in bunch of things in the normal buffer with `echo -l {1..10000}` 
2. enter alt buffer,
3. scroll very aggressively in alt buffer with+without content
4. Exit vim via `:q!` 
5. notice scroll is at the top again. You have to get pretty lucky. I noticed trying to max out my normal buffer, and also filling in content inside alt buffer & scrolling aggressively there, back <-> forth between helped increase the probability of repro. Sometimes had to launch vim multiple times and exit out re-doing the steps. 

-----------------------------------------------------
I spent some time and it seems like at certain point ` undefined  !== 1000` causes true for 
```
  if (ydisp !== this._latestYDisp) {
      this._scrollableElement.setScrollPosition({
        scrollTop: ydisp * this._renderService.dimensions.css.cell.height
      });
```
 when  ydisp is undefined after exiting out of alt buffer. Hence scroll will be brought to very top. 

* undefined above is likely coming from https://github.com/xtermjs/xterm.js/blob/a1d8e96fdd5ed93329b5af09106f5a3c6cd5740b/src/browser/Viewport.ts#L97

EDIT: ydisp cannot be undefined in sync due to https://github.com/xtermjs/xterm.js/pull/5411#discussion_r2395187542 
-----------------------------------------------------


Adding `this._latestYDisp = ydisp`in `_sync`  similar to `queueSync` seems to solve the problem.


Here are some logs PRE-PR:

(Entering vim)
<img width="1725" height="763" alt="enterAlt" src="https://github.com/user-attachments/assets/d7398b9a-0c61-48f1-8d79-6fb6ba111665" />

(Exit out of vim) 
<img width="1724" height="524" alt="backtoNorm" src="https://github.com/user-attachments/assets/281bb2af-5bb6-4297-b5a1-887fb5148e6f" />


(start scrolling) 
<img width="865" height="387" alt="startScroll" src="https://github.com/user-attachments/assets/4e8fbb13-fdab-47a2-b137-4908a0fa0265" />

