### PR TITLE
Update node-pty to ^1.2.0-beta.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "jsdom": "^27.3.0",
         "mocha": "^10.1.0",
         "mustache": "^4.2.0",
-        "node-pty": "1.1.0-beta19",
+        "node-pty": "^1.2.0-beta.9",
         "nyc": "^17.1.0",
         "source-map-loader": "^3.0.0",
         "source-map-support": "^0.5.20",
@@ -6016,11 +6016,12 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta19",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta19.tgz",
-      "integrity": "sha512-/p4Zu56EYDdXjjaLWzrIlFyrBnND11LQGP0/L6GEVGURfCNkAlHc3Twg/2I4NPxghimHXgvDlwp7Z2GtvDIh8A==",
+      "version": "1.2.0-beta.9",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.9.tgz",
+      "integrity": "sha512-XR3x/4OQZ7DlceespOQ99kk9jZHwmO78RuEIZtGsSPdsDi11s79VcK04aqcaK3x09Y6ORJM/KBz/oQ/p+WGRLg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "jsdom": "^27.3.0",
     "mocha": "^10.1.0",
     "mustache": "^4.2.0",
-    "node-pty": "1.1.0-beta19",
+    "node-pty": "^1.2.0-beta.9",
     "nyc": "^17.1.0",
     "source-map-loader": "^3.0.0",
     "source-map-support": "^0.5.20",


### PR DESCRIPTION
This is so we get: https://github.com/microsoft/node-pty/pull/881
Need before: https://github.com/xtermjs/xterm.js/pull/5619