### PR TITLE
demo - indicate screen area size when non-auto

### DIFF
--- a/demo/client/components/window/optionsWindow.ts
+++ b/demo/client/components/window/optionsWindow.ts
@@ -252,6 +252,11 @@ export class OptionsWindow extends BaseWindow implements IControlWindow {
             input.value = 'auto';
             this._handlers.updateTerminalSize();
           }
+          const screenElement = document.querySelector('.xterm-screen');
+          if (screenElement instanceof HTMLElement) {
+            screenElement.style.outline = this._autoResize ? ''
+              : 'solid thin red';
+          }
         } else if (o === 'theme') {
           value = this._getTheme();
         }


### PR DESCRIPTION
In the demo, when the size is non-auto, there should be a clearer indication of the active window area. One way would be different background compared to the rest of the window, but that was a little trickier to figure out. So I did something that was simple for me: added a css `outline` style to the `xterm-screen` element. Others may prefer a different approach.