### PR TITLE
fix(ime): keep composition text order when clipping overflow

### DIFF
--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -45,6 +45,14 @@ describe('CompositionHelper', () => {
     compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), coreService, new MockRenderService());
   });
 
+  describe('Layout', () => {
+    it('should keep composition text direction left-to-right', () => {
+      compositionHelper.compositionstart();
+      compositionHelper.compositionupdate({ data: 'nihao' });
+      assert.equal((compositionView.style as any).direction, 'ltr');
+    });
+  });
+
   describe('Input', () => {
     it('Should insert simple characters', (done) => {
       // First character 'ㅇ'

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -244,7 +244,8 @@ export class CompositionHelper {
       const maxWidth = this._bufferService.cols * this._renderService.dimensions.css.cell.width - cursorLeft;
       this._compositionView.style.maxWidth = maxWidth + 'px';
       this._compositionView.style.overflow = 'hidden';
-      this._compositionView.style.direction = 'rtl';
+      // Keep composition text order natural for IMEs (eg. pinyin) while still clipping overflow.
+      this._compositionView.style.direction = 'ltr';
       // Sync the textarea to the exact position of the composition view so the IME knows where the
       // text is.
       const compositionViewBounds = this._compositionView.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- keep IME composition overflow clipping (`maxWidth` + `overflow: hidden`) but restore natural text order by setting composition view direction to `ltr`
- add a focused unit test that asserts composition layout keeps left-to-right direction during composition updates

## Testing
- `npx eslint --max-warnings 0 src/browser/input/CompositionHelper.ts src/browser/input/CompositionHelper.test.ts`

## Related
- Fixes #5760
