### PR TITLE
feat: sanitize user text when in bracketed paste mode

### DIFF
--- a/src/browser/Clipboard.test.ts
+++ b/src/browser/Clipboard.test.ts
@@ -29,4 +29,14 @@ describe('evaluatePastedTextProcessing', () => {
     assert.equal(unbracketedText, 'foo bar');
     assert.equal(bracketedText, '\x1b[200~foo bar\x1b[201~');
   });
+
+  it('should escape embedded escape sequences in pasted text only when bracketed', () => {
+    const ESC_SYMBOL = '\u241b';
+    const pastedText = '\x1b[201~foo\x1b[200~bar';
+    const unbracketedText = Clipboard.bracketTextForPaste(pastedText, false);
+    const bracketedText = Clipboard.bracketTextForPaste(pastedText, true);
+
+    assert.equal(unbracketedText, pastedText, 'non bracketed paste should remain unchanged');
+    assert.equal(bracketedText, `\x1b[200~${ESC_SYMBOL}[201~foo${ESC_SYMBOL}[200~bar\x1b[201~`);
+  });
 });

--- a/src/browser/Clipboard.ts
+++ b/src/browser/Clipboard.ts
@@ -19,10 +19,13 @@ export function prepareTextForTerminal(text: string): string {
  * @param text The pasted text to bracket
  */
 export function bracketTextForPaste(text: string, bracketedPasteMode: boolean): string {
-  if (bracketedPasteMode) {
-    return '\x1b[200~' + text + '\x1b[201~';
+  if (!bracketedPasteMode) {
+    return text;
   }
-  return text;
+  // Sanitize pasted text to prevent injected escape sequences (e.g. exiting bracketed paste)
+  // by replacing ESC (\x1b) with its visible representation U+241B (␛).
+  const sanitizedText = text.replace(/\x1b/g, '\u241b');
+  return `\x1b[200~${sanitizedText}\x1b[201~`;
 }
 
 /**


### PR DESCRIPTION
If the user is pasting untrusted text, it can hijack out of bracketed paste mode and execute unauthorized commands.

This PR sanitizes user text to escape `\x1b` as discussed internally.