### PR TITLE
Remove eol-last eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,7 +81,6 @@ export default tseslint.config(
       '@typescript-eslint/no-duplicate-enum-values': 'off',
 
       'curly': ['warn', 'multi-line'],
-      'eol-last': 'warn',
       'eqeqeq': ['warn', 'always'],
       'jsdoc/check-alignment': 'warn',
       'jsdoc/check-param-names': 'warn',


### PR DESCRIPTION
This one's just troublesome when working with generated code. It doesn't make a difference in the end anyway.