### PR TITLE
Fix keys getting swallowed when enabling only "Report event types"

### DIFF
--- a/src/common/input/KittyKeyboard.test.ts
+++ b/src/common/input/KittyKeyboard.test.ts
@@ -478,7 +478,7 @@ describe('KittyKeyboard', () => {
         assert.strictEqual(result.key, '\x7f');
       });
 
-      it('press event explicit :1 when modifiers present', () => {
+      it('press event when modifiers present', () => {
         const result = kitty.evaluate(createEvent({ key: 'a', ctrlKey: true }), flags, KittyKeyboardEventType.PRESS);
         assert.strictEqual(result.key, '\x1b[97;5u');
       });
@@ -551,6 +551,27 @@ describe('KittyKeyboard', () => {
       it('modifier key release includes its own bit cleared', () => {
         const result = kitty.evaluate(createEvent({ key: 'Shift', code: 'ShiftLeft', shiftKey: false }), flags | KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES, KittyKeyboardEventType.RELEASE);
         assert.strictEqual(result.key, '\x1b[57441;1:3u');
+      });
+    });
+
+    // Enabling REPORT_EVENT_TYPES without DISAMBIGUATE_ESCAPE_CODES doesn't really make sense and
+    // isn't specified in the spec, but press and repeat events shouldn't get swallowed.
+    describe('REPORT_EVENT_TYPES flag without DISAMBIGUATE_ESCAPE_CODES', () => {
+      const flags = KittyKeyboardFlags.REPORT_EVENT_TYPES;
+
+      it('press event is not swallowed when modifiers present', () => {
+        const result = kitty.evaluate(createEvent({ key: 'a', ctrlKey: true }), flags, KittyKeyboardEventType.PRESS);
+        assert.strictEqual(result.key, '\x1b[97;5u');
+      });
+
+      it('repeat event is not swallowed when modifiers present', () => {
+        const result = kitty.evaluate(createEvent({ key: 'a', ctrlKey: true }), flags, KittyKeyboardEventType.REPEAT);
+        assert.strictEqual(result.key, '\x1b[97;5:2u');
+      });
+
+      it('release event is reported as CSI u sequence', () => {
+        const result = kitty.evaluate(createEvent({ key: 'a', ctrlKey: true }), flags, KittyKeyboardEventType.RELEASE);
+        assert.strictEqual(result.key, '\x1b[97;5:3u');
       });
     });
 

--- a/src/common/input/KittyKeyboard.ts
+++ b/src/common/input/KittyKeyboard.ts
@@ -485,7 +485,10 @@ export class KittyKeyboard {
     const useCsiU = !!(
       flags & KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES ||
       (reportEventTypes && eventType === KittyKeyboardEventType.RELEASE) ||
-      (flags & KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES &&
+      // Enabling REPORT_EVENT_TYPES without DISAMBIGUATE_ESCAPE_CODES doesn't really make sense, so
+      // just make REPORT_EVENT_TYPES imply DISAMBIGUATE_ESCAPE_CODES here for simplicity.
+      // See: https://github.com/kovidgoyal/kitty/issues/9999
+      ((flags & KittyKeyboardFlags.DISAMBIGUATE_ESCAPE_CODES || reportEventTypes) &&
         (
           // Per spec, Enter/Tab/Backspace "still generate the same bytes as in legacy mode" and
           // consider space to be a text-generating key, so these skip the isFunc fast-path and only


### PR DESCRIPTION
Per kovidgoyal/kitty#9999, enabling "Report event types" without
"Disambiguate escape codes" doesn't really make sense, and terminals may
choose whatever behavior they think makes sense. However, keys shouldn't
get swallowed (which, after #5791, happens when the !useCsiU branch
cannot handle the event), so instead make "Report event types"
imply "Disambiguate escape codes".
