### PR TITLE
Implement DECBKM to remap Backspace/Delete

### DIFF
--- a/src/browser/services/KeyboardService.ts
+++ b/src/browser/services/KeyboardService.ts
@@ -41,7 +41,7 @@ export class KeyboardService implements IKeyboardService {
     const kittyFlags = this._coreService.kittyKeyboard.flags;
     return this.useKitty
       ? this._getKittyKeyboard().evaluate(event, kittyFlags, event.repeat ? KittyKeyboardEventType.REPEAT : KittyKeyboardEventType.PRESS, isMac && this._optionsService.rawOptions.macOptionIsMeta)
-      : evaluateKeyboardEvent(event, this._coreService.decPrivateModes.applicationCursorKeys, isMac, this._optionsService.rawOptions.macOptionIsMeta);
+      : evaluateKeyboardEvent(event, this._coreService.decPrivateModes.applicationCursorKeys, isMac, this._optionsService.rawOptions.macOptionIsMeta, this._coreService.decPrivateModes.backarrowKey);
   }
 
   public evaluateKeyUp(event: KeyboardEvent): IKeyboardResult | undefined {

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -2440,9 +2440,21 @@ describe('InputHandler', () => {
       await inputHandler.parseP(`\x1b[?${mode}$p`);
       assert.deepEqual(reportStack.pop(), `\x1b[?${mode};2$y`);   // now inactive
     });
+    it('DECBKM (67) set/reset via DECRQM', async () => {
+      await inputHandler.parseP('\x1b[?67$p');
+      assert.deepEqual(reportStack.pop(), '\x1b[?67;2$y'); // reset by default
+      await inputHandler.parseP('\x1b[?67h');
+      assert.strictEqual(coreService.decPrivateModes.backarrowKey, true);
+      await inputHandler.parseP('\x1b[?67$p');
+      assert.deepEqual(reportStack.pop(), '\x1b[?67;1$y'); // set
+      await inputHandler.parseP('\x1b[?67l');
+      assert.strictEqual(coreService.decPrivateModes.backarrowKey, false);
+      await inputHandler.parseP('\x1b[?67$p');
+      assert.deepEqual(reportStack.pop(), '\x1b[?67;2$y'); // reset
+    });
     it('DEC privates perma modes', async () => {
       // [mode number, state value]
-      const perma = [[3, 0], [8, 3], [67, 4], [1005, 4], [1015, 4], [1048, 1]];
+      const perma = [[3, 0], [8, 3], [1005, 4], [1015, 4], [1048, 1]];
       for (const [mode, value] of perma) {
         await inputHandler.parseP(`\x1b[?${mode}$p`);
         assert.deepEqual(reportStack.pop(), `\x1b[?${mode};${value}$y`);

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -1925,6 +1925,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * | 45    | Reverse wrap-around.                                    | #Y      |
    * | 47    | Use Alternate Screen Buffer.                            | #Y      |
    * | 66    | Application keypad (DECNKM).                            | #Y      |
+   * | 67    | Backarrow key sends backspace (DECBKM).                 | #Y      |
    * | 1000  | X11 xterm mouse protocol.                               | #Y      |
    * | 1002  | Use Cell Motion Mouse Tracking.                         | #Y      |
    * | 1003  | Use All Motion Mouse Tracking.                          | #Y      |
@@ -1984,6 +1985,9 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._logService.debug('Serial port requested application keypad.');
           this._coreService.decPrivateModes.applicationKeypad = true;
           this._onRequestSyncScrollBar.fire();
+          break;
+        case 67:
+          this._coreService.decPrivateModes.backarrowKey = true;
           break;
         case 9: // X10 Mouse
           // no release, no motion, no wheel, no modifiers.
@@ -2191,6 +2195,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * | 45    | No reverse wrap-around.                                 | #Y      |
    * | 47    | Use Normal Screen Buffer.                               | #Y      |
    * | 66    | Numeric keypad (DECNKM).                                | #Y      |
+   * | 67    | Backarrow key sends delete (DECBKM).                    | #Y      |
    * | 1000  | Don't send Mouse reports.                               | #Y      |
    * | 1002  | Don't use Cell Motion Mouse Tracking.                   | #Y      |
    * | 1003  | Don't use All Motion Mouse Tracking.                    | #Y      |
@@ -2243,6 +2248,9 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._logService.debug('Switching back to normal keypad.');
           this._coreService.decPrivateModes.applicationKeypad = false;
           this._onRequestSyncScrollBar.fire();
+          break;
+        case 67:
+          this._coreService.decPrivateModes.backarrowKey = false;
           break;
         case 9: // X10 Mouse
         case 1000: // vt200 mouse
@@ -2389,7 +2397,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     if (p === 25) return f(p, b2v(!cs.isCursorHidden));
     if (p === 45) return f(p, b2v(dm.reverseWraparound));
     if (p === 66) return f(p, b2v(dm.applicationKeypad));
-    if (p === 67) return f(p, V.PERMANENTLY_RESET);
+    if (p === 67) return f(p, b2v(dm.backarrowKey));
     if (p === 1000) return f(p, b2v(mouseProtocol === 'VT200'));
     if (p === 1002) return f(p, b2v(mouseProtocol === 'DRAG'));
     if (p === 1003) return f(p, b2v(mouseProtocol === 'ANY'));

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -118,6 +118,7 @@ export class MockCoreService implements ICoreService {
   public decPrivateModes: IDecPrivateModes = {
     applicationCursorKeys: false,
     applicationKeypad: false,
+    backarrowKey: false,
     bracketedPasteMode: false,
     colorSchemeUpdates: false,
     cursorBlink: undefined,

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -267,6 +267,7 @@ export interface IModes {
 export interface IDecPrivateModes {
   applicationCursorKeys: boolean;
   applicationKeypad: boolean;
+  backarrowKey: boolean;
   bracketedPasteMode: boolean;
   colorSchemeUpdates: boolean;
   cursorBlink: boolean | undefined;

--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -20,6 +20,7 @@ function testEvaluateKeyboardEvent(partialEvent: {
   applicationCursorMode?: boolean;
   isMac?: boolean;
   macOptionIsMeta?: boolean;
+  backarrowKey?: boolean;
 } = {}): IKeyboardResult {
   const event: IKeyboardEvent = {
     altKey: partialEvent.altKey || false,
@@ -34,9 +35,10 @@ function testEvaluateKeyboardEvent(partialEvent: {
   const options = {
     applicationCursorMode: partialOptions.applicationCursorMode || false,
     isMac: partialOptions.isMac || false,
-    macOptionIsMeta: partialOptions.macOptionIsMeta || false
+    macOptionIsMeta: partialOptions.macOptionIsMeta || false,
+    backarrowKey: partialOptions.backarrowKey || false
   };
-  return evaluateKeyboardEvent(event, options.applicationCursorMode, options.isMac, options.macOptionIsMeta);
+  return evaluateKeyboardEvent(event, options.applicationCursorMode, options.isMac, options.macOptionIsMeta, options.backarrowKey);
 }
 
 describe('Keyboard', () => {
@@ -359,6 +361,21 @@ describe('Keyboard', () => {
 
     it('should return proper sequence for ctrl+_', () => {
       assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, shiftKey: true, keyCode: 189, code: 'Minus', key: '_' }).key, '\x1f');
+    });
+
+    describe('DECBKM (backarrow key mode)', () => {
+      it('default (reset): backspace sends DEL, ctrl+backspace sends BS', () => {
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 8 }, { backarrowKey: false }).key, '\x7f');
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 8, ctrlKey: true }, { backarrowKey: false }).key, '\b');
+      });
+      it('set: backspace sends BS, ctrl+backspace sends DEL', () => {
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 8 }, { backarrowKey: true }).key, '\b');
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 8, ctrlKey: true }, { backarrowKey: true }).key, '\x7f');
+      });
+      it('alt prefix is preserved in both modes', () => {
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 8, altKey: true }, { backarrowKey: false }).key, '\x1b\x7f');
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 8, altKey: true }, { backarrowKey: true }).key, '\x1b\b');
+      });
     });
 
   });

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -39,7 +39,8 @@ export function evaluateKeyboardEvent(
   ev: IKeyboardEvent,
   applicationCursorMode: boolean,
   isMac: boolean,
-  macOptionIsMeta: boolean
+  macOptionIsMeta: boolean,
+  backarrowKey: boolean = false
 ): IKeyboardResult {
   const result: IKeyboardResult = {
     type: KeyboardResultType.SEND_KEY,
@@ -82,8 +83,10 @@ export function evaluateKeyboardEvent(
       }
       break;
     case 8:
-      // backspace
-      result.key = ev.ctrlKey ? '\b' : C0.DEL; // ^H or ^?
+      // backspace (DECBKM: set -> BS, reset -> DEL)
+      result.key = backarrowKey
+        ? (ev.ctrlKey ? C0.DEL : '\b')
+        : (ev.ctrlKey ? '\b' : C0.DEL);
       if (ev.altKey) {
         result.key = C0.ESC + result.key;
       }

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -16,6 +16,7 @@ const DEFAULT_MODES: IModes = Object.freeze({
 const DEFAULT_DEC_PRIVATE_MODES: IDecPrivateModes = Object.freeze({
   applicationCursorKeys: false,
   applicationKeypad: false,
+  backarrowKey: false,
   bracketedPasteMode: false,
   colorSchemeUpdates: false,
   cursorBlink: undefined,


### PR DESCRIPTION
## Summary

Fixes #3041.

DECBKM (DEC Backarrow Key Mode, private mode 67) controls what the `Backspace` key transmits. Previously mode 67 was reported as permanently reset by DECRQM and set/reset had no effect, so applications that expected to toggle the behaviour at runtime (per the VT510 spec) had no recourse except client-side key handlers.

Per the VT510 spec:

- Reset (default, `CSI ? 67 l`): Backspace sends `DEL` (0x7f)
- Set (`CSI ? 67 h`): Backspace sends `BS` (0x08)

The `Ctrl+Backspace` inversion that xterm.js has always done is preserved in both modes:

| DECBKM | Backspace | Ctrl+Backspace |
| --- | --- | --- |
| reset (default) | `DEL` | `BS` |
| set | `BS` | `DEL` |

This matches xterm's behaviour (xterm swaps the two when `backarrowKey` is toggled) and matches the discussion on the issue — @Tyriar and @jerch landed on "implement it as a real VT sequence so apps can drive it, same as DECNKM."

## Test plan

- [x] New tests in `Keyboard.test.ts`: default mode, DECBKM set mode, alt-prefix preservation in both modes
- [x] New test in `InputHandler.test.ts`: `CSI ? 67 h` / `CSI ? 67 l` flip `decPrivateModes.backarrowKey` and DECRQM (`CSI ? 67 $ p`) reports the right state
- [x] Updated `@vt` doc tables for DECSET/DECRST to cover mode 67
- [x] Removed mode 67 from the "perma modes" DECRQM regression test (since it's no longer permanently reset)
- [x] `npm run tsc`, `npm run esbuild`, full Keyboard + InputHandler test suites pass (248 tests)