### PR TITLE
Fix wrong export path for ESM target in [addon-unicode-graphemes]

### DIFF
--- a/addons/addon-unicode-graphemes/package.json
+++ b/addons/addon-unicode-graphemes/package.json
@@ -6,7 +6,7 @@
     "url": "https://xtermjs.org/"
   },
   "main": "lib/addon-unicode-graphemes.js",
-  "module": "lib/.addon-unicode-graphemes.mjs",
+  "module": "lib/addon-unicode-graphemes.mjs",
   "types": "typings/addon-unicode-graphemes.d.ts",
   "repository": "https://github.com/xtermjs/xterm.js/tree/master/addons/addon-unicode-graphemes",
   "license": "MIT",


### PR DESCRIPTION
 Fix `@xterm/addon-unicode-graphemes` wrong export path for ESM target:
 
 https://github.com/xtermjs/xterm.js/blob/46c510a76d76d246ad015130a7f2d52e1f4629e1/addons/addon-unicode-graphemes/package.json#L9
