### PR TITLE
fix: send correct number of sequences for wheel scroll in alt buffer

### DIFF
--- a/src/browser/services/MouseService.ts
+++ b/src/browser/services/MouseService.ts
@@ -239,9 +239,6 @@ export class MouseService implements IMouseService {
       // Convert wheel events into up/down events when the buffer does not have scrollback, this
       // enables scrolling in apps hosted in the alt buffer such as vim or tmux even when mouse
       // events are not enabled.
-      // This used implementation used get the actual lines/partial lines scrolled from the
-      // viewport but since moving to the new viewport implementation has been simplified to
-      // simply send a single up or down sequence.
 
       // Do nothing if there's no vertical scroll
       const deltaY = ev.deltaY;
@@ -260,9 +257,12 @@ export class MouseService implements IMouseService {
         return false;
       }
 
-      // Construct and send sequences
+      // Construct and send sequences, repeating once per line scrolled to match
+      // the behavior of native terminals (e.g. less/man scroll 3 lines per click).
       const sequence = C0.ESC + (this._coreService.decPrivateModes.applicationCursorKeys ? 'O' : '[') + (ev.deltaY < 0 ? 'A' : 'B');
-      this._coreService.triggerDataEvent(sequence, true);
+      for (let i = 0; i < lines; i++) {
+        this._coreService.triggerDataEvent(sequence, true);
+      }
       ev.preventDefault();
       ev.stopPropagation();
       return false;


### PR DESCRIPTION
Fixes #5194

## Problem

When the terminal is in the alt buffer (no scrollback — vim, less, man, etc.), mouse wheel events are converted to up/down arrow key sequences. Previously only a **single** sequence was sent per wheel event, regardless of how many lines the wheel reported scrolling. This made scrolling in alternate-screen apps feel sluggish — one notch of the wheel moved exactly one line instead of the expected three.

The same code path that handles **touch scroll** (`_handleTouchScrollAsKeys`) already sends one sequence per line correctly. The wheel path was inconsistent with it.

## Fix

Loop `lines` times when sending the sequence, matching the existing touch scroll logic:

```ts
// before
this._coreService.triggerDataEvent(sequence, true);

// after
for (let i = 0; i < lines; i++) {
  this._coreService.triggerDataEvent(sequence, true);
}
```

`lines` is already computed by `_consumeWheelEvent` just above — no new state needed.

## Testing

Manually verified with `less` and `man`: one scroll click now moves the expected number of lines. The touch scroll path is unchanged.