### PR TITLE
refactor: add Params.resetZdm() to avoid double call on foreign object

### DIFF
--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -462,8 +462,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
     this._oscParser.reset();
     this._dcsParser.reset();
     this._apcParser.reset();
-    this._params.reset();
-    this._params.addParam(0); // ZDM
+    this._params.resetZdm();
     this._collect = 0;
     this.precedingJoinState = 0;
     // abort pending continuation from async handler
@@ -612,8 +611,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
               return handlerResult;
             }
             if (code === 0x1b) this._parseStack.transition |= ParserState.ESCAPE;
-            this._params.reset();
-            this._params.addParam(0); // ZDM
+            this._params.resetZdm();
             this._collect = 0;
             break;
           case ParserStackType.OSC:
@@ -623,8 +621,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
               return handlerResult;
             }
             if (code === 0x1b) this._parseStack.transition |= ParserState.ESCAPE;
-            this._params.reset();
-            this._params.addParam(0); // ZDM
+            this._params.resetZdm();
             this._collect = 0;
             break;
           case ParserStackType.APC:
@@ -634,8 +631,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
               return handlerResult;
             }
             if (code === 0x1b) this._parseStack.transition |= ParserState.ESCAPE;
-            this._params.reset();
-            this._params.addParam(0); // ZDM
+            this._params.resetZdm();
             this._collect = 0;
             break;
         }
@@ -666,8 +662,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
         && this.currentState < ParserState.OSC_STRING
         && i + 2 < length && data[i + 1] === 0x5b
       ) {
-        this._params.reset();
-        this._params.addParam(0); // ZDM
+        this._params.resetZdm();
         this._collect = 0;
         let k = i + 2;
         let ch = data[k];
@@ -817,8 +812,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
           this.precedingJoinState = 0;
           break;
         case ParserAction.CLEAR:
-          this._params.reset();
-          this._params.addParam(0); // ZDM
+          this._params.resetZdm();
           this._collect = 0;
           break;
         case ParserAction.DCS_HOOK:
@@ -842,8 +836,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
             return handlerResult;
           }
           if (code === 0x1b) transition |= ParserState.ESCAPE;
-          this._params.reset();
-          this._params.addParam(0); // ZDM
+          this._params.resetZdm();
           this._collect = 0;
           this.precedingJoinState = 0;
           break;
@@ -867,8 +860,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
             return handlerResult;
           }
           if (code === 0x1b) transition |= ParserState.ESCAPE;
-          this._params.reset();
-          this._params.addParam(0); // ZDM
+          this._params.resetZdm();
           this._collect = 0;
           this.precedingJoinState = 0;
           break;
@@ -892,8 +884,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
             return handlerResult;
           }
           if (code === 0x1b) transition |= ParserState.ESCAPE;
-          this._params.reset();
-          this._params.addParam(0); // ZDM
+          this._params.resetZdm();
           this._collect = 0;
           this.precedingJoinState = 0;
           break;

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -130,6 +130,19 @@ export class Params implements IParams {
   }
 
   /**
+   * Reset and add 0 as first param (ZDM).
+   */
+  public resetZdm(): void {
+    this.length = 1;
+    this._subParamsLength = 0;
+    this._rejectDigits = false;
+    this._rejectSubDigits = false;
+    this._digitIsSub = false;
+    this._subParamsIdx[0] = 0;
+    this.params[0] = 0;
+  }
+
+  /**
    * Add a parameter value.
    * `Params` only stores up to `maxLength` parameters, any later
    * parameter will be ignored.

--- a/src/common/parser/Types.ts
+++ b/src/common/parser/Types.ts
@@ -32,6 +32,7 @@ export interface IParams {
   clone(): IParams;
   toArray(): ParamsArray;
   reset(): void;
+  resetZdm(): void;
   addParam(value: number): void;
   addSubParam(value: number): void;
   hasSubParams(idx: number): boolean;


### PR DESCRIPTION
Follow-up from #5825, collapses the `reset()` + `addParam(0)` pattern into a single `resetZdm()` method on `Params`.

The parser calls this pair 10 times across different code paths. Having it as one method avoids two separate calls to a foreign object per sequence reset.

No perf change expected (confirmed with benchmarks), just a cleanup.