### PR TITLE
Fix kitty keyboard "Report event types" behavior not matching spec

### DIFF
--- a/src/common/input/KittyKeyboard.test.ts
+++ b/src/common/input/KittyKeyboard.test.ts
@@ -453,9 +453,29 @@ describe('KittyKeyboard', () => {
     describe('event types (press/repeat/release)', () => {
       const flags = KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES | KittyKeyboardFlags.REPORT_EVENT_TYPES;
 
-      it('press event (default, no suffix)', () => {
+      it('UTF-8 text press event', () => {
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.PRESS);
-        assert.strictEqual(result.key, '\x1b[97u');
+        assert.strictEqual(result.key, 'a');
+      });
+
+      it('Escape key press event (default, no suffix)', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Escape' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x1b[27u');
+      });
+
+      it('Enter key press event → legacy \\r', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\r');
+      });
+
+      it('Tab key press event → legacy \\t', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\t');
+      });
+
+      it('Backspace key press event → legacy \\x7f', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x7f');
       });
 
       it('press event explicit :1 when modifiers present', () => {
@@ -463,14 +483,54 @@ describe('KittyKeyboard', () => {
         assert.strictEqual(result.key, '\x1b[97;5u');
       });
 
-      it('repeat event → :2 suffix', () => {
+      it('UTF-8 text repeat event', () => {
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.REPEAT);
-        assert.strictEqual(result.key, '\x1b[97;1:2u');
+        assert.strictEqual(result.key, 'a');
+      });
+
+      it('Escape key repeat event → :2 suffix', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Escape' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x1b[27;1:2u');
+      });
+
+      it('Enter key repeat event → legacy \\r', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\r');
+      });
+
+      it('Tab key repeat event → legacy \\t', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\t');
+      });
+
+      it('Backspace key repeat event → legacy \\x7f', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x7f');
       });
 
       it('release event → :3 suffix', () => {
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.RELEASE);
         assert.strictEqual(result.key, '\x1b[97;1:3u');
+      });
+
+      it('Escape key release event → :3 suffix', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Escape' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, '\x1b[27;1:3u');
+      });
+
+      it('Enter key release event is not reported', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
+      });
+
+      it('Tab key release event is not reported', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
+      });
+
+      it('Backspace key release event is not reported', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
       });
 
       it('release with modifier → mod:3', () => {

--- a/src/common/input/KittyKeyboard.test.ts
+++ b/src/common/input/KittyKeyboard.test.ts
@@ -453,9 +453,29 @@ describe('KittyKeyboard', () => {
     describe('event types (press/repeat/release)', () => {
       const flags = KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES | KittyKeyboardFlags.REPORT_EVENT_TYPES;
 
-      it('press event (default, no suffix)', () => {
+      it('UTF-8 text press event', () => {
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.PRESS);
-        assert.strictEqual(result.key, '\x1b[97u');
+        assert.strictEqual(result.key, 'a');
+      });
+
+      it('Escape key press event (default, no suffix)', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Escape' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x1b[27u');
+      });
+
+      it('Enter key press event → legacy \\r', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\r');
+      });
+
+      it('Tab key press event → legacy \\t', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\t');
+      });
+
+      it('Backspace key press event → legacy \\x7f', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x7f');
       });
 
       it('press event explicit :1 when modifiers present', () => {
@@ -463,14 +483,54 @@ describe('KittyKeyboard', () => {
         assert.strictEqual(result.key, '\x1b[97;5u');
       });
 
-      it('repeat event → :2 suffix', () => {
+      it('UTF-8 text repeat event', () => {
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.REPEAT);
-        assert.strictEqual(result.key, '\x1b[97;1:2u');
+        assert.strictEqual(result.key, 'a');
+      });
+
+      it('Escape key repeat event → :2 suffix', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Escape' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x1b[27;1:2u');
+      });
+
+      it('Enter key repeat event → legacy \\r', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\r');
+      });
+
+      it('Tab key repeat event → legacy \\t', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\t');
+      });
+
+      it('Backspace key repeat event → legacy \\x7f', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x7f');
       });
 
       it('release event → :3 suffix', () => {
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.RELEASE);
         assert.strictEqual(result.key, '\x1b[97;1:3u');
+      });
+
+      it('Escape key release event → :3 suffix', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Escape' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, '\x1b[27;1:3u');
+      });
+
+      it('Enter key release event is not reported', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
+      });
+
+      it('Tab key release event is not reported', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
+      });
+
+      it('Backspace key release event is not reported', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, undefined);
       });
 
       it('release with modifier → mod:3', () => {
@@ -560,6 +620,55 @@ describe('KittyKeyboard', () => {
       it('space → CSI 32 u', () => {
         const result = kitty.evaluate(createEvent({ key: ' ' }), flags);
         assert.strictEqual(result.key, '\x1b[32u');
+      });
+    });
+
+    describe('REPORT_ALL_KEYS_AS_ESCAPE_CODES flag with REPORT_EVENT_TYPES', () => {
+      const flags = KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES | KittyKeyboardFlags.REPORT_EVENT_TYPES;
+
+      it('Enter key press event → CSI 13 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x1b[13u');
+      });
+
+      it('Tab key press event → CSI 9 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x1b[9u');
+      });
+
+      it('Backspace key press event → CSI 127 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x1b[127u');
+      });
+
+      it('Enter key repeat event → CSI 13;1:2 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x1b[13;1:2u');
+      });
+
+      it('Tab key repeat event → CSI 9;1:2 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x1b[9;1:2u');
+      });
+
+      it('Backspace key repeat event → CSI 127;1:2 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x1b[127;1:2u');
+      });
+
+      it('Enter key release event → CSI 13;1:3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Enter' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, '\x1b[13;1:3u');
+      });
+
+      it('Tab key release event → CSI 9;1:3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Tab' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, '\x1b[9;1:3u');
+      });
+
+      it('Backspace key release event → CSI 127;1:3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Backspace' }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, '\x1b[127;1:3u');
       });
     });
 

--- a/src/common/input/KittyKeyboard.ts
+++ b/src/common/input/KittyKeyboard.ts
@@ -477,7 +477,12 @@ export class KittyKeyboard {
 
     if (flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES) {
       useCsiU = true;
-    } else if (reportEventTypes) {
+    } else if (reportEventTypes && eventType === KittyKeyboardEventType.RELEASE) {
+      // Per spec, Enter/Tab/Backspace will not have release events unless "Report all keys as
+      // escape codes" (which is handled by the branch above) is also set.
+      if (keyCode === 13 || keyCode === 9 || keyCode === 127) {
+        return result;
+      }
       useCsiU = true;
     } else if (flags & KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES) {
       // Per spec, Enter/Tab/Backspace "still generate the same bytes as in legacy

--- a/src/common/input/KittyKeyboard.ts
+++ b/src/common/input/KittyKeyboard.ts
@@ -471,34 +471,33 @@ export class KittyKeyboard {
       return result;
     }
 
+    // Special handling for Enter/Tab/Backspace.
+    const specialKey = keyCode === 13 || keyCode === 9 || keyCode === 127;
+
+    // Per spec, Enter/Tab/Backspace will not have release events unless "Report all keys as escape
+    // codes" is also set.
+    if (specialKey && eventType === KittyKeyboardEventType.RELEASE && !(flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES)) {
+      return result;
+    }
+
     const isFunc = this._functionalKeyCodes[ev.key] !== undefined || this._getNumpadKeyCode(ev) !== undefined;
 
-    let useCsiU = false;
-
-    if (flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES) {
-      useCsiU = true;
-    } else if (reportEventTypes && eventType === KittyKeyboardEventType.RELEASE) {
-      // Per spec, Enter/Tab/Backspace will not have release events unless "Report all keys as
-      // escape codes" (which is handled by the branch above) is also set.
-      if (keyCode === 13 || keyCode === 9 || keyCode === 127) {
-        return result;
-      }
-      useCsiU = true;
-    } else if (flags & KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES) {
-      // Per spec, Enter/Tab/Backspace "still generate the same bytes as in legacy
-      // mode" and consider space to be a text-generating key, so these skip the isFunc fast-path
-      // and only get CSI u when modifiers are present (handled below).
-      const isDisambiguateLegacy = keyCode === 13 || keyCode === 9 || keyCode === 127;
-      if (isFunc && !isDisambiguateLegacy) {
-        useCsiU = true;
-      } else if (modifiers > 0) {
-        if (ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.key.length === 1) {
-          useCsiU = false;
-        } else {
-          useCsiU = true;
-        }
-      }
-    }
+    const useCsiU = !!(
+      flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES ||
+      (reportEventTypes && eventType === KittyKeyboardEventType.RELEASE) ||
+      (flags & KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES &&
+        (
+          // Per spec, Enter/Tab/Backspace "still generate the same bytes as in legacy mode" and
+          // consider space to be a text-generating key, so these skip the isFunc fast-path and only
+          // get CSI u when modifiers are present (handled below).
+          (isFunc && !specialKey) ||
+          (
+            (modifiers > 0 && ev.key.length !== 1) ||
+            modifiers - 1 > KittyKeyboardModifiers.SHIFT
+          )
+        )
+      )
+    );
 
     if (useCsiU) {
       result.key = this._buildCsiUSequence(ev, keyCode, modifiers, eventType, flags, isFunc, isMod);


### PR DESCRIPTION
According to spec:
- The Enter, Tab and Backspace keys will not have release events unless
  "Report all keys as escape codes" is also set.
- Key events that result in text are reported as plain UTF-8 text, so
  events are not supported for them, unless the application requests
  "key report" mode.

I checked kitty's behavior. While it does report release events for keys
that result in text as CSI sequences, press and repeat events for these
are reported as plain UTF-8 text. This commit changes Xterm.js to match
this behavior.

Fix neovim/neovim#38651
