### PR TITLE
fix utf8 terminal benchmark

### DIFF
--- a/test/benchmark/Terminal.benchmark.ts
+++ b/test/benchmark/Terminal.benchmark.ts
@@ -44,7 +44,7 @@ perfContext('Terminal: ls -lR /usr/lib', () => {
     }
   });
 
-  perfContext('write/string/async', () => {
+  perfContext('write/string', () => {
     let terminal: CoreBrowserTerminal;
     before(() => {
       terminal = new CoreBrowserTerminal({ cols: 80, rows: 25, scrollback: 1000 });
@@ -55,13 +55,13 @@ perfContext('Terminal: ls -lR /usr/lib', () => {
     }, { fork: false }).showAverageThroughput();
   });
 
-  perfContext('write/Utf8/async', () => {
+  perfContext('write/utf8', () => {
     let terminal: CoreBrowserTerminal;
     before(() => {
       terminal = new CoreBrowserTerminal({ cols: 80, rows: 25, scrollback: 1000 });
     });
     new ThroughputRuntimeCase('', async () => {
-      await new Promise<void>(res => terminal.write(content, res));
+      await new Promise<void>(res => terminal.write(contentUtf8, res));
       return { payloadSize: contentUtf8.length };
     }, { fork: false }).showAverageThroughput();
   });


### PR DESCRIPTION
Fixes #5837.

Before:
```text
   Context "out-test/benchmark/Terminal.benchmark.js"
      Context "Terminal: ls -lR /usr/lib"
         Context "write/string"
            Case "#1" : 5 runs - average throughput: 28.23 MB/s
         Context "write/utf8"
            Case "#1" : 5 runs - average throughput: 28.70 MB/s
```

After:
```text
   Context "out-test/benchmark/Terminal.benchmark.js"
      Context "Terminal: ls -lR /usr/lib"
         Context "write/string"
            Case "#1" : 5 runs - average throughput: 27.98 MB/s
         Context "write/utf8"
            Case "#1" : 5 runs - average throughput: 33.17 MB/s
```