### PR TITLE
fix: iOS Chinese IMEs cannot input punctuation (including space)

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -952,6 +952,8 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       return;
     }
 
+    this._compositionHelper?.keyup(ev);
+
     if (!wasModifierKeyOnlyEvent(ev)) {
       this.focus();
     }

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -3,12 +3,13 @@
  * @license MIT
  */
 
-import { MockCompositionHelper, MockRenderer, MockViewport, TestTerminal } from 'browser/TestUtils.test';
+import { CompositionHelper } from 'browser/input/CompositionHelper';
+import { MockCompositionHelper, MockRenderer, MockRenderService, MockViewport, TestTerminal } from 'browser/TestUtils.test';
 import type { IBrowser } from 'browser/Types';
 import { assert } from 'chai';
 import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
 import { CellData } from 'common/buffer/CellData';
-import { MockUnicodeService, createCellData } from 'common/TestUtils.test';
+import { MockBufferService, MockOptionsService, MockUnicodeService, createCellData } from 'common/TestUtils.test';
 import { IMarker } from 'common/Types';
 
 const INIT_COLS = 80;
@@ -172,6 +173,87 @@ describe('Terminal', () => {
       term.reset();
       assert.equal(term.keyDown(evKeyDown), false);
       assert.equal(term.keyPress(evKeyPress), false);
+    });
+  });
+
+  describe('keyup handling', () => {
+    const create229KeyboardEvent = (type: 'keydown' | 'keyup'): KeyboardEvent => ({
+      type,
+      key: '。',
+      keyCode: 229
+    } as KeyboardEvent);
+
+    const createCompositionHelperStub = (onKeyup: () => void): MockCompositionHelper => {
+      const compositionHelper = new MockCompositionHelper();
+      compositionHelper.keyup = () => onKeyup();
+      return compositionHelper;
+    };
+
+    const setupRealCompositionHelper = (): HTMLTextAreaElement => {
+      const textarea = {
+        value: '',
+        focus: () => {},
+        blur: () => {},
+        style: {
+          left: 0,
+          top: 0
+        }
+      } as any as HTMLTextAreaElement;
+      const compositionView = {
+        classList: {
+          add: () => {},
+          remove: () => {}
+        },
+        getBoundingClientRect: () => ({ width: 0, height: 0 }),
+        style: {
+          left: 0,
+          top: 0
+        },
+        textContent: ''
+      } as any;
+      (term as any).textarea = textarea;
+      (term as any)._compositionHelper = new CompositionHelper(
+        textarea,
+        compositionView,
+        new MockBufferService(10, 5),
+        new MockOptionsService(),
+        term.coreService as any,
+        new MockRenderService()
+      );
+      return textarea;
+    };
+
+    it('should forward keyup event to composition helper', () => {
+      let keyupCalls = 0;
+      (term as any)._compositionHelper = createCompositionHelperStub(() => keyupCalls++);
+
+      term.keyUp(create229KeyboardEvent('keyup'));
+
+      assert.equal(keyupCalls, 1);
+    });
+
+    it('should not forward keyup event when custom keyup handler returns false', () => {
+      let keyupCalls = 0;
+      (term as any)._compositionHelper = createCompositionHelperStub(() => keyupCalls++);
+      term.attachCustomKeyEventHandler(ev => ev.type !== 'keyup');
+
+      term.keyUp(create229KeyboardEvent('keyup'));
+
+      assert.equal(keyupCalls, 0);
+    });
+
+    it('should emit pending keyCode 229 input on keyup when key matches', () => {
+      const calls: string[] = [];
+      (term.coreService as any).triggerDataEvent = (data: string) => calls.push(data);
+      const textarea = setupRealCompositionHelper();
+
+      term.keyDown(create229KeyboardEvent('keydown'));
+      assert.deepEqual(calls, []);
+
+      textarea.value = '。';
+      term.keyUp(create229KeyboardEvent('keyup'));
+
+      assert.deepEqual(calls, ['。']);
     });
   });
 

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -23,6 +23,7 @@ import { Emitter, type IEvent } from 'common/Event';
 export class TestTerminal extends CoreBrowserTerminal {
   public get curAttrData(): IAttributeData { return (this as any)._inputHandler._curAttrData; }
   public keyDown(ev: any): boolean | undefined { return this._keyDown(ev); }
+  public keyUp(ev: any): void { this._keyUp(ev); }
   public keyPress(ev: any): boolean { return this._keyPress(ev); }
   public writeP(data: string | Uint8Array): Promise<void> {
     return new Promise(r => this.write(data, r));
@@ -358,6 +359,8 @@ export class MockCompositionHelper implements ICompositionHelper {
   }
   public keydown(ev: KeyboardEvent): boolean {
     return true;
+  }
+  public keyup(ev: KeyboardEvent): void {
   }
 }
 

--- a/src/browser/Types.ts
+++ b/src/browser/Types.ts
@@ -43,6 +43,7 @@ export interface ICompositionHelper {
   compositionend(): void;
   updateCompositionElements(dontRecurse?: boolean): void;
   keydown(ev: KeyboardEvent): boolean;
+  keyup(ev: KeyboardEvent): void;
 }
 
 export interface IBrowser {

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -6,6 +6,7 @@
 import { assert } from 'chai';
 import { CompositionHelper } from 'browser/input/CompositionHelper';
 import { MockRenderService } from 'browser/TestUtils.test';
+import { C0 } from 'common/data/EscapeSequences';
 import { MockCoreService, MockBufferService, MockOptionsService } from 'common/TestUtils.test';
 
 describe('CompositionHelper', () => {
@@ -13,6 +14,20 @@ describe('CompositionHelper', () => {
   let compositionView: HTMLElement;
   let textarea: HTMLTextAreaElement;
   let handledText: string;
+  const nextTick = (callback: () => void): void => {
+    setTimeout(callback, 0);
+  };
+  const keydown229 = (key: string): boolean => compositionHelper.keydown({ keyCode: 229, key } as KeyboardEvent);
+  const keyup229 = (key: string): void => compositionHelper.keyup({ keyCode: 229, key } as KeyboardEvent);
+  const startPending229 = (oldValue: string, key = 'x'): void => {
+    textarea.value = oldValue;
+    assert.equal(keydown229(key), false);
+  };
+  const applyPending229Change = (oldValue: string, newValue: string, key = 'x'): void => {
+    startPending229(oldValue, key);
+    textarea.value = newValue;
+    keyup229(key);
+  };
 
   beforeEach(() => {
     compositionView = {
@@ -258,6 +273,209 @@ describe('CompositionHelper', () => {
           done();
         }, 0);
       }, 0);
+    });
+
+    it('Should handle keyCode 229 on keyup when key matches', () => {
+      textarea.value = '';
+      assert.equal(keydown229('。'), false);
+      textarea.value = '。';
+
+      keyup229('。');
+
+      assert.equal(handledText, '。');
+    });
+
+    it('Should allow keyup with a different key value and still emit from keydown path', (done) => {
+      textarea.value = '';
+      assert.equal(keydown229('。'), false);
+      textarea.value = '。';
+
+      keyup229('x');
+
+      nextTick(() => {
+        assert.equal(handledText, '。');
+        done();
+      });
+    });
+
+    it('Should emit precise DEL+insert on keyup for equal-length replacements in pending keyCode 229 path', (done) => {
+      applyPending229Change('ab', 'ac');
+
+      assert.equal(handledText, `${C0.DEL}c`);
+      nextTick(() => {
+        done();
+      });
+    });
+
+    it('Should emit precise DEL+insert on timer for equal-length replacements in pending keyCode 229 path', (done) => {
+      startPending229('ab');
+      textarea.value = 'ac';
+
+      nextTick(() => {
+        assert.equal(handledText, `${C0.DEL}c`);
+        done();
+      });
+    });
+
+    it('Should emit prefix-based DEL+insert for mid-string replacement', () => {
+      applyPending229Change('abcde', 'abXYde');
+
+      assert.equal(handledText, `${C0.DEL.repeat(3)}XYde`);
+    });
+
+    it('Should emit only inserted text for append-only changes', () => {
+      applyPending229Change('ab', 'abXYZ');
+
+      assert.equal(handledText, 'XYZ');
+    });
+
+    it('Should emit single DEL and cache new value on shrink', () => {
+      applyPending229Change('abc', 'a');
+
+      assert.equal(handledText, `${C0.DEL}`);
+      assert.equal((compositionHelper as any)._dataAlreadySent, 'a');
+    });
+
+    it('Should not emit when baseline and textarea value are unchanged', (done) => {
+      applyPending229Change('same', 'same');
+      assert.equal(handledText, '');
+      nextTick(() => {
+        assert.equal(handledText, '');
+        done();
+      });
+    });
+
+    it('Should emit pending keyCode 229 data from earliest baseline', (done) => {
+      textarea.value = 'x';
+      assert.equal(keydown229('。'), false);
+      textarea.value = 'xy';
+      assert.equal(keydown229('，'), false);
+      textarea.value = 'xy，';
+
+      keyup229('，');
+
+      nextTick(() => {
+        assert.equal(handledText, 'y，');
+        done();
+      });
+    });
+
+    it('Should create only one timer for repeated keyCode 229 keydown', () => {
+      const originalSetTimeout = globalThis.setTimeout;
+      let scheduled = 0;
+      (globalThis as any).setTimeout = () => {
+        scheduled++;
+        return 1;
+      };
+      try {
+        textarea.value = '';
+        assert.equal(keydown229('。'), false);
+        assert.equal(keydown229('，'), false);
+        assert.equal(keydown229('！'), false);
+        assert.equal(scheduled, 1);
+      } finally {
+        (globalThis as any).setTimeout = originalSetTimeout;
+      }
+    });
+
+    it('Should start a timer when keyCode 229 baseline exists but timer is missing', (done) => {
+      textarea.value = 'x';
+      assert.equal(keydown229('。'), false);
+
+      nextTick(() => {
+        assert.equal((compositionHelper as any)._pending229Baseline, 'x');
+        assert.equal((compositionHelper as any)._textareaChangeTimer, undefined);
+        assert.equal((compositionHelper as any)._pending229TimerFired, true);
+
+        assert.equal(keydown229('，'), false);
+        assert.notEqual((compositionHelper as any)._textareaChangeTimer, undefined);
+        assert.equal((compositionHelper as any)._pending229TimerFired, false);
+
+        keyup229('，');
+        nextTick(() => {
+          assert.equal((compositionHelper as any)._pending229Baseline, undefined);
+          done();
+        });
+      });
+    });
+
+    it('Should clear pending baseline after timer and keyup fire without data', (done) => {
+      textarea.value = 'x';
+      assert.equal(keydown229('。'), false);
+
+      nextTick(() => {
+        keyup229('。');
+        textarea.value = 'xyz';
+        assert.equal(keydown229('，'), false);
+        textarea.value = 'xyz，';
+        keyup229('，');
+
+        assert.equal(handledText, '，');
+        done();
+      });
+    });
+
+    it('Should allow keyup fallback when keydown 229 key is non-printable', (done) => {
+      textarea.value = '';
+      assert.equal(keydown229('Process'), false);
+
+      nextTick(() => {
+        textarea.value = '。';
+        keyup229('Unidentified');
+        assert.equal(handledText, '。');
+        done();
+      });
+    });
+
+    it('Should not emit pending keyCode 229 data after compositionstart', (done) => {
+      textarea.value = '';
+      assert.equal(keydown229('。'), false);
+      textarea.value = '。';
+
+      compositionHelper.compositionstart();
+
+      nextTick(() => {
+        assert.equal(handledText, '');
+        done();
+      });
+    });
+
+    it('Should cancel pending keyCode 229 keydown send on compositionend finalize after composition data is sent', (done) => {
+      textarea.value = '';
+      assert.equal(keydown229('。'), false);
+      nextTick(() => {
+        compositionHelper.compositionstart();
+        compositionHelper.compositionupdate({ data: 'x' });
+        textarea.value = 'x';
+        compositionHelper.compositionend();
+
+        nextTick(() => {
+          assert.equal(handledText, 'x');
+          assert.equal((compositionHelper as any)._pending229Baseline, undefined);
+          keyup229('。');
+          assert.equal(handledText, 'x');
+          done();
+        });
+      });
+    });
+
+    it('Should keep pending keyCode 229 keydown send on compositionend finalize when no composition data is sent', (done) => {
+      textarea.value = '';
+      assert.equal(keydown229('。'), false);
+      nextTick(() => {
+        compositionHelper.compositionstart();
+        compositionHelper.compositionupdate({ data: 'x' });
+        compositionHelper.compositionend();
+
+        nextTick(() => {
+          assert.equal(handledText, '');
+          assert.equal((compositionHelper as any)._pending229Baseline, '');
+          textarea.value = '。';
+          keyup229('。');
+          assert.equal(handledText, '。');
+          done();
+        });
+      });
     });
   });
 });

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -160,7 +160,8 @@ export class CompositionHelper {
   }
 
   /**
-   * Handles keyup for deferred keyCode=229 processing.
+   * Handles keyup for deferred keyCode=229 processing. Some IMEs do not expose the final
+   * non-composition character on keydown, and keyup serves as a reliable fallback.
    */
   public keyup(_ev: KeyboardEvent): void {
     this._flushPending229('keyup');

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -50,7 +50,20 @@ export class CompositionHelper {
   /**
    * The pending textarea change timer, if any.
    */
-  private _textareaChangeTimer?: number;
+  private _textareaChangeTimer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * Snapshot of textarea value captured when the current 229 pending cycle started.
+   */
+  private _pending229Baseline: string | undefined;
+  /**
+   * Whether the timeout fallback has executed for the current pending cycle.
+   */
+  private _pending229TimerFired: boolean;
+  /**
+   * Whether matching keyup has executed for the current pending cycle.
+   */
+  private _pending229KeyupFired: boolean;
 
   constructor(
     private readonly _textarea: HTMLTextAreaElement,
@@ -65,6 +78,10 @@ export class CompositionHelper {
     this._compositionPosition = { start: 0, end: 0 };
     this._compositionSuffix = '';
     this._dataAlreadySent = '';
+    this._textareaChangeTimer = undefined;
+    this._pending229Baseline = undefined;
+    this._pending229TimerFired = false;
+    this._pending229KeyupFired = false;
   }
 
   /**
@@ -131,11 +148,22 @@ export class CompositionHelper {
     if (ev.keyCode === 229) {
       // If the "composition character" is used but gets to this point it means a non-composition
       // character (eg. numbers and punctuation) was pressed when the IME was active.
-      this._handleAnyTextareaChanges();
+      if (this._pending229Baseline === undefined) {
+        this._pending229Baseline = this._textarea.value;
+        this._pending229KeyupFired = false;
+      }
+      this._ensurePending229Timer();
       return false;
     }
 
     return true;
+  }
+
+  /**
+   * Handles keyup for deferred keyCode=229 processing.
+   */
+  public keyup(_ev: KeyboardEvent): void {
+    this._flushPending229('keyup');
   }
 
   /**
@@ -154,7 +182,10 @@ export class CompositionHelper {
       // Cancel any delayed composition send requests and send the input immediately.
       this._isSendingComposition = false;
       const input = this._textarea.value.substring(this._compositionPosition.start, this._compositionPosition.end);
-      this._coreService.triggerDataEvent(input, true);
+      if (input.length > 0) {
+        this._clearPending229();
+        this._coreService.triggerDataEvent(input, true);
+      }
     } else {
       // Make a deep copy of the composition position here as a new compositionstart event may
       // fire before the setTimeout executes.
@@ -196,6 +227,7 @@ export class CompositionHelper {
             input = value.substring(currentCompositionPosition.start, Math.max(currentCompositionPosition.start, valueEnd));
           }
           if (input.length > 0) {
+            this._clearPending229();
             this._coreService.triggerDataEvent(input, true);
           }
         }
@@ -209,31 +241,75 @@ export class CompositionHelper {
    * character" (229) is triggered, in order to allow non-composition text to be entered when an
    * IME is active.
    */
-  private _handleAnyTextareaChanges(): void {
-    if (this._textareaChangeTimer) {
+  private _handleAnyTextareaChanges(oldValue: string): boolean {
+    const newValue = this._textarea.value;
+    if (newValue === oldValue) {
+      return false;
+    }
+    if (newValue.length < oldValue.length) {
+      this._dataAlreadySent = newValue;
+      this._coreService.triggerDataEvent(`${C0.DEL}`, true);
+      return true;
+    }
+
+    let commonPrefixLength = 0;
+    while (
+      commonPrefixLength < oldValue.length &&
+      commonPrefixLength < newValue.length &&
+      oldValue.charCodeAt(commonPrefixLength) === newValue.charCodeAt(commonPrefixLength)
+    ) {
+      commonPrefixLength++;
+    }
+
+    const removedCount = oldValue.length - commonPrefixLength;
+    const inserted = newValue.substring(commonPrefixLength);
+    const payload = `${C0.DEL.repeat(removedCount)}${inserted}`;
+
+    this._dataAlreadySent = inserted;
+    this._coreService.triggerDataEvent(payload, true);
+    return true;
+  }
+
+  private _flushPending229(source: 'timer' | 'keyup'): void {
+    const baseline = this._pending229Baseline;
+    if (baseline === undefined) {
       return;
     }
-    const oldValue = this._textarea.value;
-    this._textareaChangeTimer = window.setTimeout(() => {
+    // If a composition has started, cancel this cycle to avoid stale baseline.
+    if (this._isComposing) {
+      this._clearPending229();
+      return;
+    }
+    if (source === 'timer') {
+      this._pending229TimerFired = true;
+    } else {
+      this._pending229KeyupFired = true;
+    }
+    const dataSent = this._handleAnyTextareaChanges(baseline);
+    if (dataSent || (this._pending229TimerFired && this._pending229KeyupFired)) {
+      this._clearPending229();
+    }
+  }
+
+  private _ensurePending229Timer(): void {
+    if (this._textareaChangeTimer !== undefined) {
+      return;
+    }
+    this._pending229TimerFired = false;
+    this._textareaChangeTimer = setTimeout(() => {
       this._textareaChangeTimer = undefined;
-      // Ignore if a composition has started since the timeout
-      if (!this._isComposing) {
-        const newValue = this._textarea.value;
-
-        const diff = newValue.replace(oldValue, '');
-
-        this._dataAlreadySent = diff;
-
-        if (newValue.length > oldValue.length) {
-          this._coreService.triggerDataEvent(diff, true);
-        } else if (newValue.length < oldValue.length) {
-          this._coreService.triggerDataEvent(`${C0.DEL}`, true);
-        } else if ((newValue.length === oldValue.length) && (newValue !== oldValue)) {
-          this._coreService.triggerDataEvent(newValue, true);
-        }
-
-      }
+      this._flushPending229('timer');
     }, 0);
+  }
+
+  private _clearPending229(): void {
+    if (this._textareaChangeTimer !== undefined) {
+      clearTimeout(this._textareaChangeTimer);
+      this._textareaChangeTimer = undefined;
+    }
+    this._pending229Baseline = undefined;
+    this._pending229TimerFired = false;
+    this._pending229KeyupFired = false;
   }
 
   /**


### PR DESCRIPTION
Fixes #5835.

On iOS with Chinese IMEs, punctuation (including space) may not be sent to the terminal. The event sequence shows these characters are not reliably available at keydown time (`keyCode=229` path), but become observable after input updates and at keyup.

This patch adds a keyup fallback path for pending keyCode 229 handling so punctuation/space input can be delivered reliably, including the consecutive-space conversion case (delete-then-insert to `。`).