### PR TITLE
feat: support voice IMEs that update input via tail replacement

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -59,6 +59,13 @@ import { Emitter, EventUtils, type IEvent } from 'common/Event';
 import { addDisposableListener } from 'browser/Dom';
 import { MutableDisposable, toDisposable } from 'common/Lifecycle';
 
+interface ITailReplacementPairingState {
+  oldValue: string;
+  start: number;
+  end: number;
+  data: string;
+}
+
 export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   public textarea: HTMLTextAreaElement | undefined;
   public element: HTMLElement | undefined;
@@ -120,6 +127,18 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
    */
   private _unprocessedDeadKey: boolean = false;
 
+  /**
+   * Snapshot used to pair `beforeinput` with the next `input` for tail replacement.
+   *
+   * Some voice IMEs (for example on iOS) update text by selecting the current tail candidate
+   * and replacing that selection with a longer committed phrase via `insertText`.
+   * Typical sequence:
+   * - `beforeinput`: selection is `[0, tailLength]`, `data` is the full new phrase
+   * - `input`: value becomes the new phrase and caret moves to the end
+   *
+   * For terminal semantics we need to emit DELs for the replaced tail, then emit the new text.
+   */
+  private _tailReplacementPairingState: ITailReplacementPairingState | undefined;
   private _compositionHelper: ICompositionHelper | undefined;
   private _accessibilityManager: MutableDisposable<AccessibilityManager> = this._register(new MutableDisposable());
 
@@ -416,6 +435,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     this._register(addDisposableListener(this.textarea!, 'compositionstart', () => this._compositionHelper!.compositionstart()));
     this._register(addDisposableListener(this.textarea!, 'compositionupdate', (e: CompositionEvent) => this._compositionHelper!.compositionupdate(e)));
     this._register(addDisposableListener(this.textarea!, 'compositionend', () => this._compositionHelper!.compositionend()));
+    this._register(addDisposableListener(this.textarea!, 'beforeinput', (ev: InputEvent) => this._beforeInputEvent(ev), true));
     this._register(addDisposableListener(this.textarea!, 'input', (ev: InputEvent) => this._inputEvent(ev), true));
     this._register(this.onRender(() => this._compositionHelper!.updateCompositionElements()));
   }
@@ -1270,12 +1290,85 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   }
 
   /**
+   * Handle a beforeinput event.
+   * Key Resources:
+   *   - https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event
+   * @param ev The beforeinput event to be handled.
+   */
+  protected _beforeInputEvent(ev: InputEvent): void {
+    // Keep only the latest candidate; the next input event consumes and clears it.
+    this._tailReplacementPairingState = undefined;
+
+    const textarea = this.textarea;
+    if (!textarea || ev.inputType !== 'insertText' || !ev.composed || ev.isComposing || typeof ev.data !== 'string') {
+      return;
+    }
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const oldValue = textarea.value;
+    // Pairing only supports replacing a non-empty selection at the tail of the textarea value.
+    if (start === null || end === null || end - start <= 0 || end !== oldValue.length) {
+      return;
+    }
+
+    this._tailReplacementPairingState = {
+      oldValue,
+      start,
+      end,
+      data: ev.data
+    };
+  }
+
+  private _handleTailReplacementPairingState(ev: InputEvent): boolean {
+    // Skip pairing when keypress already emitted input, otherwise this path can emit extra DEL/data.
+    if (this.optionsService.rawOptions.screenReaderMode || this._keyPressHandled) {
+      this._tailReplacementPairingState = undefined;
+      return false;
+    }
+
+    // Pair input with the most recent valid beforeinput snapshot.
+    const pairingState = this._tailReplacementPairingState;
+    this._tailReplacementPairingState = undefined;
+    if (!pairingState) {
+      return false;
+    }
+    if (!this.textarea || ev.inputType !== 'insertText' || !ev.composed || ev.isComposing || ev.data !== pairingState.data) {
+      return false;
+    }
+
+    const newValue = this.textarea.value;
+    if (newValue !== `${pairingState.oldValue.slice(0, pairingState.start)}${pairingState.data}`) {
+      return false;
+    }
+
+    // For tail replacement, emit deletes for the replaced suffix then insert new text.
+    const deleteCount = this._countDeleteCharacters(pairingState.oldValue.slice(pairingState.start, pairingState.end));
+    const payload = `${C0.DEL.repeat(deleteCount)}${pairingState.data}`;
+    this.coreService.triggerDataEvent(payload, true);
+
+    ev.preventDefault();
+    ev.stopPropagation();
+    return true;
+  }
+
+  private _countDeleteCharacters(text: string): number {
+    // `Array.from` iterates UTF-16 strings by Unicode code point.
+    return Array.from(text).length;
+  }
+
+  /**
    * Handle an input event.
    * Key Resources:
    *   - https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
    * @param ev The input event to be handled.
    */
   protected _inputEvent(ev: InputEvent): boolean {
+    // Prefer beforeinput/input pairing when possible; otherwise fall back to legacy behavior.
+    if (this._handleTailReplacementPairingState(ev)) {
+      return true;
+    }
+
     // Only support emoji IMEs when screen reader mode is disabled as the event must bubble up to
     // support reading out character input which can doubling up input characters
     // Based on these event traces: https://github.com/xtermjs/xterm.js/issues/3679

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -8,6 +8,7 @@ import type { IBrowser } from 'browser/Types';
 import { assert } from 'chai';
 import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
 import { CellData } from 'common/buffer/CellData';
+import { C0 } from 'common/data/EscapeSequences';
 import { MockUnicodeService } from 'common/TestUtils.test';
 import { IMarker } from 'common/Types';
 
@@ -172,6 +173,179 @@ describe('Terminal', () => {
       term.reset();
       assert.equal(term.keyDown(evKeyDown), false);
       assert.equal(term.keyPress(evKeyPress), false);
+    });
+  });
+
+  describe('input event pairing', () => {
+    function createInputEvent(overrides: Partial<InputEvent> = {}): InputEvent {
+      return {
+        preventDefault: () => { },
+        stopPropagation: () => { },
+        inputType: 'insertText',
+        data: '',
+        composed: true,
+        isComposing: false,
+        ...overrides
+      } as InputEvent;
+    }
+
+    beforeEach(() => {
+      (term as any).textarea = {
+        value: '',
+        selectionStart: 0,
+        selectionEnd: 0
+      };
+    });
+
+    it('should send delete and insert when tail replacement matches', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = '你好';
+      (term as any).textarea.selectionStart = 0;
+      (term as any).textarea.selectionEnd = 2;
+      term.beforeInput(createInputEvent({ data: '你好世界' }));
+
+      (term as any).textarea.value = '你好世界';
+      const handled = term.input(createInputEvent({ data: '你好世界' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, [`${C0.DEL.repeat(2)}你好世界`]);
+    });
+
+    it('should not emit DEL/data from pairing when keypress already handled input', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+
+      const evKeyPress = {
+        preventDefault: () => { },
+        stopPropagation: () => { },
+        type: 'keypress',
+        charCode: 97,
+        keyCode: 65
+      } as KeyboardEvent;
+      assert.equal(term.keyPress(evKeyPress), true);
+
+      (term as any).textarea.value = 'selected';
+      (term as any).textarea.selectionStart = 0;
+      (term as any).textarea.selectionEnd = 8;
+      term.beforeInput(createInputEvent({ data: 'a' }));
+
+      (term as any).textarea.value = 'a';
+      const handled = term.input(createInputEvent({ data: 'a' }));
+
+      assert.equal(handled, false);
+      assert.deepEqual(calls, ['a']);
+    });
+
+    it('should count surrogate pairs as a single delete', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = 'A😀';
+      (term as any).textarea.selectionStart = 1;
+      (term as any).textarea.selectionEnd = 3;
+      term.beforeInput(createInputEvent({ data: 'B' }));
+
+      (term as any).textarea.value = 'AB';
+      const handled = term.input(createInputEvent({ data: 'B' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, [`${C0.DEL}B`]);
+    });
+
+    it('should count a ZWJ emoji sequence by code point', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      const familyEmoji = '👨‍👩‍👧‍👦';
+      (term as any).textarea.value = `A${familyEmoji}`;
+      (term as any).textarea.selectionStart = 1;
+      (term as any).textarea.selectionEnd = (term as any).textarea.value.length;
+      term.beforeInput(createInputEvent({ data: 'B' }));
+
+      (term as any).textarea.value = 'AB';
+      const handled = term.input(createInputEvent({ data: 'B' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, [`${C0.DEL.repeat(7)}B`]);
+    });
+
+    it('should only send inserted text when selection is empty at the end', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = '你好';
+      (term as any).textarea.selectionStart = 2;
+      (term as any).textarea.selectionEnd = 2;
+      term.beforeInput(createInputEvent({ data: '世界' }));
+
+      (term as any).textarea.value = '你好世界';
+      const handled = term.input(createInputEvent({ data: '世界' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, ['世界']);
+    });
+
+    it('should fallback to legacy input logic when beforeinput is not tail replacement', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = 'abc';
+      (term as any).textarea.selectionStart = 1;
+      (term as any).textarea.selectionEnd = 2;
+      term.beforeInput(createInputEvent({ data: 'z' }));
+
+      (term as any).textarea.value = 'azc';
+      const handled = term.input(createInputEvent({ data: 'z' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, ['z']);
+    });
+
+    it('should fallback to legacy input logic when structure check fails', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = '你好';
+      (term as any).textarea.selectionStart = 0;
+      (term as any).textarea.selectionEnd = 2;
+      term.beforeInput(createInputEvent({ data: '你好世界' }));
+
+      (term as any).textarea.value = '错误';
+      const handled = term.input(createInputEvent({ data: '你好世界' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, ['你好世界']);
+    });
+
+    it('should require composed=true and isComposing=false for the new path', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = '你';
+      (term as any).textarea.selectionStart = 0;
+      (term as any).textarea.selectionEnd = 1;
+      term.beforeInput(createInputEvent({ data: '你好', composed: false }));
+
+      (term as any).textarea.value = '你好';
+      const handled = term.input(createInputEvent({ data: '你好', isComposing: true }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, ['你好']);
+    });
+
+    it('should use latest beforeinput snapshot only', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      (term as any).textarea.value = '你';
+      (term as any).textarea.selectionStart = 0;
+      (term as any).textarea.selectionEnd = 1;
+      term.beforeInput(createInputEvent({ data: '你好' }));
+
+      (term as any).textarea.value = '你好';
+      (term as any).textarea.selectionStart = 0;
+      (term as any).textarea.selectionEnd = 2;
+      term.beforeInput(createInputEvent({ data: '你好世界' }));
+
+      (term as any).textarea.value = '你好世界';
+      const handled = term.input(createInputEvent({ data: '你好世界' }));
+
+      assert.equal(handled, true);
+      assert.deepEqual(calls, [`${C0.DEL.repeat(2)}你好世界`]);
     });
   });
 

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -24,6 +24,8 @@ export class TestTerminal extends CoreBrowserTerminal {
   public get curAttrData(): IAttributeData { return (this as any)._inputHandler._curAttrData; }
   public keyDown(ev: any): boolean | undefined { return this._keyDown(ev); }
   public keyPress(ev: any): boolean { return this._keyPress(ev); }
+  public beforeInput(ev: any): void { this._beforeInputEvent(ev); }
+  public input(ev: any): boolean { return this._inputEvent(ev); }
   public writeP(data: string | Uint8Array): Promise<void> {
     return new Promise(r => this.write(data, r));
   }


### PR DESCRIPTION
## Summary

This PR improves handling of voice IMEs that update text via tail replacement (`beforeinput` + `input` with `insertText`).

When the IME replaces a selected suffix candidate with a longer committed phrase, the terminal now emits:
1. `DEL` for the replaced suffix length (counted by Unicode code point)
2. the new committed text

If pairing conditions do not match, behavior falls back to the legacy input path.

## Why

Some voice IME flows (observed on mobile browsers) do not append text incrementally. Instead, they repeatedly select and replace the current tail candidate. Without pairing this sequence, terminal input can miss required deletes.

## Evidence (event trace)

The key signal is the selection range seen in `beforeinput`:
- Tail replacement pattern: non-empty tail selection like `sel=[0,N]`, followed by `input` with a longer committed text.
- Normal append pattern: empty selection at end like `sel=[N,N]`.

Observed trace excerpts:

```text
#23 beforeinput len=3 sel=[0,3,none] value="你好世" inputType="insertText" data="你好世界" isComposing=false composed=true
#24 input       len=4 sel=[4,4,none] value="你好世界" inputType="insertText" data="你好世界" isComposing=false composed=true

#27 beforeinput len=4 sel=[0,4,none] value="你好世界" inputType="insertText" data="你好" isComposing=false composed=true
#28 input       len=2 sel=[2,2,none] value="你好" inputType="insertText" data="你好" isComposing=false composed=true

#29 beforeinput len=2 sel=[2,2,none] value="你好" inputType="insertText" data="世界" isComposing=false composed=true
#30 input       len=4 sel=[4,4,none] value="你好世界" inputType="insertText" data="世界" isComposing=false composed=true
```

## Implementation

- Add `beforeinput` snapshot state for candidate pairing.
- Handle validated tail replacement before legacy `_inputEvent` logic.
- Emit `DEL.repeat(deleteCount) + insertedText` for matched replacement.
- Keep guards for:
  - `screenReaderMode`
  - `_keyPressHandled`
  - composing/non-composed mismatches
  - structural mismatch (fallback path)

## Tests

Added/updated tests for:
- matching tail replacement emits `DEL + insert`
- no duplicate emit when keypress already handled input
- surrogate pair delete count
- ZWJ emoji sequence delete count by code point
- empty tail selection falls back to insert only
- structural mismatch fallback to legacy path
- composed/isComposing guard behavior
- latest `beforeinput` snapshot wins

## Risk and compatibility

- No public API changes.
- Changes are scoped to browser input event handling.
- Fallback path preserves previous behavior when pairing cannot be validated.
