### PR TITLE
Fix IME composition text overflowing terminal

### DIFF
--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -239,6 +239,12 @@ export class CompositionHelper {
       this._compositionView.style.lineHeight = cellHeight + 'px';
       this._compositionView.style.fontFamily = this._optionsService.rawOptions.fontFamily;
       this._compositionView.style.fontSize = this._optionsService.rawOptions.fontSize + 'px';
+      // Limit the composition view width to the space between the cursor and
+      // the terminal's right edge, preventing it from overflowing the terminal.
+      const maxWidth = this._bufferService.cols * this._renderService.dimensions.css.cell.width - cursorLeft;
+      this._compositionView.style.maxWidth = maxWidth + 'px';
+      this._compositionView.style.overflow = 'hidden';
+      this._compositionView.style.direction = 'rtl';
       // Sync the textarea to the exact position of the composition view so the IME knows where the
       // text is.
       const compositionViewBounds = this._compositionView.getBoundingClientRect();


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/300251
See the bug in the referenced issue above.


After this PR (symlinked local xterm to oss): 
https://github.com/user-attachments/assets/2b57ce17-967c-45ae-ba36-0fa0e43d8487

We are basically matching behavior from ghostty: 


https://github.com/user-attachments/assets/119c3130-8d6f-4c17-a919-148bcc905d27

Had hard time repro with Korean so showing Chinese here