### PR TITLE
Fix infinite recursion OOM crash in addon-ligatures 

### DIFF
--- a/addons/addon-ligatures/src/fontLigatures/flatten.ts
+++ b/addons/addon-ligatures/src/fontLigatures/flatten.ts
@@ -1,13 +1,13 @@
 import { ILookupTree, IFlattenedLookupTree, ILookupTreeEntry, IFlattenedLookupTreeEntry } from './types';
 
-export default function flatten(tree: ILookupTree): IFlattenedLookupTree {
+export default function flatten(tree: ILookupTree, visited: Map<ILookupTreeEntry, IFlattenedLookupTreeEntry> = new Map()): IFlattenedLookupTree {
   const result: IFlattenedLookupTree = {};
   for (const [glyphId, entry] of Object.entries(tree.individual)) {
-    result[glyphId] = flattenEntry(entry);
+    result[glyphId] = flattenEntry(entry, visited);
   }
 
   for (const { range, entry } of tree.range) {
-    const flattened = flattenEntry(entry);
+    const flattened = flattenEntry(entry, visited);
     for (let glyphId = range[0]; glyphId < range[1]; glyphId++) {
       result[glyphId] = flattened;
     }
@@ -16,15 +16,20 @@ export default function flatten(tree: ILookupTree): IFlattenedLookupTree {
   return result;
 }
 
-function flattenEntry(entry: ILookupTreeEntry): IFlattenedLookupTreeEntry {
+function flattenEntry(entry: ILookupTreeEntry, visited: Map<ILookupTreeEntry, IFlattenedLookupTreeEntry>): IFlattenedLookupTreeEntry {
+  if (visited.has(entry)) {
+    return visited.get(entry)!;
+  }
+
   const result: IFlattenedLookupTreeEntry = {};
+  visited.set(entry, result);
 
   if (entry.forward) {
-    result.forward = flatten(entry.forward);
+    result.forward = flatten(entry.forward, visited);
   }
 
   if (entry.reverse) {
-    result.reverse = flatten(entry.reverse);
+    result.reverse = flatten(entry.reverse, visited);
   }
 
   if (entry.lookup) {

--- a/addons/addon-ligatures/src/fontLigatures/processors/helper.ts
+++ b/addons/addon-ligatures/src/fontLigatures/processors/helper.ts
@@ -43,29 +43,41 @@ export function processLookaheadPosition(
   currentEntries: IEntryMeta[]
 ): IEntryMeta[] {
   const nextEntries: IEntryMeta[] = [];
-  for (const currentEntry of currentEntries) {
-    for (const glyph of glyphs) {
-      const entry: ILookupTreeEntry = {};
-      if (!currentEntry.entry.forward) {
-        currentEntry.entry.forward = {
-          individual: {},
-          range: []
-        };
-      }
-      nextEntries.push({
-        entry,
-        substitutions: currentEntry.substitutions
-      });
+  const processedEntries = new Set<ILookupTreeEntry>();
 
+  for (const currentEntry of currentEntries) {
+    // Skip if we've already processed this entry object
+    if (processedEntries.has(currentEntry.entry)) {
+      continue;
+    }
+    processedEntries.add(currentEntry.entry);
+
+    if (!currentEntry.entry.forward) {
+      currentEntry.entry.forward = {
+        individual: {},
+        range: []
+      };
+    }
+
+    // All glyphs at this position share ONE entry - lookahead just needs to match,
+    // all paths lead to the same result
+    const sharedEntry: ILookupTreeEntry = {};
+
+    for (const glyph of glyphs) {
       if (Array.isArray(glyph)) {
         currentEntry.entry.forward.range.push({
-          entry,
+          entry: sharedEntry,
           range: glyph
         });
       } else {
-        currentEntry.entry.forward.individual[glyph] = entry;
+        currentEntry.entry.forward.individual[glyph] = sharedEntry;
       }
     }
+
+    nextEntries.push({
+      entry: sharedEntry,
+      substitutions: currentEntry.substitutions
+    });
   }
 
   return nextEntries;
@@ -76,29 +88,41 @@ export function processBacktrackPosition(
   currentEntries: IEntryMeta[]
 ): IEntryMeta[] {
   const nextEntries: IEntryMeta[] = [];
-  for (const currentEntry of currentEntries) {
-    for (const glyph of glyphs) {
-      const entry: ILookupTreeEntry = {};
-      if (!currentEntry.entry.reverse) {
-        currentEntry.entry.reverse = {
-          individual: {},
-          range: []
-        };
-      }
-      nextEntries.push({
-        entry,
-        substitutions: currentEntry.substitutions
-      });
+  const processedEntries = new Set<ILookupTreeEntry>();
 
+  for (const currentEntry of currentEntries) {
+    // Skip if we've already processed this entry object
+    if (processedEntries.has(currentEntry.entry)) {
+      continue;
+    }
+    processedEntries.add(currentEntry.entry);
+
+    if (!currentEntry.entry.reverse) {
+      currentEntry.entry.reverse = {
+        individual: {},
+        range: []
+      };
+    }
+
+    // All glyphs at this position share ONE entry - backtrack just needs to match,
+    // all paths lead to the same result
+    const sharedEntry: ILookupTreeEntry = {};
+
+    for (const glyph of glyphs) {
       if (Array.isArray(glyph)) {
         currentEntry.entry.reverse.range.push({
-          entry,
+          entry: sharedEntry,
           range: glyph
         });
       } else {
-        currentEntry.entry.reverse.individual[glyph] = entry;
+        currentEntry.entry.reverse.individual[glyph] = sharedEntry;
       }
     }
+
+    nextEntries.push({
+      entry: sharedEntry,
+      substitutions: currentEntry.substitutions
+    });
   }
 
   return nextEntries;


### PR DESCRIPTION
1. processLookahead/BacktrackPosition created separate entry objects
   for each glyph at each position (O(N^M) with N glyphs, M positions).
   Now all glyphs at a position share one entry object.
2. cloneEntry, cloneTree, flattenEntry, and mergeTreeEntry could
   infinitely recurse or duplicate work on shared/cyclic references.
   Added visited/merged tracking maps to cache results.

Note that parsing CommitMono locks up the renderer for some time still
so there is still a performance issue here, this fixes the OOM though.
This was mostly defensive generated code since the codebase is
unfamiliar to me.

Fixes https://github.com/xtermjs/xterm.js/issues/5570

Timeline of the perf problem:

<img width="1039" height="633" alt="image" src="https://github.com/user-attachments/assets/cb291d3c-0323-477a-b9cd-cbf2ced470dd" />
