### PR TITLE
Fix dispose leaks: register CursorBlinkStateManager + _pausedResizeTask

### DIFF
--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -30,7 +30,7 @@ import { createRenderDimensions } from 'browser/renderer/shared/RendererUtils';
 
 export class WebglRenderer extends Disposable implements IRenderer {
   private _renderLayers: IRenderLayer[];
-  private _cursorBlinkStateManager: MutableDisposable<CursorBlinkStateManager> = new MutableDisposable();
+  private _cursorBlinkStateManager: MutableDisposable<CursorBlinkStateManager> = this._register(new MutableDisposable());
   private _textBlinkStateManager: TextBlinkStateManager;
   private _charAtlasDisposable = this._register(new MutableDisposable());
   private _charAtlas: ITextureAtlas | undefined;

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -68,7 +68,7 @@ export class RenderService extends Disposable implements IRenderService {
   ) {
     super();
 
-    this._pausedResizeTask = new DebouncedIdleTask(this._logService);
+    this._pausedResizeTask = this._register(new DebouncedIdleTask(this._logService));
 
     this._renderDebouncer = new RenderDebouncer((start, end) => this._renderRows(start, end), this._coreBrowserService);
     this._register(this._renderDebouncer);

--- a/src/common/TaskQueue.ts
+++ b/src/common/TaskQueue.ts
@@ -168,4 +168,8 @@ export class DebouncedIdleTask {
   public flush(): void {
     this._queue.flush();
   }
+
+  public dispose(): void {
+    this._queue.clear();
+  }
 }


### PR DESCRIPTION
Fixes #5818.

Three small edits that add missing `this._register(...)` wrappers to disposables that were created but never registered. Full problem description with heap-snapshot evidence in the linked issue.

### Diff

```
 addons/addon-webgl/src/WebglRenderer.ts | 2 +-
 src/browser/services/RenderService.ts   | 2 +-
 src/common/TaskQueue.ts                 | 4 ++++
 3 files changed, 6 insertions(+), 2 deletions(-)
```

### Downstream verification

Reproduced in kolu (SolidJS + xterm.js terminal workspace) with a Focus ↔ Canvas layout toggle that synchronously remounts all `<Terminal>` components:

| Stage                                         | Retained disposed xterm Terminals |
| --------------------------------------------- | --------------------------------- |
| Pre-fix (after forced GC)                     | 24 / 28                           |
| After downstream-only workaround              | 6 / 28                            |
| **After this PR** (no downstream workaround)  | 0 / 28                            |

Downstream PR exercising the fork via git-URL override (and passing CI across both the host typecheck and full Nix build): juspay/kolu#609.

### Risk

Zero behavior change for hosts that already dispose the renderer correctly — this PR just ensures disposal actually propagates where it was already intended to. The three edits follow the same pattern as surrounding sibling fields in each file.

Happy to address any feedback. Thanks for xterm.js.