### PR TITLE
Drop inline <style> textContent for theme colors (#4445)

### DIFF
--- a/css/xterm.css
+++ b/css/xterm.css
@@ -241,6 +241,24 @@
     transform: rotate(180deg);
 }
 
+/* Theme colors applied via CSS custom properties set on the terminal element at
+ * runtime, so theming works without style-src 'unsafe-inline'. See #4445. */
+.xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider {
+    background: var(--xterm-scrollbar-slider-background, rgba(100, 100, 100, 0.4));
+}
+.xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider:hover {
+    background: var(--xterm-scrollbar-slider-hover-background, rgba(100, 100, 100, 0.7));
+}
+.xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider.xterm-active {
+    background: var(--xterm-scrollbar-slider-active-background, rgba(0, 0, 0, 0.6));
+}
+
+.xterm .xterm-rows span {
+    display: inline-block;
+    height: 100%;
+    vertical-align: top;
+}
+
 .xterm .xterm-scrollable-element > .xterm-visible {
 	opacity: 1;
 

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -20,7 +20,6 @@ export class Viewport extends Disposable {
   public readonly onRequestScrollLines = this._onRequestScrollLines.event;
 
   private _scrollableElement: SmoothScrollableElement;
-  private _styleElement: HTMLStyleElement;
 
   private _queuedAnimationFrame?: number;
   private _latestYDisp?: number;
@@ -80,21 +79,12 @@ export class Viewport extends Disposable {
     element.appendChild(this._scrollableElement.getDomNode());
     this._register(toDisposable(() => this._scrollableElement.getDomNode().remove()));
 
-    this._styleElement = coreBrowserService.mainDocument.createElement('style');
-    screenElement.appendChild(this._styleElement);
-    this._register(toDisposable(() => this._styleElement.remove()));
+    // Apply theme colors via CSS custom properties rather than an inline <style>
+    // textContent, so the terminal works under a strict style-src 'self' CSP (#4445).
     this._register(EventUtils.runAndSubscribe(themeService.onChangeColors, () => {
-      this._styleElement.textContent = [
-        `.xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider {`,
-        `  background: ${themeService.colors.scrollbarSliderBackground.css};`,
-        `}`,
-        `.xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider:hover {`,
-        `  background: ${themeService.colors.scrollbarSliderHoverBackground.css};`,
-        `}`,
-        `.xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider.xterm-active {`,
-        `  background: ${themeService.colors.scrollbarSliderActiveBackground.css};`,
-        `}`
-      ].join('\n');
+      element.style.setProperty('--xterm-scrollbar-slider-background', themeService.colors.scrollbarSliderBackground.css);
+      element.style.setProperty('--xterm-scrollbar-slider-hover-background', themeService.colors.scrollbarSliderHoverBackground.css);
+      element.style.setProperty('--xterm-scrollbar-slider-active-background', themeService.colors.scrollbarSliderActiveBackground.css);
     }));
 
     this._register(this._bufferService.onResize(() => this.queueSync()));

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -39,7 +39,6 @@ export class DomRenderer extends Disposable implements IRenderer {
   private _terminalClass: number = nextTerminalId++;
 
   private _themeStyleElement!: HTMLStyleElement;
-  private _dimensionsStyleElement!: HTMLStyleElement;
   private _rowContainer: HTMLElement;
   private _rowElements: HTMLElement[] = [];
   private _selectionContainer: HTMLElement;
@@ -118,7 +117,6 @@ export class DomRenderer extends Disposable implements IRenderer {
       this._selectionContainer.remove();
       this._widthCache.dispose();
       this._themeStyleElement.remove();
-      this._dimensionsStyleElement.remove();
     }));
 
     this._widthCache = new WidthCache();
@@ -154,19 +152,9 @@ export class DomRenderer extends Disposable implements IRenderer {
       element.style.overflow = 'hidden';
     }
 
-    if (!this._dimensionsStyleElement) {
-      this._dimensionsStyleElement = this._document.createElement('style');
-      this._screenElement.appendChild(this._dimensionsStyleElement);
-    }
-
-    const styles =
-      `${this._terminalSelector} .${ROW_CONTAINER_CLASS} span {` +
-      ` display: inline-block;` +   // TODO: find workaround for inline-block (creates ~20% render penalty)
-      ` height: 100%;` +
-      ` vertical-align: top;` +
-      `}`;
-
-    this._dimensionsStyleElement.textContent = styles;
+    // Row span rules (inline-block, full height) live in the static xterm.css
+    // stylesheet rather than an injected <style>, so the DOM renderer works under
+    // a strict style-src 'self' CSP (#4445).
 
     this._selectionContainer.style.height = this._viewportElement.style.height;
     this._screenElement.style.width = `${this.dimensions.css.canvas.width}px`;


### PR DESCRIPTION
Fixes the two specific `<style>` textContent sites called out in #4445 so that xterm.js renders correctly under a strict `style-src 'self'` Content Security Policy (no `unsafe-inline` needed).

## What changes

- **`Viewport.ts`** – the scrollbar slider `<style>` element is gone. Its theme-dependent colors (`scrollbarSliderBackground`, `scrollbarSliderHoverBackground`, `scrollbarSliderActiveBackground`) are now applied via `element.style.setProperty('--xterm-scrollbar-slider-*-background', ...)` on the terminal element whenever the theme changes. The `setProperty` DOM API is not subject to `style-src`, so the CSP warnings and the broken scrollbar reported in the issue both go away.
- **`DomRenderer.ts`** – the row-container `span` rule (`display: inline-block; height: 100%; vertical-align: top;`) is static, never varied by theme or options. The whole `_dimensionsStyleElement` is dropped and the rule lives in the static stylesheet.
- **`css/xterm.css`** – new rules for `.xterm-slider[:hover|.xterm-active]` consuming the three CSS custom properties (with sensible fallbacks matching the existing defaults) plus the migrated `.xterm-rows span` rule.

## Behavior

Visually unchanged: the fallback values on each `var(--xterm-*, ...)` match the color set that was previously generated inline, and `Viewport` immediately sets the real values on construction (via `runAndSubscribe`) before any paint. Multiple terminals on the same page stay isolated because the custom properties are set on each terminal's root element, not on `:root`/`documentElement`.

This only addresses the two cases Tyriar linked in the issue thread. `DomRenderer._injectCss` still injects a `<style>` textContent for the per-terminal theme CSS — worth a follow-up, but a much larger refactor (cursor blink keyframes, 256-ANSI color classes, per-terminal selector names) that I'd rather keep out of this PR.

## Testing

- `npm run tsc` – clean
- `npm run test-unit` – 2261 passing

I don't have a CSP test page in the repo, but the fix is easy to verify manually by serving the demo with `Content-Security-Policy: style-src 'self'` and confirming the scrollbar renders and no `Refused to apply inline style` warning appears.

Refs #4445.