### PR TITLE
Fix incorrect ITheme reference in comments

### DIFF
--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -367,17 +367,17 @@ declare module '@xterm/xterm' {
     selectionInactiveBackground?: string;
     /**
      * The scrollbar slider background color. Defaults to
-     * {@link ITerminalOptions.foreground foreground} with 20% opacity.
+     * {@link ITheme.foreground} with 20% opacity.
      */
     scrollbarSliderBackground?: string;
     /**
      * The scrollbar slider background color when hovered. Defaults to
-     * {@link ITerminalOptions.foreground foreground} with 40% opacity.
+     * {@link ITheme.foreground} with 40% opacity.
      */
     scrollbarSliderHoverBackground?: string;
     /**
      * The scrollbar slider background color when clicked. Defaults to
-     * {@link ITerminalOptions.foreground foreground} with 50% opacity.
+     * {@link ITheme.foreground} with 50% opacity.
      */
     scrollbarSliderActiveBackground?: string;
     /**


### PR DESCRIPTION
The scrollbar background comments incorrectly referenced `ITerminalOptions.foreground`. These defaults are derived from
`ITheme.foreground`, not `ITerminalOptions`.