### PR TITLE
fix: sync helper textarea position after resize

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -573,7 +573,10 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       this._renderService!.handleCursorMove();
       this._syncTextArea();
     }));
-    this._register(this.onResize(() => this._renderService!.handleResize(this.cols, this.rows)));
+    this._register(this.onResize(() => {
+      this._renderService!.handleResize(this.cols, this.rows);
+      this._syncTextArea();
+    }));
     this._register(this.onBlur(() => this._renderService!.handleBlur()));
     this._register(this.onFocus(() => this._renderService!.handleFocus()));
 


### PR DESCRIPTION
## Summary
- call `_syncTextArea()` in the terminal resize handler after renderer resize
- keep the helper textarea anchored to the current cursor cell after `Terminal.resize`
- avoid stale textarea `top`/`height` values that can place it below the viewport and trigger extra page scrollbars on shrink

## Testing
- `npm run lint -- src/browser/CoreBrowserTerminal.ts`

## Related
Fixes #3390
