### PR TITLE
Report current SGR state in DECRQSS response

### DIFF
--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -2359,6 +2359,67 @@ describe('InputHandler', () => {
       assert.deepEqual(sendStack.pop(), '\x1bP1$r0"q\x1b\\');  // reported as DECSCA 0
     });
   });
+  describe('DECRQSS SGR', () => {
+    const sendStack: string[] = [];
+    beforeEach(() => {
+      sendStack.length = 0;
+      coreService.onData(d => sendStack.push(d));
+    });
+    const query = async (): Promise<string | undefined> => {
+      await inputHandler.parseP('\x1bP$qm\x1b\\');
+      return sendStack.pop();
+    };
+    it('reports 0m by default', async () => {
+      assert.deepEqual(await query(), '\x1bP1$r0m\x1b\\');
+    });
+    it('reports bold/dim/italic', async () => {
+      await inputHandler.parseP('\x1b[1;2;3m');
+      assert.deepEqual(await query(), '\x1bP1$r0;1;2;3m\x1b\\');
+    });
+    it('reports underline styles', async () => {
+      await inputHandler.parseP('\x1b[4m');
+      assert.deepEqual(await query(), '\x1bP1$r0;4m\x1b\\');
+      await inputHandler.parseP('\x1b[0m\x1b[21m');
+      assert.deepEqual(await query(), '\x1bP1$r0;21m\x1b\\');
+      await inputHandler.parseP('\x1b[0m\x1b[4:3m');
+      assert.deepEqual(await query(), '\x1bP1$r0;4:3m\x1b\\');
+      await inputHandler.parseP('\x1b[0m\x1b[4:4m');
+      assert.deepEqual(await query(), '\x1bP1$r0;4:4m\x1b\\');
+      await inputHandler.parseP('\x1b[0m\x1b[4:5m');
+      assert.deepEqual(await query(), '\x1bP1$r0;4:5m\x1b\\');
+    });
+    it('reports inverse, invisible, strikethrough, overline', async () => {
+      await inputHandler.parseP('\x1b[7;8;9;53m');
+      assert.deepEqual(await query(), '\x1bP1$r0;7;8;9;53m\x1b\\');
+    });
+    it('reports blink only when blinkIntervalDuration > 0', async () => {
+      await inputHandler.parseP('\x1b[5m');
+      assert.deepEqual(await query(), '\x1bP1$r0m\x1b\\');
+      optionsService.options.blinkIntervalDuration = 500;
+      assert.deepEqual(await query(), '\x1bP1$r0;5m\x1b\\');
+      optionsService.options.blinkIntervalDuration = 0;
+    });
+    it('reports 16-color fg/bg', async () => {
+      await inputHandler.parseP('\x1b[31;42m');
+      assert.deepEqual(await query(), '\x1bP1$r0;31;42m\x1b\\');
+      await inputHandler.parseP('\x1b[0m\x1b[93;104m');
+      assert.deepEqual(await query(), '\x1bP1$r0;93;104m\x1b\\');
+    });
+    it('reports 256-color fg/bg', async () => {
+      await inputHandler.parseP('\x1b[38;5;123;48;5;45m');
+      assert.deepEqual(await query(), '\x1bP1$r0;38:5:123;48:5:45m\x1b\\');
+    });
+    it('reports RGB fg/bg', async () => {
+      await inputHandler.parseP('\x1b[38;2;10;20;30;48;2;40;50;60m');
+      assert.deepEqual(await query(), '\x1bP1$r0;38:2::10:20:30;48:2::40:50:60m\x1b\\');
+    });
+    it('reports underline color', async () => {
+      await inputHandler.parseP('\x1b[4;58:5:99m');
+      assert.deepEqual(await query(), '\x1bP1$r0;4;58:5:99m\x1b\\');
+      await inputHandler.parseP('\x1b[0m\x1b[4;58:2::1:2:3m');
+      assert.deepEqual(await query(), '\x1bP1$r0;4;58:2::1:2:3m\x1b\\');
+    });
+  });
   describe('DECRQM', () => {
     const reportStack: string[] = [];
     beforeEach(() => {

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -3520,7 +3520,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    *
    * | Type                             | Request           | Response (`Pt`)                                       |
    * | -------------------------------- | ----------------- | ----------------------------------------------------- |
-   * | Graphic Rendition (SGR)          | `DCS $ q m ST`    | always reporting `0m` (currently broken)              |
+   * | Graphic Rendition (SGR)          | `DCS $ q m ST`    | `Ps ; ... m` reporting the current SGR state          |
    * | Top and Bottom Margins (DECSTBM) | `DCS $ q r ST`    | `Ps ; Ps r`                                           |
    * | Cursor Style (DECSCUSR)          | `DCS $ q SP q ST` | `Ps SP q`                                             |
    * | Protection Attribute (DECSCA)    | `DCS $ q " q ST`  | `Ps " q` (DECSCA 2 is reported as Ps = 0)             |
@@ -3528,7 +3528,6 @@ export class InputHandler extends Disposable implements IInputHandler {
    *
    *
    * TODO:
-   * - fix SGR report
    * - either check which conformance is better suited or remove the report completely
    *   --> we are currently a mixture of all up to VT400 but dont follow anyone strictly
    */
@@ -3546,10 +3545,49 @@ export class InputHandler extends Disposable implements IInputHandler {
     if (data === '"q') return f(`P1$r${this._curAttrData.isProtected() ? 1 : 0}"q`);
     if (data === '"p') return f(`P1$r61;1"p`);
     if (data === 'r') return f(`P1$r${b.scrollTop + 1};${b.scrollBottom + 1}r`);
-    // FIXME: report real SGR settings instead of 0m
-    if (data === 'm') return f(`P1$r0m`);
+    if (data === 'm') return f(`P1$r${this._reportSGR()}m`);
     if (data === ' q') return f(`P1$r${STYLES[opts.cursorStyle] - (opts.cursorBlink ? 1 : 0)} q`);
     return f(`P0$r`);
+  }
+
+  private _reportSGR(): string {
+    const attr = this._curAttrData;
+    const opts = this._optionsService.rawOptions;
+    let report = '0';
+    if (attr.isBold()) report += ';1';
+    if (attr.isDim()) report += ';2';
+    if (attr.isItalic()) report += ';3';
+    switch (attr.getUnderlineStyle()) {
+      case UnderlineStyle.SINGLE: report += ';4'; break;
+      case UnderlineStyle.DOUBLE: report += ';21'; break;
+      case UnderlineStyle.CURLY: report += ';4:3'; break;
+      case UnderlineStyle.DOTTED: report += ';4:4'; break;
+      case UnderlineStyle.DASHED: report += ';4:5'; break;
+    }
+    if (opts.blinkIntervalDuration > 0 && attr.isBlink()) report += ';5';
+    if (attr.isInverse()) report += ';7';
+    if (attr.isInvisible()) report += ';8';
+    if (attr.isStrikethrough()) report += ';9';
+    if (attr.isOverline()) report += ';53';
+    const colorAttr = (color: number, colorMode: number, baseAttr: number): string => {
+      switch (colorMode) {
+        case Attributes.CM_P16:
+          if (color < 8) return `;${baseAttr + color}`;
+          return `;${baseAttr + 60 + color - 8}`;
+        case Attributes.CM_P256:
+          return `;${baseAttr + 8}:5:${color}`;
+        case Attributes.CM_RGB:
+          return `;${baseAttr + 8}:2::${(color >> 16) & 0xFF}:${(color >> 8) & 0xFF}:${color & 0xFF}`;
+        default:
+          return '';
+      }
+    };
+    report += colorAttr(attr.getFgColor(), attr.getFgColorMode(), 30);
+    report += colorAttr(attr.getBgColor(), attr.getBgColorMode(), 40);
+    if (attr.hasExtendedAttrs() && ~attr.extended.underlineColor) {
+      report += colorAttr(attr.getUnderlineColor(), attr.getUnderlineColorMode(), 50);
+    }
+    return report;
   }
 
   public markRangeDirty(y1: number, y2: number): void {


### PR DESCRIPTION
## Summary

Fixes #4099.

DECRQSS for SGR (`DCS $ q m ST`) was hard-coded to always respond with `0m` regardless of the current state. Applications that use DECRQSS to round-trip the active SGR attributes were getting no useful information back.

This reports the real state. The structure follows the patch outline @j4james posted in the issue thread — credit to him for the design.

Covers:

- `1` bold, `2` dim, `3` italic
- Underline styles: `4` single, `21` double, and extended forms `4:3` curly, `4:4` dotted, `4:5` dashed
- `5` blink (only when `blinkIntervalDuration > 0`, mirroring the render-time gate so the reported state matches what's actually visible)
- `7` inverse, `8` invisible, `9` strikethrough, `53` overline
- Foreground (`30`–`37`, `90`–`97`, `38:5:n`, `38:2::r:g:b`)
- Background (`40`–`47`, `100`–`107`, `48:5:n`, `48:2::r:g:b`)
- Underline color (`58:5:n`, `58:2::r:g:b`) when extended attrs are set

Also removed the `FIXME` and the `fix SGR report` TODO line, and updated the `@vt` doc table entry which still described the old broken behaviour.

## Test plan

- [x] Added `DECRQSS SGR` suite in `InputHandler.test.ts` covering default state, bold/dim/italic, all five underline styles, inverse/invisible/strikethrough/overline, blink gated on `blinkIntervalDuration`, 16-color and bright 16-color fg/bg, 256-color fg/bg, RGB fg/bg, and underline color (256 + RGB)
- [x] `npm run tsc`
- [x] `npm run esbuild`
- [x] Full `InputHandler.test.ts` suite passes (192 tests)