### PR TITLE
Preserve selected match when re-highlighting during search

### DIFF
--- a/addons/addon-search/src/SearchAddon.ts
+++ b/addons/addon-search/src/SearchAddon.ts
@@ -72,9 +72,36 @@ export class SearchAddon extends Disposable implements ITerminalAddon, ISearchAp
     if (this._state.cachedSearchTerm && this._state.lastSearchOptions?.decorations) {
       this._highlightTimeout.value = disposableTimeout(() => {
         const term = this._state.cachedSearchTerm;
+        const lastOptions = this._state.lastSearchOptions;
+        if (!term || !lastOptions) {
+          return;
+        }
+        // Preserve the currently selected match across re-highlights triggered
+        // by new output or resize. Without this, the "X of Y" index flickers
+        // or jumps as each incremental re-search starts from the terminal
+        // selection — see #3886.
+        const prevMatch = this._resultTracker.selectedDecoration?.match;
         this._state.clearCachedTerm();
-        this.findPrevious(term!, { ...this._state.lastSearchOptions, incremental: true }, { noScroll: true });
+        this._highlightAllMatches(term, { ...lastOptions, incremental: true });
+        this._restoreSelectedMatch(prevMatch, lastOptions);
+        this._fireResults(lastOptions);
+        this._state.cachedSearchTerm = term;
       }, 200);
+    }
+  }
+
+  private _restoreSelectedMatch(prevMatch: ISearchResult | undefined, searchOptions: ISearchOptions): void {
+    if (!this._decorationManager || !prevMatch || !searchOptions.decorations) {
+      return;
+    }
+    const idx = this._resultTracker.findResultIndex(prevMatch);
+    if (idx === -1) {
+      return;
+    }
+    const match = this._resultTracker.searchResults[idx];
+    const activeDecoration = this._decorationManager.createActiveDecoration(match, searchOptions.decorations);
+    if (activeDecoration) {
+      this._resultTracker.selectedDecoration = activeDecoration;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #3886.

When new output (or a resize) fires while a search is active, the addon debounces a re-highlight 200ms later. Previously that re-highlight was routed through `findPrevious`, which starts from the terminal's current selection and walks backward through the matches — so every chunk of incoming output moved the "selected" match (often wrapping around to the end). The net effect for `onDidChangeResults` consumers is that "X of Y" flickers or jumps to `Y` on any streaming output, which makes the feature hard to build on top of. @Tyriar called this out in [the thread](https://github.com/xtermjs/xterm.js/issues/3886#issuecomment-1221253080) — the ideal is to keep the previously selected match selected.

This change:

- Captures `_selectedDecoration.match` before re-highlighting.
- Re-highlights directly via `_highlightAllMatches` (no selection motion).
- Re-applies the active decoration to the *same* match position in the new result set.
- Fires `onDidChangeResults` with the preserved index.
- Falls back to no active decoration only when the previously selected match has genuinely fallen out of the result set (e.g. pushed out of scrollback or no longer matches after a resize-driven reflow).

## Test plan

- [x] `npm run tsc`, `npm run esbuild`
- [x] Existing `addon-search` suites still pass (86 tests)
- [ ] Manual: run a search in a terminal streaming rapid output, confirm the `X of Y` index stays on the user's current match instead of flickering/jumping