### PR TITLE
  fix: prevent crash when dimensions getter is called before renderer is initialized

### DIFF
--- a/src/browser/services/RenderService.test.ts
+++ b/src/browser/services/RenderService.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import jsdom = require('jsdom');
+import { assert } from 'chai';
+import { RenderService } from 'browser/services/RenderService';
+import { IRenderDimensions, IRenderer, IRequestRedrawEvent } from 'browser/renderer/shared/Types';
+import { MockBufferService, MockOptionsService, MockCoreService, MockLogService, MockDecorationService } from 'common/TestUtils.test';
+import { MockCharSizeService, MockThemeService } from 'browser/TestUtils.test';
+import { ICoreBrowserService } from 'browser/services/Services';
+import { IEvent, Emitter } from 'common/Event';
+
+class TestCoreBrowserService implements ICoreBrowserService {
+  public serviceBrand: undefined;
+  public isFocused: boolean = true;
+  public dpr: number = 1;
+  public onDprChange: IEvent<number> = new Emitter<number>().event;
+  public onWindowChange: IEvent<Window & typeof globalThis> = new Emitter<Window & typeof globalThis>().event;
+
+  constructor(private _window: Window & typeof globalThis) {}
+
+  public get window(): Window & typeof globalThis {
+    return this._window;
+  }
+
+  public get mainDocument(): Document {
+    return this._window.document;
+  }
+}
+
+class MockRenderer implements IRenderer {
+  public readonly dimensions: IRenderDimensions;
+  private readonly _onRequestRedraw = new Emitter<IRequestRedrawEvent>();
+  public readonly onRequestRedraw: IEvent<IRequestRedrawEvent> = this._onRequestRedraw.event;
+  public readonly onContextLoss: IEvent<void> = new Emitter<void>().event;
+
+  constructor(cellWidth: number = 10, cellHeight: number = 20) {
+    this.dimensions = {
+      css: {
+        canvas: { width: cellWidth * 80, height: cellHeight * 24 },
+        cell: { width: cellWidth, height: cellHeight }
+      },
+      device: {
+        canvas: { width: cellWidth * 80 * 2, height: cellHeight * 24 * 2 },
+        cell: { width: cellWidth * 2, height: cellHeight * 2 },
+        char: { width: cellWidth * 2 - 1, height: cellHeight * 2 - 2, top: 0, left: 0 }
+      }
+    };
+  }
+
+  public dispose(): void {}
+  public handleDevicePixelRatioChange(): void {}
+  public handleResize(cols: number, rows: number): void {}
+  public handleCharSizeChanged(): void {}
+  public handleBlur(): void {}
+  public handleFocus(): void {}
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {}
+  public handleCursorMove(): void {}
+  public clear(): void {}
+  public renderRows(start: number, end: number): void {}
+  public clearTextureAtlas(): void {}
+}
+
+describe('RenderService', () => {
+  let dom: jsdom.JSDOM;
+  let screenElement: HTMLElement;
+  let renderService: RenderService;
+  let optionsService: MockOptionsService;
+  let bufferService: MockBufferService;
+
+  beforeEach(() => {
+    dom = new jsdom.JSDOM('');
+    (dom.window as any).requestAnimationFrame = (cb: FrameRequestCallback): number => dom.window.setTimeout(() => cb(0), 0);
+    (dom.window as any).cancelAnimationFrame = (id: number): void => dom.window.clearTimeout(id);
+    screenElement = dom.window.document.createElement('div');
+
+    optionsService = new MockOptionsService();
+    bufferService = new MockBufferService(80, 24, optionsService);
+
+    renderService = new RenderService(
+      24, // rowCount
+      screenElement,
+      optionsService,
+      new MockLogService(),
+      new MockCharSizeService(10, 20),
+      new MockCoreService(),
+      new MockDecorationService(),
+      bufferService,
+      new TestCoreBrowserService(dom.window as unknown as Window & typeof globalThis),
+      new MockThemeService()
+    );
+  });
+
+  afterEach(() => {
+    try {
+      renderService.dispose();
+    } catch (_e) {
+      // Already disposed
+    }
+  });
+
+  describe('dimensions', () => {
+    it('should return default dimensions when renderer is not set', () => {
+      assert.isFalse(renderService.hasRenderer());
+      const dimensions = renderService.dimensions;
+      assert.isDefined(dimensions);
+      assert.strictEqual(dimensions.css.canvas.width, 0);
+      assert.strictEqual(dimensions.css.canvas.height, 0);
+      assert.strictEqual(dimensions.css.cell.width, 0);
+      assert.strictEqual(dimensions.css.cell.height, 0);
+      assert.strictEqual(dimensions.device.canvas.width, 0);
+      assert.strictEqual(dimensions.device.canvas.height, 0);
+      assert.strictEqual(dimensions.device.cell.width, 0);
+      assert.strictEqual(dimensions.device.cell.height, 0);
+      assert.strictEqual(dimensions.device.char.width, 0);
+      assert.strictEqual(dimensions.device.char.height, 0);
+    });
+
+    it('should return renderer dimensions when renderer is set', () => {
+      const mockRenderer = new MockRenderer(10, 20);
+      renderService.setRenderer(mockRenderer);
+      assert.isTrue(renderService.hasRenderer());
+      const dimensions = renderService.dimensions;
+      assert.strictEqual(dimensions, mockRenderer.dimensions);
+      assert.strictEqual(dimensions.css.cell.width, 10);
+      assert.strictEqual(dimensions.css.cell.height, 20);
+    });
+
+    it('should return default dimensions after service is disposed', () => {
+      const mockRenderer = new MockRenderer(10, 20);
+      renderService.setRenderer(mockRenderer);
+      assert.strictEqual(renderService.dimensions.css.cell.width, 10);
+      renderService.dispose();
+      const dimensions = renderService.dimensions;
+      assert.isDefined(dimensions);
+      assert.strictEqual(dimensions.css.cell.width, 0);
+      assert.strictEqual(dimensions.css.cell.height, 0);
+    });
+  });
+});
+

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -52,7 +52,11 @@ export class RenderService extends Disposable implements IRenderService {
   private readonly _onRefreshRequest = this._register(new Emitter<{ start: number, end: number }>());
   public readonly onRefreshRequest = this._onRefreshRequest.event;
 
-  public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }
+  private static readonly _defaultDimensions: IRenderDimensions = {
+    css: { canvas: { width: 0, height: 0 }, cell: { width: 0, height: 0 } },
+    device: { canvas: { width: 0, height: 0 }, cell: { width: 0, height: 0 }, char: { width: 0, height: 0, top: 0, left: 0 } }
+  };
+  public get dimensions(): IRenderDimensions { return this._renderer.value?.dimensions ?? RenderService._defaultDimensions; }
 
   constructor(
     private _rowCount: number,


### PR DESCRIPTION
## Problem
  The `dimensions` getter in `RenderService` crashes when `_renderer.value` is undefined:

  public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }

  ### Impact on VSCode
  This bug breaks the VSCode integrated terminal on macOS 26 (Tahoe). When users run interactive CLI tools that
  use raw mode (Inquirer.js prompts, Claude Code, `npx create-next-app`, etc.), the terminal becomes
  unresponsive:

  - **Enter key stops working**
  - **Backspace key stops working**
  - **Control keys stop working**
  The only workaround is to close and reopen the terminal.

  **VSCode issue:** microsoft/vscode#300192
  ### Root Cause
  A race condition occurs where `dimensions` is accessed before the renderer is initialized or after it's
  disposed. The non-null assertion (`!`) causes an uncaught exception that breaks terminal input handling.

  ## Solution
  Added a static fallback object and replaced the non-null assertion with optional chaining:

  private static readonly _defaultDimensions: IRenderDimensions = {
    css: { canvas: { width: 0, height: 0 }, cell: { width: 0, height: 0 } },
    device: { canvas: { width: 0, height: 0 }, cell: { width: 0, height: 0 }, char: { width: 0, height: 0, top: 0,
   left: 0 } }
  };
  public get dimensions(): IRenderDimensions { return this._renderer.value?.dimensions ??
  RenderService._defaultDimensions; }

  ## Testing
  - [x] Added unit tests for the `dimensions` getter (3 test cases)
  - [x] All existing tests pass (2236 tests)
  - [x] Lint passes
  - [x] Manually verified fix in VSCode (Code-OSS) integrated terminal
