### PR TITLE
Do not open link when user is selecting the link text

### DIFF
--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -15,6 +15,7 @@ export class Linkifier extends Disposable implements ILinkifier2 {
   public get currentLink(): ILinkWithState | undefined { return this._currentLink; }
   protected _currentLink: ILinkWithState | undefined;
   private _mouseDownLink: ILinkWithState | undefined;
+  private _lastMouseDownPos: IBufferCellPosition | undefined;
   private _lastMouseEvent: MouseEvent | undefined;
   private _linkCacheDisposables: IDisposable[] = [];
   private _lastBufferCell: IBufferCellPosition | undefined;
@@ -213,11 +214,21 @@ export class Linkifier extends Disposable implements ILinkifier2 {
     return linkProvided;
   }
 
-  private _handleMouseDown(): void {
+  private _handleMouseDown(event: MouseEvent): void {
+    if (!this._element) {
+      return;
+    }
+    const position = this._positionFromMouseEvent(event, this._element);
+
     this._mouseDownLink = this._currentLink;
+
+    this._lastMouseDownPos = position;
   }
 
   private _handleMouseUp(event: MouseEvent): void {
+    const mouseDownLink = this._mouseDownLink;
+    this._mouseDownLink = undefined;
+
     if (!this._currentLink) {
       return;
     }
@@ -227,7 +238,15 @@ export class Linkifier extends Disposable implements ILinkifier2 {
       return;
     }
 
-    if (this._mouseDownLink && linkEquals(this._mouseDownLink.link, this._currentLink.link) && this._linkAtPosition(this._currentLink.link, position)) {
+    // compare last mouse down position: if we strayed too much, don't open the link
+    // that's because very likely user intended to select the text instead of opening the link
+    let selectionDetected = true;
+    if (this._lastMouseDownPos) {
+      const deltaMov = Math.abs(this._lastMouseDownPos.x - position.x) + Math.abs(this._lastMouseDownPos.y - position.y);
+      selectionDetected = deltaMov >= 2;
+    }
+
+    if (!selectionDetected && mouseDownLink && linkEquals(mouseDownLink.link, this._currentLink.link) && this._linkAtPosition(this._currentLink.link, position)) {
       this._currentLink.link.activate(event, this._currentLink.link.text);
     }
   }


### PR DESCRIPTION
This PR fixes a UX issue where clicking and dragging to select text over a linkified URL, then releasing the mouse button while a click modifier key is still pressed (e.g. Cmd on macOS), would still open the link on mouse up. This issue was previously raised in #1947, though it appears to have been closed without a fix.

# What's changed

- **`_handleMouseDown`** now records the terminal cell position at mouse-down time in `_lastMouseDownPos`.
- **`_handleMouseUp`** compares the mouse-down and mouse-up positions using Manhattan distance (`|Δx| + |Δy|`). If the total movement is greater than or equal to 2 cells, it treats the action as a selection and skips link activation. I chose a threshold of 2 cells because it is large enough to account for sub-cell jitter, but small enough that a click with slight hand movement still opens the link.

# Manual Testing

1. Holding the modifier key while clicking a link without dragging still opens it.
2. With the modifier key always held, clicking and dragging across a link selects text without opening the link.
3. A very small mouse drift click (1 cell) still opens the link.