### PR TITLE
Add fontStretch option

### DIFF
--- a/addons/addon-webgl/src/CharAtlasUtils.ts
+++ b/addons/addon-webgl/src/CharAtlasUtils.ts
@@ -45,6 +45,7 @@ export function generateConfig(deviceCellWidth: number, deviceCellHeight: number
     fontSize: options.fontSize,
     fontWeight: options.fontWeight,
     fontWeightBold: options.fontWeightBold,
+    fontStretch: options.fontStretch,
     allowTransparency: options.allowTransparency,
     drawBoldTextInBrightColors: options.drawBoldTextInBrightColors,
     minimumContrastRatio: options.minimumContrastRatio,
@@ -66,6 +67,7 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
       a.fontSize === b.fontSize &&
       a.fontWeight === b.fontWeight &&
       a.fontWeightBold === b.fontWeightBold &&
+      a.fontStretch === b.fontStretch &&
       a.allowTransparency === b.allowTransparency &&
       a.deviceCharWidth === b.deviceCharWidth &&
       a.deviceCharHeight === b.deviceCharHeight &&

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -512,7 +512,7 @@ export class TextureAtlas implements ITextureAtlas {
     const fontWeight = bold ? this._config.fontWeightBold : this._config.fontWeight;
     const fontStyle = italic ? 'italic' : '';
     this._tmpCtx.font =
-      `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
+      `${fontStyle} ${fontWeight} ${this._config.fontStretch} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
     this._tmpCtx.textBaseline = TEXT_BASELINE;
 
     const powerlineGlyph = chars.length === 1 && isPowerlineGlyph(chars.charCodeAt(0));

--- a/addons/addon-webgl/src/Types.ts
+++ b/addons/addon-webgl/src/Types.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { FontWeight } from '@xterm/xterm';
+import { FontStretch, FontWeight } from '@xterm/xterm';
 import { IColorSet } from 'browser/Types';
 import { ISelectionRenderModel } from 'browser/renderer/shared/Types';
 import { CursorInactiveStyle, CursorStyle, type IDisposable } from 'common/Types';
@@ -45,6 +45,7 @@ export interface ICharAtlasConfig {
   fontFamily: string;
   fontWeight: FontWeight;
   fontWeightBold: FontWeight;
+  fontStretch: FontStretch;
   deviceCellWidth: number;
   deviceCellHeight: number;
   deviceCharWidth: number;

--- a/addons/addon-webgl/src/renderLayer/BaseRenderLayer.ts
+++ b/addons/addon-webgl/src/renderLayer/BaseRenderLayer.ts
@@ -216,7 +216,7 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     const fontWeight = isBold ? terminal.options.fontWeightBold : terminal.options.fontWeight;
     const fontStyle = isItalic ? 'italic' : '';
 
-    return `${fontStyle} ${fontWeight} ${terminal.options.fontSize! * this._coreBrowserService.dpr}px ${terminal.options.fontFamily}`;
+    return `${fontStyle} ${fontWeight} ${terminal.options.fontStretch} ${terminal.options.fontSize! * this._coreBrowserService.dpr}px ${terminal.options.fontFamily}`;
   }
 }
 

--- a/demo/client/components/window/optionsWindow.ts
+++ b/demo/client/components/window/optionsWindow.ts
@@ -137,6 +137,7 @@ export class OptionsWindow extends BaseWindow implements IControlWindow {
       fontFamily: null,
       fontWeight: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
       fontWeightBold: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
+      fontStretch: ['normal', 'ultra-condensed', 'extra-condensed', 'condensed', 'semi-condensed', 'semi-expanded', 'expanded', 'extra-expanded', 'ultra-expanded'],
       logLevel: ['trace', 'debug', 'info', 'warn', 'error', 'off'],
       theme: ['default', 'xtermjs', 'sapphire', 'light'],
       wordSeparator: null,

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -126,7 +126,8 @@ export class DomRenderer extends Disposable implements IRenderer {
       this._optionsService.rawOptions.fontFamily,
       this._optionsService.rawOptions.fontSize,
       this._optionsService.rawOptions.fontWeight,
-      this._optionsService.rawOptions.fontWeightBold
+      this._optionsService.rawOptions.fontWeightBold,
+      this._optionsService.rawOptions.fontStretch
     );
     this._setDefaultSpacing();
   }
@@ -203,9 +204,11 @@ export class DomRenderer extends Disposable implements IRenderer {
     styles +=
       `${this._terminalSelector} span:not(.${RowCss.BOLD_CLASS}) {` +
       ` font-weight: ${this._optionsService.rawOptions.fontWeight};` +
+      ` font-stretch: ${this._optionsService.rawOptions.fontStretch};` +
       `}` +
       `${this._terminalSelector} span.${RowCss.BOLD_CLASS} {` +
       ` font-weight: ${this._optionsService.rawOptions.fontWeightBold};` +
+      ` font-stretch: ${this._optionsService.rawOptions.fontStretch};` +
       `}` +
       `${this._terminalSelector} span.${RowCss.ITALIC_CLASS} {` +
       ` font-style: italic;` +
@@ -498,7 +501,8 @@ export class DomRenderer extends Disposable implements IRenderer {
       this._optionsService.rawOptions.fontFamily,
       this._optionsService.rawOptions.fontSize,
       this._optionsService.rawOptions.fontWeight,
-      this._optionsService.rawOptions.fontWeightBold
+      this._optionsService.rawOptions.fontWeightBold,
+      this._optionsService.rawOptions.fontStretch
     );
     this._setDefaultSpacing();
   }

--- a/src/browser/renderer/dom/WidthCache.test.ts
+++ b/src/browser/renderer/dom/WidthCache.test.ts
@@ -10,7 +10,7 @@ import { IWidthCacheFontVariantCanvas, WidthCache, WidthCacheSettings } from 'br
 class MockWidthCacheFontVariantCanvas implements IWidthCacheFontVariantCanvas {
   public widths: { [key: string]: number } = {};
 
-  public setFont(_fontFamily: string, _fontSize: number, _fontWeight: unknown, _italic: boolean): void {
+  public setFont(_fontFamily: string, _fontSize: number, _fontWeight: unknown, _fontStretch: unknown, _italic: boolean): void {
   }
 
   public measure(c: string): number {
@@ -52,7 +52,7 @@ describe('WidthCache', () => {
   let wc: TestWidthCache;
   beforeEach(() => {
     wc = new TestWidthCache();
-    wc.setFont('monospace', 15, 'normal', 'bold');
+    wc.setFont('monospace', 15, 'normal', 'bold', 'normal');
   });
   describe('cache invalidation', () => {
     beforeEach(() => {
@@ -71,31 +71,37 @@ describe('WidthCache', () => {
       assert.deepStrictEqual(wc.holey?.size, 0);
     });
     it('setFont with changed font name', () => {
-      wc.setFont('Arial', 15, 'normal', 'bold');
+      wc.setFont('Arial', 15, 'normal', 'bold', 'normal');
       assert.deepStrictEqual(wc.flat[0], castf32(WidthCacheSettings.FLAT_UNSET));
       assert.deepStrictEqual(wc.holey?.get('a'), undefined);
       assert.deepStrictEqual(wc.holey?.size, 0);
     });
     it('setFont with changed font size', () => {
-      wc.setFont('monospace', 14, 'normal', 'bold');
+      wc.setFont('monospace', 14, 'normal', 'bold', 'normal');
       assert.deepStrictEqual(wc.flat[0], castf32(WidthCacheSettings.FLAT_UNSET));
       assert.deepStrictEqual(wc.holey?.get('a'), undefined);
       assert.deepStrictEqual(wc.holey?.size, 0);
     });
     it('setFont with changed weight', () => {
-      wc.setFont('monospace', 15, '100', 'bold');
+      wc.setFont('monospace', 15, '100', 'bold', 'normal');
       assert.deepStrictEqual(wc.flat[0], castf32(WidthCacheSettings.FLAT_UNSET));
       assert.deepStrictEqual(wc.holey?.get('a'), undefined);
       assert.deepStrictEqual(wc.holey?.size, 0);
     });
     it('setFont with changed weightBold', () => {
-      wc.setFont('monospace', 15, 'normal', '900');
+      wc.setFont('monospace', 15, 'normal', '900', 'normal');
+      assert.deepStrictEqual(wc.flat[0], castf32(WidthCacheSettings.FLAT_UNSET));
+      assert.deepStrictEqual(wc.holey?.get('a'), undefined);
+      assert.deepStrictEqual(wc.holey?.size, 0);
+    });
+    it('setFont with changed stretch', () => {
+      wc.setFont('monospace', 15, 'normal', 'bold', 'condensed');
       assert.deepStrictEqual(wc.flat[0], castf32(WidthCacheSettings.FLAT_UNSET));
       assert.deepStrictEqual(wc.holey?.get('a'), undefined);
       assert.deepStrictEqual(wc.holey?.size, 0);
     });
     it('setFont with unchanged settings does not cache entries', () => {
-      wc.setFont('monospace', 15, 'normal', 'bold');
+      wc.setFont('monospace', 15, 'normal', 'bold', 'normal');
       assert.deepStrictEqual(wc.flat[0], castf32(1.23));
       assert.deepStrictEqual(wc.holey?.get('a'), 2.34);
       assert.deepStrictEqual(wc.holey?.size, 1);

--- a/src/browser/renderer/dom/WidthCache.ts
+++ b/src/browser/renderer/dom/WidthCache.ts
@@ -5,7 +5,7 @@
 
 import { throwIfFalsy } from 'browser/renderer/shared/RendererUtils';
 import { IDisposable } from 'common/Types';
-import { FontWeight } from 'common/services/Services';
+import { FontStretch, FontWeight } from 'common/services/Services';
 
 
 export const enum WidthCacheSettings {
@@ -26,7 +26,7 @@ const enum FontVariant {
 }
 
 export interface IWidthCacheFontVariantCanvas {
-  setFont(fontFamily: string, fontSize: number, fontWeight: FontWeight, italic: boolean): void;
+  setFont(fontFamily: string, fontSize: number, fontWeight: FontWeight, fontStretch: FontStretch, italic: boolean): void;
   measure(c: string): number;
 }
 
@@ -47,6 +47,7 @@ export class WidthCache implements IDisposable {
   private _fontSize = 0;
   private _weight: FontWeight = 'normal';
   private _weightBold: FontWeight = 'bold';
+  private _stretch: FontStretch = 'normal';
   private _canvasElements: IWidthCacheFontVariantCanvas[] = [];
 
   constructor(
@@ -81,13 +82,14 @@ export class WidthCache implements IDisposable {
    * Must be called for any changes on font settings.
    * Also clears the cache.
    */
-  public setFont(font: string, fontSize: number, weight: FontWeight, weightBold: FontWeight): void {
+  public setFont(font: string, fontSize: number, weight: FontWeight, weightBold: FontWeight, stretch: FontStretch): void {
     // skip if nothing changed
     if (
       font === this._font &&
       fontSize === this._fontSize &&
       weight === this._weight &&
-      weightBold === this._weightBold
+      weightBold === this._weightBold &&
+      stretch === this._stretch
     ) {
       return;
     }
@@ -96,11 +98,12 @@ export class WidthCache implements IDisposable {
     this._fontSize = fontSize;
     this._weight = weight;
     this._weightBold = weightBold;
+    this._stretch = stretch;
 
-    this._canvasElements[FontVariant.REGULAR].setFont(font, fontSize, weight, false);
-    this._canvasElements[FontVariant.BOLD].setFont(font, fontSize, weightBold, false);
-    this._canvasElements[FontVariant.ITALIC].setFont(font, fontSize, weight, true);
-    this._canvasElements[FontVariant.BOLD_ITALIC].setFont(font, fontSize, weightBold, true);
+    this._canvasElements[FontVariant.REGULAR].setFont(font, fontSize, weight, stretch, false);
+    this._canvasElements[FontVariant.BOLD].setFont(font, fontSize, weightBold, stretch, false);
+    this._canvasElements[FontVariant.ITALIC].setFont(font, fontSize, weight, stretch, true);
+    this._canvasElements[FontVariant.BOLD_ITALIC].setFont(font, fontSize, weightBold, stretch, true);
 
     this.clear();
   }
@@ -158,9 +161,9 @@ class WidthCacheFontVariantCanvas implements IWidthCacheFontVariantCanvas {
     }
   }
 
-  public setFont(fontFamily: string, fontSize: number, fontWeight: FontWeight, italic: boolean): void {
+  public setFont(fontFamily: string, fontSize: number, fontWeight: FontWeight, fontStretch: FontStretch, italic: boolean): void {
     const fontStyle = italic ? 'italic' : '';
-    this._ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`.trim();
+    this._ctx.font = `${fontStyle} ${fontWeight} ${fontStretch} ${fontSize}px ${fontFamily}`.trim();
   }
 
   public measure(c: string): number {

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -102,6 +102,7 @@ export class RenderService extends Disposable implements IRenderService {
       'fontSize',
       'fontWeight',
       'fontWeightBold',
+      'fontStretch',
       'minimumContrastRatio',
       'rescaleOverlappingGlyphs'
     ], () => {

--- a/src/common/services/OptionsService.test.ts
+++ b/src/common/services/OptionsService.test.ts
@@ -58,6 +58,17 @@ describe('OptionsService', () => {
       service.options.fontWeight = 1000;
       assert.equal(service.options.fontWeight, 1000, 'Range should include maximum value: 1000');
     });
+    it('applies valid fontStretch option values', () => {
+      service.options.fontStretch = 'condensed';
+      assert.equal(service.options.fontStretch, 'condensed');
+      service.options.fontStretch = 'ultra-expanded';
+      assert.equal(service.options.fontStretch, 'ultra-expanded');
+    });
+    it('normalizes invalid fontStretch option values', () => {
+      service.options.fontStretch = 'condensed';
+      service.options.fontStretch = 'squashed' as any;
+      assert.equal(service.options.fontStretch, DEFAULT_OPTIONS.fontStretch, 'unknown keyword should reset to default');
+    });
     it('normalizes invalid fontWeight option values', () => {
       service.options.fontWeight = 350;
       assert.doesNotThrow(() => service.options.fontWeight = 10000, 'fontWeight should be normalized instead of throwing');

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -6,7 +6,7 @@
 import { Disposable, toDisposable } from 'common/Lifecycle';
 import { isMac } from 'common/Platform';
 import { CursorStyle, IDisposable } from 'common/Types';
-import { FontWeight, IOptionsService, ITerminalOptions } from 'common/services/Services';
+import { FontStretch, FontWeight, IOptionsService, ITerminalOptions } from 'common/services/Services';
 import { Emitter } from 'common/Event';
 
 export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
@@ -25,6 +25,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   fontSize: 15,
   fontWeight: 'normal',
   fontWeightBold: 'bold',
+  fontStretch: 'normal',
   ignoreBracketedPasteMode: false,
   lineHeight: 1.0,
   letterSpacing: 0,
@@ -60,6 +61,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
 };
 
 const FONT_WEIGHT_OPTIONS: Extract<FontWeight, string>[] = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
+const FONT_STRETCH_OPTIONS: FontStretch[] = ['normal', 'ultra-condensed', 'extra-condensed', 'condensed', 'semi-condensed', 'semi-expanded', 'expanded', 'extra-expanded', 'ultra-expanded'];
 
 export class OptionsService extends Disposable implements IOptionsService {
   public serviceBrand: any;
@@ -168,6 +170,9 @@ export class OptionsService extends Disposable implements IOptionsService {
           break;
         }
         value = FONT_WEIGHT_OPTIONS.includes(value) ? value : DEFAULT_OPTIONS[key];
+        break;
+      case 'fontStretch':
+        value = FONT_STRETCH_OPTIONS.includes(value) ? value : DEFAULT_OPTIONS[key];
         break;
       case 'blinkIntervalDuration':
         value = Math.floor(value);

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -204,6 +204,7 @@ export interface IOptionsService {
 }
 
 export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | number;
+export type FontStretch = 'normal' | 'ultra-condensed' | 'extra-condensed' | 'condensed' | 'semi-condensed' | 'semi-expanded' | 'expanded' | 'extra-expanded' | 'ultra-expanded';
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'off';
 
 export interface ITerminalOptions {
@@ -225,6 +226,7 @@ export interface ITerminalOptions {
   fontFamily?: string;
   fontWeight?: FontWeight;
   fontWeightBold?: FontWeight;
+  fontStretch?: FontStretch;
   ignoreBracketedPasteMode?: boolean;
   letterSpacing?: number;
   lineHeight?: number;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -16,6 +16,11 @@ declare module '@xterm/xterm' {
   export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | number;
 
   /**
+   * Valid `fontStretch` values matching CSS's `font-stretch` keyword range.
+   */
+  export type FontStretch = 'normal' | 'ultra-condensed' | 'extra-condensed' | 'condensed' | 'semi-condensed' | 'semi-expanded' | 'expanded' | 'extra-expanded' | 'ultra-expanded';
+
+  /**
    * A string representing log level.
    */
   export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'off';
@@ -131,6 +136,14 @@ declare module '@xterm/xterm' {
      * The font weight used to render bold text.
      */
     fontWeightBold?: FontWeight;
+
+    /**
+     * The font stretch used to render text. This maps to the CSS `font-stretch`
+     * keyword range and is applied to both DOM and canvas-based renderers.
+     * Note that browser support in canvas rendering varies; fonts without a
+     * matching stretched face will fall back to the nearest available one.
+     */
+    fontStretch?: FontStretch;
 
     /**
      * Whether to ignore the bracketed paste mode. When true, this will always


### PR DESCRIPTION
Fixes #2946.

## What

Adds a \`fontStretch\` terminal option so users can select a specific stretched font face (e.g. \`Iosevka Expanded\`) without hacking the font-family name. The value accepts any CSS \`font-stretch\` keyword: \`normal\`, \`ultra-condensed\`, \`extra-condensed\`, \`condensed\`, \`semi-condensed\`, \`semi-expanded\`, \`expanded\`, \`extra-expanded\`, \`ultra-expanded\` (percentages are intentionally out of scope — keeps the type surface narrow and matches the existing \`FontWeight\` keyword style).

## Plumbing

The option is threaded through every place where \`fontWeight\` already flows:

- Default + validation in \`OptionsService\` (invalid values fall back to \`normal\`, matching \`fontWeight\`)
- \`ITerminalOptions\` + \`FontStretch\` type in both internal \`Services.ts\` and the public \`xterm.d.ts\`
- DOM renderer: \`font-stretch\` in the injected CSS for both regular and bold span rules
- DOM \`WidthCache\`: included in the measurement canvas font string, and its change invalidates the cache
- WebGL \`TextureAtlas\` and \`BaseRenderLayer\`: included in the glyph font string
- WebGL \`CharAtlasUtils.generateConfig\`/\`configEquals\`: tracked in the config hash so atlases are regenerated on change
- \`RenderService\`: added to the refresh trigger list
- Demo \`optionsWindow\`: exposes a dropdown for manual testing

## Tests

- \`OptionsService.test.ts\` — validates keyword acceptance and invalid-value normalization
- \`WidthCache.test.ts\` — \`setFont with changed stretch\` invalidates the cache; updated the mock signature and existing \`setFont\` calls

## Caveats

Canvas-side support for the \`font-stretch\` shorthand component varies by browser; fonts without a matching face fall back to the nearest available one, consistent with CSS. The DOM path works everywhere.