### PR TITLE
Dont useDefineForClassField after tsgo migration

### DIFF
--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -9,6 +9,7 @@
     "pretty": true,
 
     "incremental": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false
   }
 }


### PR DESCRIPTION
Wanted to resolve errors like: https://github.com/microsoft/vscode/actions/runs/22105196713/job/63885776359?pr=295701 