### PR TITLE
Configure "exports" field in package.json [headless]

### DIFF
--- a/headless/package.json
+++ b/headless/package.json
@@ -5,6 +5,11 @@
  "main": "lib-headless/xterm-headless.js",
  "module": "lib-headless/xterm-headless.mjs",
  "types": "typings/xterm-headless.d.ts",
+ "exports": {
+  "types": "./typings/xterm-headless.d.ts",
+  "import": "./lib-headless/xterm-headless.mjs",
+  "require": "./lib-headless/xterm-headless.js"
+ },
  "repository": "https://github.com/xtermjs/xterm.js",
  "license": "MIT",
  "keywords": [


### PR DESCRIPTION
This PR fixes 
- https://github.com/xtermjs/xterm.js/issues/5441
- https://github.com/xtermjs/xterm.js/issues/5448 

Added de-facto standard `"exports"` field in `package.json`  to fix ESM module resolution in node environments.