### PR TITLE
fix(addon-image): disable desynchronized resize canvas

### DIFF
--- a/addons/addon-image/src/ImageRenderer.ts
+++ b/addons/addon-image/src/ImageRenderer.ts
@@ -358,8 +358,7 @@ export class ImageRenderer extends Disposable implements IDisposable {
       canvas.style.zIndex = '0';
       screenElement.appendChild(canvas);
     }
-    // Keep rendering synchronized with resize to avoid blank-frame jitter on some platforms.
-    const ctx = canvas.getContext('2d', { alpha: true, desynchronized: false });
+    const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) {
       canvas.remove();
       return;

--- a/addons/addon-image/src/ImageRenderer.ts
+++ b/addons/addon-image/src/ImageRenderer.ts
@@ -358,7 +358,8 @@ export class ImageRenderer extends Disposable implements IDisposable {
       canvas.style.zIndex = '0';
       screenElement.appendChild(canvas);
     }
-    const ctx = canvas.getContext('2d', { alpha: true, desynchronized: true });
+    // Keep rendering synchronized with resize to avoid blank-frame jitter on some platforms.
+    const ctx = canvas.getContext('2d', { alpha: true, desynchronized: false });
     if (!ctx) {
       canvas.remove();
       return;


### PR DESCRIPTION
## Summary
- Image addon currently creates layer canvases with { desynchronized: true }.
- During resize this can show blank-frame jitter on some platforms because repaint may miss the resize frame.
- Switch layer canvas creation to { desynchronized: false } so resize and repaint stay synchronized.

Fixes #5691.

## Validation
- npm run lint -- addons/addon-image/src/ImageRenderer.ts