### PR TITLE
Underline entire wrapped OSC 8 links on hover

### DIFF
--- a/src/browser/Linkifier.test.ts
+++ b/src/browser/Linkifier.test.ts
@@ -43,6 +43,20 @@ describe('Linkifier2', () => {
     },
     activate: () => { }
   };
+  const multiLineLink: ILink = {
+    text: 'foo',
+    range: {
+      start: {
+        x: 2,
+        y: 1
+      },
+      end: {
+        x: 4,
+        y: 2
+      }
+    },
+    activate: () => { }
+  };
 
   beforeEach(() => {
     const dom = new jsdom.JSDOM();
@@ -84,6 +98,32 @@ describe('Linkifier2', () => {
     });
 
     linkifier.linkLeave({ classList: { add: () => { } } } as any, link, {} as any);
+  });
+
+  it('onShowLinkUnderline event range is correct for wrapped links', done => {
+    linkifier.onShowLinkUnderline(e => {
+      assert.equal(multiLineLink.range.start.x - 1, e.x1);
+      assert.equal(multiLineLink.range.start.y - 1, e.y1);
+      assert.equal(multiLineLink.range.end.x, e.x2);
+      assert.equal(multiLineLink.range.end.y - 1, e.y2);
+
+      done();
+    });
+
+    linkifier.linkHover({ classList: { add: () => { } } } as any, multiLineLink, {} as any);
+  });
+
+  it('onHideLinkUnderline event range is correct for wrapped links', done => {
+    linkifier.onHideLinkUnderline(e => {
+      assert.equal(multiLineLink.range.start.x - 1, e.x1);
+      assert.equal(multiLineLink.range.start.y - 1, e.y1);
+      assert.equal(multiLineLink.range.end.x, e.x2);
+      assert.equal(multiLineLink.range.end.y - 1, e.y2);
+
+      done();
+    });
+
+    linkifier.linkLeave({ classList: { add: () => { } } } as any, multiLineLink, {} as any);
   });
 
 });

--- a/src/browser/OscLinkProvider.test.ts
+++ b/src/browser/OscLinkProvider.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { OscLinkProvider } from 'browser/OscLinkProvider';
+import { ILink } from 'browser/Types';
+import { createCellData, MockBufferService, MockOptionsService } from 'common/TestUtils.test';
+import { IBufferService, IOscLinkService } from 'common/services/Services';
+import { IBufferLine, IOscLinkData } from 'common/Types';
+
+class TestOscLinkService implements IOscLinkService {
+  public serviceBrand: any;
+  public registerLink(_linkData: IOscLinkData): number { return 0; }
+  public addLineToLink(_linkId: number, _y: number): void { }
+  public getLinkData(linkId: number): IOscLinkData | undefined {
+    return { uri: `https://example.com/${linkId}` };
+  }
+}
+
+function setText(line: IBufferLine | undefined, x: number, text: string): void {
+  if (!line) {
+    throw new Error('Missing buffer line');
+  }
+  for (let i = 0; i < text.length; i++) {
+    line.setCell(x + i, createCellData(0, text[i], 1));
+  }
+}
+
+function setUrl(line: IBufferLine | undefined, x: number, text: string, linkId: number): void {
+  if (!line) {
+    throw new Error('Missing buffer line');
+  }
+  for (let i = 0; i < text.length; i++) {
+    const cell = createCellData(0, text[i], 1);
+    cell.extended.urlId = linkId;
+    cell.updateExtended();
+    line.setCell(x + i, cell);
+  }
+}
+
+function getLinks(provider: OscLinkProvider, y: number): Promise<ILink[]> {
+  return new Promise(resolve => provider.provideLinks(y, links => resolve(links ?? [])));
+}
+
+describe('OscLinkProvider', () => {
+  let bufferService: IBufferService;
+  let provider: OscLinkProvider;
+
+  beforeEach(() => {
+    const optionsService = new MockOptionsService();
+    bufferService = new MockBufferService(5, 5, optionsService);
+    provider = new OscLinkProvider(bufferService, optionsService, new TestOscLinkService());
+  });
+
+  it('expands a wrapped link range backward to the previous line', async () => {
+    const line1 = bufferService.buffer.lines.get(0);
+    const line2 = bufferService.buffer.lines.get(1);
+    setText(line1, 0, 'aa');
+    setUrl(line1, 2, 'bbb', 1);
+    setUrl(line2, 0, 'cccc', 1);
+    setText(line2, 4, 'x');
+    line2!.isWrapped = true;
+
+    const links = await getLinks(provider, 2);
+    assert.lengthOf(links, 1);
+    assert.deepEqual(links[0].range, {
+      start: { x: 3, y: 1 },
+      end: { x: 4, y: 2 }
+    });
+  });
+
+  it('expands a wrapped link range forward when a link ends at line boundary', async () => {
+    const line1 = bufferService.buffer.lines.get(0);
+    const line2 = bufferService.buffer.lines.get(1);
+    setUrl(line1, 0, 'aaaaa', 1);
+    setUrl(line2, 0, 'bb', 1);
+    setText(line2, 2, 'ccc');
+    line2!.isWrapped = true;
+
+    const links = await getLinks(provider, 1);
+    assert.lengthOf(links, 1);
+    assert.deepEqual(links[0].range, {
+      start: { x: 1, y: 1 },
+      end: { x: 2, y: 2 }
+    });
+  });
+
+  it('does not merge wrapped links with different url ids', async () => {
+    const line1 = bufferService.buffer.lines.get(0);
+    const line2 = bufferService.buffer.lines.get(1);
+    setUrl(line1, 0, 'aaaaa', 1);
+    setUrl(line2, 0, 'bbb', 2);
+    setText(line2, 3, 'cc');
+    line2!.isWrapped = true;
+
+    const links = await getLinks(provider, 1);
+    assert.lengthOf(links, 1);
+    assert.deepEqual(links[0].range, {
+      start: { x: 1, y: 1 },
+      end: { x: 5, y: 1 }
+    });
+  });
+});

--- a/src/browser/OscLinkProvider.ts
+++ b/src/browser/OscLinkProvider.ts
@@ -6,6 +6,7 @@
 import { IBufferRange, ILink } from 'browser/Types';
 import { ILinkProvider } from 'browser/services/Services';
 import { CellData } from 'common/buffer/CellData';
+import { IBufferLine } from 'common/Types';
 import { IBufferService, IOptionsService, IOscLinkService } from 'common/services/Services';
 
 export class OscLinkProvider implements ILinkProvider {
@@ -57,19 +58,8 @@ export class OscLinkProvider implements ILinkProvider {
       if (finishLink || (currentStart !== -1 && x === lineLength - 1)) {
         const text = this._oscLinkService.getLinkData(currentLinkId)?.uri;
         if (text) {
-          // These ranges are 1-based
-          const range: IBufferRange = {
-            start: {
-              x: currentStart + 1,
-              y
-            },
-            end: {
-              // Offset end x if it's a link that ends on the last cell in the line
-              x: x + (!finishLink && x === lineLength - 1 ? 1 : 0),
-              y
-            }
-          };
-
+          const endX = x + (!finishLink && x === lineLength - 1 ? 1 : 0);
+          const range = this._getRangeWithLineWrap(y, currentStart, endX, currentLinkId);
           let ignoreLink = false;
           if (!linkHandler?.allowNonHttpProtocols) {
             try {
@@ -110,6 +100,82 @@ export class OscLinkProvider implements ILinkProvider {
     // TODO: Handle fetching and returning other link ranges to underline other links with the same
     //       id
     callback(result);
+  }
+
+  /**
+   * Expand a single-line OSC 8 range to a contiguous wrapped range for the same link id.
+   */
+  private _getRangeWithLineWrap(y: number, startX: number, endX: number, linkId: number): IBufferRange {
+    let startY = y;
+    let finalStartX = startX;
+    let endY = y;
+    let finalEndX = endX;
+
+    // Expand upward only when this segment starts at column 0 and the current line is wrapped.
+    while (finalStartX === 0) {
+      const currentLine = this._bufferService.buffer.lines.get(startY - 1);
+      if (!currentLine?.isWrapped) {
+        break;
+      }
+      const previousLine = this._bufferService.buffer.lines.get(startY - 2);
+      if (!previousLine) {
+        break;
+      }
+      const previousLineLength = previousLine.getTrimmedLength();
+      if (previousLineLength === 0 || !this._hasUrlId(previousLine, previousLineLength - 1, linkId)) {
+        break;
+      }
+      let previousStartX = previousLineLength - 1;
+      while (previousStartX > 0 && this._hasUrlId(previousLine, previousStartX - 1, linkId)) {
+        previousStartX--;
+      }
+      startY--;
+      finalStartX = previousStartX;
+    }
+
+    // Expand downward only when this segment reaches trimmed EOL and the next line is wrapped.
+    while (true) {
+      const currentLine = this._bufferService.buffer.lines.get(endY - 1);
+      if (!currentLine) {
+        break;
+      }
+      const currentLineLength = currentLine.getTrimmedLength();
+      if (finalEndX !== currentLineLength) {
+        break;
+      }
+      const nextLine = this._bufferService.buffer.lines.get(endY);
+      if (!nextLine?.isWrapped) {
+        break;
+      }
+      const nextLineLength = nextLine.getTrimmedLength();
+      if (nextLineLength === 0 || !this._hasUrlId(nextLine, 0, linkId)) {
+        break;
+      }
+      let nextEndX = 1;
+      while (nextEndX < nextLineLength && this._hasUrlId(nextLine, nextEndX, linkId)) {
+        nextEndX++;
+      }
+      endY++;
+      finalEndX = nextEndX;
+    }
+
+    // IBufferRange uses 1-based coordinates.
+    return {
+      start: {
+        x: finalStartX + 1,
+        y: startY
+      },
+      end: {
+        x: finalEndX,
+        y: endY
+      }
+    };
+  }
+
+  private _hasUrlId(line: IBufferLine, x: number, linkId: number): boolean {
+    const cell = this._workCell;
+    line.loadCell(x, cell);
+    return !!cell.hasExtendedAttrs() && cell.extended.urlId === linkId;
   }
 }
 


### PR DESCRIPTION
Partially addresses #4006 

This PR fixes OSC 8 hyperlink hover feedback when a link wraps across lines. Previously, only the hovered line segment switched to solid underline. Now, hovering any wrapped segment underlines the full contiguous wrapped link range.

**Without fix:**

https://github.com/user-attachments/assets/c9cc63c3-3c7d-4a40-baea-bf77dbd8e2f9

**With fix:**

https://github.com/user-attachments/assets/9c095383-5426-4a4c-9846-1b6c9ccbabbe

### What changed
- Expand OSC 8 link ranges in `OscLinkProvider` across wrapped neighbouring lines when `urlId` is continuous.
- Keep existing link activation/filtering behaviour unchanged.
