### PR TITLE
Clear IntersectionObserver reference on dispose

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -29,6 +29,7 @@ export class RenderService extends Disposable implements IRenderService {
   private _renderDebouncer: IRenderDebouncerWithCallback;
   private _pausedResizeTask: DebouncedIdleTask;
   private _observerDisposable = this._register(new MutableDisposable());
+  private _intersectionObserver: IntersectionObserver | undefined;
 
   private _isPaused: boolean = false;
   private _needsFullRefresh: boolean = false;
@@ -127,8 +128,12 @@ export class RenderService extends Disposable implements IRenderService {
     // and resume based on terminal visibility if so
     if ('IntersectionObserver' in w) {
       const observer = new w.IntersectionObserver(e => this._handleIntersectionChange(e[e.length - 1]), { threshold: 0 });
+      this._observerDisposable.value = toDisposable(() => {
+        this._intersectionObserver?.disconnect();
+        this._intersectionObserver = undefined;
+      });
+      this._intersectionObserver = observer;
       observer.observe(screenElement);
-      this._observerDisposable.value = toDisposable(() => observer.disconnect());
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the IntersectionObserver retention path from #5820 without using `WeakRef`.

`RenderService._registerIntersectionObserver` currently creates an observer whose callback closes over `this`. The disposable disconnects the observer, but the disposable closure also keeps a JS reference to the observer. Since the observer owns its callback, the disposed `RenderService` can remain reachable through:

`RenderService -> MutableDisposable -> disposable closure -> IntersectionObserver -> callback -> RenderService`

Store the observer on `RenderService` instead, and have the disposable disconnect and null out that field. The disposable no longer captures the observer object, so after dispose there is no JS-land reference from the disposed service back to the observer/callback pair.

This is an alternative to #5821's `WeakRef` version.

## Evidence

Kolu reproduced the original leak on the pre-#617 UI and compared three arms in Chrome DevTools MCP. Each arm used a fresh `just dev`, 7 terminals created/restored through the UI, and 30 Focus<->Canvas round trips via the visible header toggle.

| Arm | xterm variant | xterm buffer retention delta / 30 toggles |
|---|---|---:|
| A | unpatched baseline, pre-#5821 | `Uint32Array +339`, `JSArrayBufferData +339` |
| B | #5821 WeakRef fix | `Uint32Array +0`, `JSArrayBufferData +0` |
| C | this observer-nullify variant | `Uint32Array +0`, `JSArrayBufferData +0` |

The baseline reproduced the retained xterm-buffer signature. Both WeakRef and this observer-nullify variant retained zero additional xterm buffer arrays.

Caveat: this MCP run did not reproduce the original +367 MB magnitude because the clean UI-created/restored terminals had only ~118 scrollback rows instead of the large restored buffers from the production repro. The retention signature still distinguishes the baseline from both fixes.

## Test

- `npm run lint-changes`

Closes #5820
