### PR TITLE
Fix text-producing keys in Kitty keyboard REPORT_EVENT_TYPES mode

### DIFF
--- a/src/common/input/KittyKeyboard.test.ts
+++ b/src/common/input/KittyKeyboard.test.ts
@@ -453,9 +453,21 @@ describe('KittyKeyboard', () => {
     describe('event types (press/repeat/release)', () => {
       const flags = KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES | KittyKeyboardFlags.REPORT_EVENT_TYPES;
 
-      it('press event (default, no suffix)', () => {
+      it('text-producing key uses legacy encoding in REPORT_EVENT_TYPES mode', () => {
+        // Per spec: "In report event types mode, function keys are encoded as CSI u...
+        // all other keys are encoded in legacy mode"
         const result = kitty.evaluate(createEvent({ key: 'a' }), flags, KittyKeyboardEventType.PRESS);
-        assert.strictEqual(result.key, '\x1b[97u');
+        assert.strictEqual(result.key, 'a');
+      });
+
+      it('Shift+1 (text-producing) sends character in PRESS, CSI u in RELEASE', () => {
+        // Regression test for issue where Shift+1 was not sending '!' character
+        // PRESS event should send the character
+        const pressResult = kitty.evaluate(createEvent({ key: '!', code: 'Digit1', shiftKey: true }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(pressResult.key, '!');
+        // RELEASE event should send CSI u sequence
+        const releaseResult = kitty.evaluate(createEvent({ key: '!', code: 'Digit1', shiftKey: true }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(releaseResult.key, '\x1b[49;2:3u');
       });
 
       it('press event explicit :1 when modifiers present', () => {

--- a/src/common/input/KittyKeyboard.ts
+++ b/src/common/input/KittyKeyboard.ts
@@ -478,7 +478,24 @@ export class KittyKeyboard {
     if (flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES) {
       useCsiU = true;
     } else if (reportEventTypes) {
-      useCsiU = true;
+      // In REPORT_EVENT_TYPES mode:
+      // - Function keys always use CSI u (for all event types)
+      // - Text-producing keys use legacy encoding for plain PRESS, but CSI u for:
+      //   - PRESS with modifiers (except plain Shift)
+      //   - REPEAT and RELEASE events
+      if (isFunc) {
+        useCsiU = true;
+      } else {
+        // For text-producing keys
+        if (eventType !== KittyKeyboardEventType.PRESS) {
+          // REPEAT and RELEASE always use CSI u
+          useCsiU = true;
+        } else if (modifiers > 0) {
+          // PRESS with modifiers uses CSI u, except for plain Shift
+          const plainShiftOnly = ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.key.length === 1;
+          useCsiU = !plainShiftOnly;
+        }
+      }
     } else if (flags & KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES) {
       // Per spec, Enter/Tab/Backspace "still generate the same bytes as in legacy
       // mode" and consider space to be a text-generating key, so these skip the isFunc fast-path


### PR DESCRIPTION
Attempt to fix #5823 

In REPORT_EVENT_TYPES mode (CSI > 3 u), text-producing keys like Shift+1 should send the actual character ('!') for PRESS events, not CSI u escape sequences. Only REPEAT and RELEASE events should use CSI u for text-producing keys, while function keys use CSI u for all event types.

Fixes issue where Shift+1 was not outputting '!' character.