### PR TITLE
Use element window instead of global object

### DIFF
--- a/src/browser/services/MouseCoordsService.ts
+++ b/src/browser/services/MouseCoordsService.ts
@@ -18,7 +18,7 @@ export class MouseCoordsService implements IMouseCoordsService {
 
   public getCoords(event: {clientX: number, clientY: number}, element: HTMLElement, colCount: number, rowCount: number, isSelection?: boolean): [number, number] | undefined {
     return getCoords(
-      window,
+      getWindow(element),
       event,
       element,
       colCount,


### PR DESCRIPTION
If xterm is running in another frame than its dom, `window.getComputedStyle` returns an empty object in Firefox, which completely breaks the user selections