### PR TITLE
Add fontSmoothing option to control text anti-aliasing

### DIFF
--- a/addons/addon-webgl/src/CharAtlasUtils.ts
+++ b/addons/addon-webgl/src/CharAtlasUtils.ts
@@ -43,6 +43,7 @@ export function generateConfig(deviceCellWidth: number, deviceCellHeight: number
     deviceCharHeight: deviceCharHeight,
     fontFamily: options.fontFamily,
     fontSize: options.fontSize,
+    fontSmoothing: options.fontSmoothing,
     fontWeight: options.fontWeight,
     fontWeightBold: options.fontWeightBold,
     allowTransparency: options.allowTransparency,
@@ -64,6 +65,7 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
       a.letterSpacing === b.letterSpacing &&
       a.fontFamily === b.fontFamily &&
       a.fontSize === b.fontSize &&
+      a.fontSmoothing === b.fontSmoothing &&
       a.fontWeight === b.fontWeight &&
       a.fontWeightBold === b.fontWeightBold &&
       a.allowTransparency === b.allowTransparency &&

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -101,6 +101,11 @@ export class TextureAtlas implements ITextureAtlas {
       alpha: this._config.allowTransparency,
       willReadFrequently: true
     }));
+
+    // Apply font smoothing to the canvas used for glyph rasterization
+    if (this._config.fontSmoothing !== 'auto') {
+      (this._tmpCanvas.style as any).webkitFontSmoothing = this._config.fontSmoothing;
+    }
   }
 
   public dispose(): void {

--- a/addons/addon-webgl/src/Types.ts
+++ b/addons/addon-webgl/src/Types.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { FontWeight } from '@xterm/xterm';
+import { FontSmoothing, FontWeight } from '@xterm/xterm';
 import { IColorSet } from 'browser/Types';
 import { ISelectionRenderModel } from 'browser/renderer/shared/Types';
 import { CursorInactiveStyle, CursorStyle, type IDisposable } from 'common/Types';
@@ -43,6 +43,7 @@ export interface ICharAtlasConfig {
   lineHeight: number;
   fontSize: number;
   fontFamily: string;
+  fontSmoothing: FontSmoothing;
   fontWeight: FontWeight;
   fontWeightBold: FontWeight;
   deviceCellWidth: number;

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -187,6 +187,7 @@ export class DomRenderer extends Disposable implements IRenderer {
       ` font-family: ${this._optionsService.rawOptions.fontFamily};` +
       ` font-size: ${this._optionsService.rawOptions.fontSize}px;` +
       ` font-kerning: none;` +
+      ` -webkit-font-smoothing: ${this._optionsService.rawOptions.fontSmoothing};` +
       ` white-space: pre` +
       `}`;
     styles +=

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -6,7 +6,7 @@
 import { Disposable, toDisposable } from 'common/Lifecycle';
 import { isMac } from 'common/Platform';
 import { CursorStyle, IDisposable } from 'common/Types';
-import { FontWeight, IOptionsService, ITerminalOptions } from 'common/services/Services';
+import { FontSmoothing, FontWeight, IOptionsService, ITerminalOptions } from 'common/services/Services';
 import { Emitter } from 'common/Event';
 
 export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
@@ -23,6 +23,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   fastScrollSensitivity: 5,
   fontFamily: 'monospace',
   fontSize: 15,
+  fontSmoothing: 'auto',
   fontWeight: 'normal',
   fontWeightBold: 'bold',
   ignoreBracketedPasteMode: false,
@@ -60,6 +61,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
 };
 
 const FONT_WEIGHT_OPTIONS: Extract<FontWeight, string>[] = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
+const FONT_SMOOTHING_OPTIONS: FontSmoothing[] = ['auto', 'none', 'antialiased', 'subpixel-antialiased'];
 
 export class OptionsService extends Disposable implements IOptionsService {
   public serviceBrand: any;
@@ -159,6 +161,11 @@ export class OptionsService extends Disposable implements IOptionsService {
       case 'wordSeparator':
         if (!value) {
           value = DEFAULT_OPTIONS[key];
+        }
+        break;
+      case 'fontSmoothing':
+        if (!FONT_SMOOTHING_OPTIONS.includes(value)) {
+          throw new Error(`"${value}" is not a valid value for ${key}`);
         }
         break;
       case 'fontWeight':

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -220,6 +220,7 @@ export interface IOptionsService {
 }
 
 export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | number;
+export type FontSmoothing = 'auto' | 'none' | 'antialiased' | 'subpixel-antialiased';
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'off';
 
 export interface ITerminalOptions {
@@ -239,6 +240,7 @@ export interface ITerminalOptions {
   fastScrollSensitivity?: number;
   fontSize?: number;
   fontFamily?: string;
+  fontSmoothing?: FontSmoothing;
   fontWeight?: FontWeight;
   fontWeightBold?: FontWeight;
   ignoreBracketedPasteMode?: boolean;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -16,6 +16,11 @@ declare module '@xterm/xterm' {
   export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | number;
 
   /**
+   * A string representing font smoothing mode.
+   */
+  export type FontSmoothing = 'auto' | 'none' | 'antialiased' | 'subpixel-antialiased';
+
+  /**
    * A string representing log level.
    */
   export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'off';
@@ -121,6 +126,18 @@ declare module '@xterm/xterm' {
      * The font family used to render text.
      */
     fontFamily?: string;
+
+    /**
+     * The font smoothing mode used to render text. This controls the
+     * `-webkit-font-smoothing` CSS property of the terminal.
+     *
+     * - `'auto'` - Use the browser's default font smoothing (default).
+     * - `'none'` - No font smoothing is applied.
+     * - `'antialiased'` - Smooth the font on the level of the pixel, as
+     *   opposed to the subpixel.
+     * - `'subpixel-antialiased'` - Use subpixel antialiasing.
+     */
+    fontSmoothing?: FontSmoothing;
 
     /**
      * The font weight used to render non-bold text.


### PR DESCRIPTION
## Summary

Adds a `fontSmoothing` terminal option that allows users to control the `-webkit-font-smoothing` CSS property for text rendering in xterm.js. This addresses text rendering quality issues, particularly on macOS with external displays.

Resolves #2464

## Changes

- Added `FontSmoothing` type: `'auto' | 'none' | 'antialiased' | 'subpixel-antialiased'`
- Added `fontSmoothing` property to `ITerminalOptions` (default: `'auto'`)
- **DOM renderer**: Applies `-webkit-font-smoothing` via CSS stylesheet injection
- **WebGL renderer**: Applies font smoothing to the canvas used for glyph rasterization in `TextureAtlas`
- Added input validation with descriptive error messages

## Usage

```ts
const terminal = new Terminal({
  fontSmoothing: 'antialiased' // 'auto' | 'none' | 'antialiased' | 'subpixel-antialiased'
});

// Or change at runtime
terminal.options.fontSmoothing = 'subpixel-antialiased';
```

## Files Changed

| File | Change |
|------|--------|
| `typings/xterm.d.ts` | Public API type + docs |
| `src/common/services/Services.ts` | Internal interface |
| `src/common/services/OptionsService.ts` | Default value + validation |
| `src/browser/renderer/dom/DomRenderer.ts` | DOM renderer CSS injection |
| `addons/addon-webgl/src/Types.ts` | WebGL config interface |
| `addons/addon-webgl/src/CharAtlasUtils.ts` | Atlas config generation |
| `addons/addon-webgl/src/TextureAtlas.ts` | Canvas font smoothing |
