### PR TITLE
Clear stale isWrapped when resize skips reflow for cursor line

### DIFF
--- a/src/common/buffer/Buffer.test.ts
+++ b/src/common/buffer/Buffer.test.ts
@@ -518,6 +518,26 @@ describe('Buffer', () => {
         assert.equal(secondMarker.line, 1, 'second marker should be restored');
         assert.equal(thirdMarker.line, 2, 'third marker should be restored');
       });
+      it('should clear stale isWrapped when the cursor is on a wrapped line and reflow is skipped (#3482)', () => {
+        buffer.fillViewportRows();
+        buffer.resize(5, 10);
+        for (let i = 0; i < 5; i++) {
+          buffer.lines.get(0)!.set(i, [0, 'a', 1, 'a'.charCodeAt(0)]);
+          buffer.lines.get(1)!.set(i, [0, 'b', 1, 'b'.charCodeAt(0)]);
+        }
+        buffer.lines.get(1)!.isWrapped = true;
+        // Leave the cursor inside the wrapped group — this matches the real
+        // scenario where the user is still typing on the wrapped line.
+        buffer.y = 1;
+        buffer.x = 5;
+        buffer.resize(10, 10);
+        // Content is preserved (the program owns the cursor line) but the
+        // wrap is no longer valid in the wider layout, so isWrapped must be
+        // cleared — otherwise triple-click still treats both rows as one
+        // logical line.
+        assert.equal(buffer.lines.get(0)!.isWrapped, false);
+        assert.equal(buffer.lines.get(1)!.isWrapped, false);
+      });
       it('should correctly reflow wrapped lines that end in 0 space (via tab char)', () => {
         buffer.fillViewportRows();
         buffer.resize(4, 10);

--- a/src/common/buffer/BufferReflow.ts
+++ b/src/common/buffer/BufferReflow.ts
@@ -44,8 +44,15 @@ export function reflowLargerGetLinesToRemove(lines: CircularList<IBufferLine>, o
 
     if (!reflowCursorLine) {
       // If these lines contain the cursor don't touch them, the program will handle fixing up
-      // wrapped lines with the cursor
+      // wrapped lines with the cursor. But clear stale `isWrapped` flags for wraps that cannot
+      // exist in the wider layout — otherwise selection (e.g. triple-click) still treats the
+      // group as one logical line even though each row now visually stands alone. See #3482.
       if (bufferAbsoluteY >= y && bufferAbsoluteY < i) {
+        for (let j = 1; j < wrappedLines.length; j++) {
+          if (!wrappedLines[j - 1].hasContent(newCols - 1)) {
+            wrappedLines[j].isWrapped = false;
+          }
+        }
         y += wrappedLines.length - 1;
         continue;
       }


### PR DESCRIPTION
Fixes #3482.

## What

When resizing to a wider terminal, `_reflowLarger` skips merging a wrapped-line group if the cursor is inside that group — the comment already notes that "the program will handle fixing up wrapped lines with the cursor". But the wrapped rows keep `isWrapped = true` even though their content no longer wraps in the new width. Any consumer of `isWrapped` (triple-click selection is the user-visible symptom in the issue) then treats the now-visually-separate rows as a single logical line.

## Fix

Inside the cursor-skip branch, clear `isWrapped` on any continuation row whose predecessor no longer fills the new last column. The predecessor's last cell has already been null-padded by the pre-reflow line resize, so `hasContent(newCols - 1)` is a reliable signal that the wrap cannot exist at the new width.

Content on the cursor line is deliberately left alone — only the flag is cleaned up, matching the "program will fix up" contract.

## Repro

Before:

```
cols=5, two rows "aaaaa" / "bbbbb" (isWrapped=true), cursor inside group
→ resize cols=10 → line0="aaaaa     " line1="bbbbb     " isWrapped=true (stale)
→ triple-click selects both rows
```

After: `line1.isWrapped === false`; triple-click selects only one row.

## Test

Added `should clear stale isWrapped when the cursor is on a wrapped line and reflow is skipped (#3482)` in `Buffer.test.ts`.