### PR TITLE
fix: remove global loop variable in verification methods

### DIFF
--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -20,8 +20,6 @@ import type { IEvent } from 'common/Event';
  */
 const CONSTRUCTOR_ONLY_OPTIONS = ['cols', 'rows'];
 
-let $value = 0;
-
 export class Terminal extends Disposable implements ITerminalApi {
   private _core: ITerminal;
   private _addonManager: AddonManager;
@@ -255,16 +253,16 @@ export class Terminal extends Disposable implements ITerminalApi {
   }
 
   private _verifyIntegers(...values: number[]): void {
-    for ($value of values) {
-      if ($value === Infinity || isNaN($value) || $value % 1 !== 0) {
+    for (const value of values) {
+      if (value === Infinity || isNaN(value) || value % 1 !== 0) {
         throw new Error('This API only accepts integers');
       }
     }
   }
 
   private _verifyPositiveIntegers(...values: number[]): void {
-    for ($value of values) {
-      if ($value && ($value === Infinity || isNaN($value) || $value % 1 !== 0 || $value < 0)) {
+    for (const value of values) {
+      if (value && (value === Infinity || isNaN(value) || value % 1 !== 0 || value < 0)) {
         throw new Error('This API only accepts positive integers');
       }
     }


### PR DESCRIPTION
## Summary

Remove the global `$value` variable that was being used in `_verifyIntegers` and `_verifyPositiveIntegers` methods in `src/browser/public/Terminal.ts`.

## Problem

Using a global variable as a loop variable is problematic because:

1. It makes the code non-reentrant and not thread-safe
2. The global variable persists between method calls
3. If multiple verification methods are called concurrently, it could lead to race conditions

## Solution

Changed to use local `const value` in for-of loops, which is the standard and safe way to iterate in TypeScript.

## Changes

- Removed global variable `$value` declared at line 23
- Changed `for ($value of values)` to `for (const value of values)` in `_verifyIntegers()`
- Changed `for ($value of values)` to `for (const value of values)` in `_verifyPositiveIntegers()`

This is a straightforward fix that improves code safety without changing any functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)