### PR TITLE
Flush writes on resize

### DIFF
--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -176,6 +176,10 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
     x = Math.max(x, MINIMUM_COLS);
     y = Math.max(y, MINIMUM_ROWS);
 
+    // Flush pending writes before resize to avoid race conditions where async
+    // writes are processed with incorrect dimensions
+    this._writeBuffer.flushSync();
+
     this._bufferService.resize(x, y);
   }
 

--- a/src/common/input/WriteBuffer.test.ts
+++ b/src/common/input/WriteBuffer.test.ts
@@ -106,5 +106,24 @@ describe('WriteBuffer', () => {
       wb.writeSync('1', 10);
       assert.equal(last, '11'); // 1 + 10 sub calls = 11
     });
+    it('flushSync processes all pending writes', done => {
+      wb.write('a', () => { cbStack.push('a'); });
+      wb.write('b', () => { cbStack.push('b'); });
+      wb.write('c', () => { cbStack.push('c'); });
+      wb.flushSync();
+      assert.deepEqual(stack, ['a', 'b', 'c']);
+      assert.deepEqual(cbStack, ['a', 'b', 'c']);
+      wb.write('x', () => { cbStack.push('x'); });
+      wb.write('', () => {
+        assert.deepEqual(stack, ['a', 'b', 'c', 'x', '']);
+        assert.deepEqual(cbStack, ['a', 'b', 'c', 'x']);
+        done();
+      });
+    });
+    it('flushSync with no pending writes is a no-op', () => {
+      wb.flushSync();
+      assert.deepEqual(stack, []);
+      assert.deepEqual(cbStack, []);
+    });
   });
 });


### PR DESCRIPTION
Fixes #5597

I expect this to reduce the number of errors thrown in our error telemetry. Seems like a safe change and good improvement.