### PR TITLE
Fix ^C not working to end for newer fish + kitty keyboard protocol

### DIFF
--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -3570,7 +3570,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       return true;
     }
     const flags = params.params[0] || 0;
-    const mode = params.params[1] || 1;
+    const mode = params.length > 1 ? (params.params[1] || 1) : 1;
     const state = this._coreService.kittyKeyboard;
 
     switch (mode) {


### PR DESCRIPTION
Should resolve: https://github.com/microsoft/vscode/issues/295372 
We shouldn't read beyond params.length - 1:
https://github.com/xtermjs/xterm.js/blob/a12061c899066bb49a535ac7afa46909e503e113/src/common/parser/Params.ts#L19

Reset only sets this.length = 0, it does not zero out underlying array.

So when fish sends CSI = 0 u (one param), params.length is 1, but params.params[1] reads whatever int was left in slot 1 from previous CSI sequence. 
SO if that leftover vlaue happens to be 2 or 3, `mode` becomes 2,3 instead of spec-mandated default 1: 

> If the modifier field is not present in the escape code, its default value is 1 which means no modifiers.  in https://sw.kovidgoyal.net/kitty/keyboard-protocol/#modifiers