### PR TITLE
Hold this via WeakRef in IntersectionObserver callback

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -124,9 +124,25 @@ export class RenderService extends Disposable implements IRenderService {
 
   private _registerIntersectionObserver(w: Window & typeof globalThis, screenElement: HTMLElement): void {
     // Detect whether IntersectionObserver is detected and enable renderer pause
-    // and resume based on terminal visibility if so
+    // and resume based on terminal visibility if so.
+    //
+    // The callback closes over a WeakRef to `this` rather than a strong
+    // reference. Even though `_observerDisposable` calls `observer.disconnect()`
+    // on disposal, in practice some browser-side (or devtools/extension-side)
+    // registries retain the callback past disconnect — the retained closure
+    // then keeps `this` (RenderService) alive, which transitively keeps
+    // `_coreService → _bufferService → buffers → BufferLines → Uint32Array`
+    // alive. Each leaked terminal was pinning ~1.3 KB × scrollback-lines of
+    // cell data, producing hundreds of MB of retained native buffer bytes
+    // across mode-toggle churn. WeakRef lets the RenderService (and hence
+    // its service graph and BufferLines) GC even if the callback itself
+    // is retained.
     if ('IntersectionObserver' in w) {
-      const observer = new w.IntersectionObserver(e => this._handleIntersectionChange(e[e.length - 1]), { threshold: 0 });
+      const weakSelf = new WeakRef(this);
+      const observer = new w.IntersectionObserver(
+        e => weakSelf.deref()?._handleIntersectionChange(e[e.length - 1]),
+        { threshold: 0 }
+      );
       observer.observe(screenElement);
       this._observerDisposable.value = toDisposable(() => observer.disconnect());
     }


### PR DESCRIPTION
## Summary

Fix for #5820. `RenderService._registerIntersectionObserver` creates an `IntersectionObserver` whose callback closes over `this` directly. Although `_observerDisposable` calls `observer.disconnect()` on dispose, the retained callback chain keeps `this` (RenderService) alive in practice — along with `_coreService → _bufferService → buffers → BufferLine → Uint32Array` cell data.

Wrap `this` in a `WeakRef`. While RenderService is alive, `deref()` returns it and the handler runs unchanged. Once no strong refs remain, the callback becomes a no-op and the BufferService graph can GC.

## Evidence (from #5820)

Heap-snapshot diff across 30 mount/unmount cycles of 7 `Terminal` instances in a multi-tile app:

| Class | Δ count | Δ bytes |
|---|---|---|
| `native:system / JSArrayBufferData` | +175,594 | **+220 MB** |
| `object:Uint32Array` | +175,594 | +10 MB |
| `object:ArrayBuffer` | +175,594 | +9 MB |
| `object:BufferLine` | +175,594 | +5 MB |

Every retained `Uint32Array` traced to the same retainer chain — global `IntersectionObserver` registry → callback closure → `RenderService` → service graph → BufferLines. After the WeakRef fix, production-equivalent local testing shows Memory Footprint flat across 30 mode-toggles (was +367 MB/30-toggles before).

## Why not just fix `disconnect()`?

Unclear why `observer.disconnect()` isn't releasing the callback in the observed environment — could be DevTools instrumentation, a Chrome extension patching `window.IntersectionObserver`, a native registry quirk, or something else. The WeakRef wrap is a defensive fix that breaks the retention chain regardless of the underlying cause and preserves functional semantics exactly.

## Test

No behavioral change to validate beyond existing renderer-pause-on-visibility tests. A regression would manifest as the pause handler not firing when visibility changes; while RenderService is strongly rooted (which it is for any live terminal), `deref()` always returns the instance.

Closes #5820
