### PR TITLE
Only show char codes for parsing data on trace

### DIFF
--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -444,7 +444,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     }
 
     // Log debug data, the log level gate is to prevent extra work in this hot path
-    if (this._logService.logLevel === LogLevelEnum.DEBUG) {
+    if (this._logService.logLevel <= LogLevelEnum.DEBUG) {
       this._logService.debug(`parsing data ${typeof data === 'string' ? ` "${data}"` : ` "${Array.prototype.map.call(data, e => String.fromCharCode(e)).join('')}"`}`);
     }
     if (this._logService.logLevel === LogLevelEnum.TRACE) {


### PR DESCRIPTION
We previously did: https://github.com/xtermjs/xterm.js/pull/5420 to log character codes for `sending data` only on trace.
Should we do the same for `parsing data`? 
Otherwise, the debug level for terminal output still is filled with bunch of character codes. 