### PR TITLE
Do not report lock key presses without REPORT_ALL_KEYS in Kitty keyboard

### DIFF
--- a/src/common/input/KittyKeyboard.test.ts
+++ b/src/common/input/KittyKeyboard.test.ts
@@ -506,6 +506,25 @@ describe('KittyKeyboard', () => {
         const result = kitty.evaluate(createEvent({ key: 'Shift', code: 'ShiftLeft', shiftKey: false }), flags, KittyKeyboardEventType.RELEASE);
         assert.strictEqual(result.key, undefined);
       });
+
+      it('does not report CapsLock press without REPORT_ALL_KEYS_AS_ESCAPE_CODES', () => {
+        assert.strictEqual(kitty.evaluate(createEvent({ key: 'CapsLock', code: 'CapsLock' }), KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES).key, undefined);
+        assert.strictEqual(kitty.evaluate(createEvent({ key: 'CapsLock', code: 'CapsLock' }), KittyKeyboardFlags.REPORT_EVENT_TYPES).key, undefined);
+        assert.strictEqual(kitty.evaluate(createEvent({ key: 'CapsLock', code: 'CapsLock' }), KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES | KittyKeyboardFlags.REPORT_EVENT_TYPES).key, undefined);
+      });
+
+      it('does not report NumLock press without REPORT_ALL_KEYS_AS_ESCAPE_CODES', () => {
+        assert.strictEqual(kitty.evaluate(createEvent({ key: 'NumLock', code: 'NumLock' }), KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES).key, undefined);
+      });
+
+      it('does not report ScrollLock press without REPORT_ALL_KEYS_AS_ESCAPE_CODES', () => {
+        assert.strictEqual(kitty.evaluate(createEvent({ key: 'ScrollLock', code: 'ScrollLock' }), KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES).key, undefined);
+      });
+
+      it('does not report CapsLock release without REPORT_ALL_KEYS_AS_ESCAPE_CODES', () => {
+        const result = kitty.evaluate(createEvent({ key: 'CapsLock', code: 'CapsLock' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
+      });
     });
 
     describe('REPORT_ALL_KEYS_AS_ESCAPE_CODES flag', () => {

--- a/src/common/input/KittyKeyboard.ts
+++ b/src/common/input/KittyKeyboard.ts
@@ -266,6 +266,19 @@ export class KittyKeyboard {
   }
 
   /**
+   * Check if a key is a lock key (CapsLock/NumLock/ScrollLock).
+   *
+   * Kitty's reference implementation classifies these as modifier keys for the
+   * purpose of suppressing press events (kitty/keys.c `is_modifier_key()`
+   * includes `GLFW_FKEY_CAPS_LOCK`, `GLFW_FKEY_SCROLL_LOCK`, `GLFW_FKEY_NUM_LOCK`),
+   * and its test suite asserts that a CapsLock press with no protocol flags
+   * produces empty output.
+   */
+  private _isLockKey(ev: IKeyboardEvent): boolean {
+    return ev.key === 'CapsLock' || ev.key === 'NumLock' || ev.key === 'ScrollLock';
+  }
+
+  /**
    * Build CSI letter sequence for arrow keys, Home, End.
    * Format: CSI [1;mod] letter
    */
@@ -419,6 +432,14 @@ export class KittyKeyboard {
     }
 
     if (isMod && !(flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES)) {
+      return result;
+    }
+
+    // Spec § "Report all keys as escape codes": "Additionally, with this mode,
+    // events for pressing modifier keys are reported." — i.e. *without* this
+    // mode, modifier-key press events are suppressed. Kitty's is_modifier_key()
+    // treats CapsLock/NumLock/ScrollLock as modifier keys for this rule.
+    if (this._isLockKey(ev) && !(flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES)) {
       return result;
     }
 


### PR DESCRIPTION
Resolves: #5787
Related: https://github.com/microsoft/vscode/issues/304679 /cc @meganrogge 

Problem:

When an application enables the Kitty keyboard protocol (e.g. `CSI >1u`), pressing CapsLock emits `\x1b[57358u` which appears as visible garbage `[57358u` in the terminal. Same for ScrollLock (`57359`) and NumLock (`57360`).

* `_isModifierKey()` only checks `Shift/Control/Alt/Meta`. Lock keys fall through the modifier-suppression guard, hit * `_functionalKeyCodes['CapsLock']` → `57358`, and get encoded as a CSI u sequence.

Solution:

Add `_isLockKey()` and a guard in `evaluate()` that suppresses lock-key press events unless flag 8 (`REPORT_ALL_KEYS_AS_ESCAPE_CODES`) is set. This matches Kitty's reference implementation:

- [`keys.c:36-48`](https://github.com/kovidgoyal/kitty/blob/master/kitty/keys.c#L36-L48): `is_modifier_key()` includes `GLFW_FKEY_CAPS_LOCK`, `GLFW_FKEY_SCROLL_LOCK`, `GLFW_FKEY_NUM_LOCK`
- [`key_encoding.c:434`](https://github.com/kovidgoyal/kitty/blob/master/kitty/key_encoding.c#L434): `if (!ev.report_text && is_modifier_key(e->key)) return 0;`
- [`kitty_tests/keys.py:408-409`](https://github.com/kovidgoyal/kitty/blob/master/kitty_tests/keys.py#L408-L409): `ae(enc(key=defines.GLFW_FKEY_CAPS_LOCK), '')`

Also consistent with X11's `IsModifierKey` macro (`Xutil.h`), which includes `XK_Caps_Lock` (by range) and `XK_Num_Lock` (explicit). xterm's `TypeOfKeysym()` routes these to `modifyModifierKeys`, not `modifyOtherKeys`, so bare lock-key presses produce no output there either.

Encoding lock state in the modifier bits (caps_lock=64, num_lock=128) is tracked separately in #5789.

----
Videos

Before this PR: 

https://github.com/user-attachments/assets/c7f3812a-9c95-424a-94a8-c227c09470b2


After this PR: 

https://github.com/user-attachments/assets/70a2f105-470c-4a07-b7a9-4f9578c4b215


