### PR TITLE
Prevent entire page from scrolling when scrolling in alt buffer with mouse event off   

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -831,7 +831,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
           self._coreBrowserService?.dpr
         );
         if (lines === 0) {
-          return false;
+          return this.cancel(ev, true);
         }
 
         // Construct and send sequences


### PR DESCRIPTION
Resolves: https://github.com/xtermjs/xterm.js/issues/5419

Was able to repro on mac!
Bug (Note how page scrolls bit when scrolling in terminal):

https://github.com/user-attachments/assets/0c2ad38a-68b8-460d-955a-1b3b8f8a6391

After PR: 

https://github.com/user-attachments/assets/81d1ff89-9731-4b80-b05d-c2a407e16e06

