### PR TITLE
work around Safari sending keycode 13 (enter) when typing ctrl-c (take 2)

### DIFF
--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -99,8 +99,9 @@ export function evaluateKeyboardEvent(
       break;
     case 13:
       // return/enter
-      if (ev.key == 'c' && ev.ctrlKey) {
-        // Safari on iPad, iOS, AppleVisionPro sends key 13 when typing ctrl-c on hardware keyboard
+      if (ev.key === 'c' && ev.ctrlKey) {
+        // HACK: Safari on iPad, iOS, AppleVisionPro sends key 13 when typing ctrl-c on hardware
+        // keyboard
         result.key = C0.ETX;
       } else {
         result.key = ev.altKey ? C0.ESC + C0.CR : C0.CR;


### PR DESCRIPTION
Fixes https://github.com/xtermjs/xterm.js/issues/5721

See https://github.com/xtermjs/xterm.js/pull/5720, couldn't amend PR as fork was locked.