### PR TITLE
fix: avoid invisible text when theme background is transparent in inverse video

### DIFF
--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -348,7 +348,12 @@ export class TextureAtlas implements ITextureAtlas {
       case Attributes.CM_DEFAULT:
       default:
         if (inverse) {
-          result = this._config.colors.background;
+          // When the theme background is transparent, using it directly as
+          // the foreground (text) color produces invisible glyphs. Fall back
+          // to the foreground color so text remains readable.
+          result = color.isOpaque(this._config.colors.background)
+            ? this._config.colors.background
+            : this._config.colors.foreground;
         } else {
           result = this._config.colors.foreground;
         }
@@ -396,7 +401,11 @@ export class TextureAtlas implements ITextureAtlas {
       case Attributes.CM_DEFAULT:
       default:
         if (inverse) {
-          return this._config.colors.background.rgba;
+          // Mirror the _getForegroundColor fallback: avoid returning a
+          // transparent value that would break contrast ratio calculations.
+          return color.isOpaque(this._config.colors.background)
+            ? this._config.colors.background.rgba
+            : this._config.colors.foreground.rgba;
         }
         return this._config.colors.foreground.rgba;
     }

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -303,8 +303,8 @@ export class DomRenderer extends Disposable implements IRenderer {
         `${this._terminalSelector} .${BG_CLASS_PREFIX}${i} { background-color: ${c.css}; }`;
     }
     styles +=
-      `${this._terminalSelector} .${FG_CLASS_PREFIX}${INVERTED_DEFAULT_COLOR} { color: ${color.opaque(colors.background).css}; }` +
-      `${this._terminalSelector} .${FG_CLASS_PREFIX}${INVERTED_DEFAULT_COLOR}.${RowCss.DIM_CLASS} { color: ${color.multiplyOpacity(color.opaque(colors.background), 0.5).css}; }` +
+      `${this._terminalSelector} .${FG_CLASS_PREFIX}${INVERTED_DEFAULT_COLOR} { color: ${(color.isOpaque(colors.background) ? colors.background : colors.foreground).css}; }` +
+      `${this._terminalSelector} .${FG_CLASS_PREFIX}${INVERTED_DEFAULT_COLOR}.${RowCss.DIM_CLASS} { color: ${color.multiplyOpacity(color.isOpaque(colors.background) ? colors.background : colors.foreground, 0.5).css}; }` +
       `${this._terminalSelector} .${BG_CLASS_PREFIX}${INVERTED_DEFAULT_COLOR} { background-color: ${colors.foreground.css}; }`;
 
     this._themeStyleElement.textContent = styles;


### PR DESCRIPTION
Fixes #1898

## Problem

When `allowTransparency: true` and `theme.background` is set to `'transparent'`, cells rendered in **inverse-video mode** (e.g. nano's status bar, `less` highlighted results) display invisible text.

The cause: in inverse video the foreground (text) color is resolved from `colors.background`. When that color is transparent (`rgba = 0x00000000`), making it opaque produces `#000000` — black. On any dark page background (the typical reason someone sets a transparent terminal), black text is invisible.

This affects both renderers:

- **WebGL** (`TextureAtlas._getForegroundColor` and `_resolveForegroundRgba`): returns `colors.background.rgba` directly, which is `0x00000000`.
- **DOM** (`DomRenderer`): generates `.xterm-fg-257 { color: ${opaque(colors.background).css} }`, which becomes `color: #000000`.

## Fix

In both renderers, when resolving the inverse-video default foreground color, fall back to `colors.foreground` whenever `colors.background` is not opaque:

```ts
// WebGL — TextureAtlas._getForegroundColor
if (inverse) {
  result = color.isOpaque(this._config.colors.background)
    ? this._config.colors.background
    : this._config.colors.foreground;
}

// DOM — DomRenderer CSS generation
`.xterm-fg-257 { color: ${(color.isOpaque(colors.background) ? colors.background : colors.foreground).css}; }`
```

`colors.foreground` is always opaque and is the color the user already chose to be readable on their background — it is the right fallback when the background carries no meaningful color information.

The same fallback is applied to `_resolveForegroundRgba`, which feeds `_getMinimumContrastColor`, to keep contrast ratio calculations consistent.

## Testing

Reproduced with:
```js
const term = new Terminal({ allowTransparency: true, theme: { background: 'transparent' } });
```
Then running `nano` or any program that uses reverse-video attributes. Before this fix: status bar text invisible. After: text visible, using the foreground color on the inverted background.