### PR TITLE
Remove line ending editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,6 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
-end_of_line = lf
 
 [*.{j,t}s]
 max_line_length = 100


### PR DESCRIPTION
This is normalized by git and ends up causing git status to show files that don't actually need to be committed after line ending normalization.