### PR TITLE
Fix webgl rendering corruption from atlas page merges

### DIFF
--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -373,6 +373,10 @@ export class GlyphRenderer extends Disposable {
 
   public setAtlas(atlas: ITextureAtlas): void {
     this._atlas = atlas;
+    this.invalidateAtlasTextures();
+  }
+
+  public invalidateAtlasTextures(): void {
     for (const glTexture of this._atlasTextures) {
       glTexture.version = -1;
     }

--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -358,7 +358,9 @@ export class GlyphRenderer extends Disposable {
     gl.bindBuffer(gl.ARRAY_BUFFER, this._attributesBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, activeBuffer.subarray(0, bufferLength), gl.STREAM_DRAW);
 
-    // Bind the atlas page texture if they have changed
+    // Bind the atlas page texture if they have changed. AtlasPage.version is globally
+    // monotonic, so a page object swap at the same index (which happens after a page merge)
+    // is detected by the same comparison.
     for (let i = 0; i < this._atlas.pages.length; i++) {
       if (this._atlas.pages[i].version !== this._atlasTextures[i].version) {
         this._bindAtlasPageTexture(gl, this._atlas, i);

--- a/addons/addon-webgl/src/RectangleRenderer.ts
+++ b/addons/addon-webgl/src/RectangleRenderer.ts
@@ -336,8 +336,9 @@ export class RectangleRenderer extends Disposable {
       }
     }
 
-    if (vertices.attributes.length < offset + 4) {
-      vertices.attributes = expandFloat32Array(vertices.attributes, this._terminal.rows * this._terminal.cols * INDICES_PER_RECTANGLE);
+    if (vertices.attributes.length < offset + INDICES_PER_RECTANGLE) {
+      // +1 for the viewport-clear rectangle at offset 0.
+      vertices.attributes = expandFloat32Array(vertices.attributes, (this._terminal.rows * this._terminal.cols + 1) * INDICES_PER_RECTANGLE);
     }
     $x1 = startX * this._dimensions.device.cell.width;
     $y1 = y * this._dimensions.device.cell.height;

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -133,7 +133,9 @@ export class TextureAtlas implements ITextureAtlas {
 
   private _requestClearModel = false;
   public beginFrame(): boolean {
-    return this._requestClearModel;
+    const result = this._requestClearModel;
+    this._requestClearModel = false;
+    return result;
   }
 
   public clearTexture(): void {
@@ -193,7 +195,7 @@ export class TextureAtlas implements ITextureAtlas {
 
       // Merge into the new page
       const mergedPage = this._mergePages(mergingPages, mergedPageIndex);
-      mergedPage.version++;
+      mergedPage.version = ++AtlasPage.nextVersion;
 
       // Delete the pages, shifting glyph texture pages as needed
       for (let i = sortedMergingPagesIndexes.length - 1; i >= 0; i--) {
@@ -251,7 +253,7 @@ export class TextureAtlas implements ITextureAtlas {
       for (const g of adjustingPage.glyphs) {
         g.texturePage--;
       }
-      adjustingPage.version++;
+      adjustingPage.version = ++AtlasPage.nextVersion;
     }
   }
 
@@ -937,7 +939,7 @@ export class TextureAtlas implements ITextureAtlas {
       rasterizedGlyph.size.y
     );
     activePage.addGlyph(rasterizedGlyph);
-    activePage.version++;
+    activePage.version = ++AtlasPage.nextVersion;
 
     return rasterizedGlyph;
   }
@@ -1047,9 +1049,13 @@ class AtlasPage {
   }
 
   /**
-   * Used to check whether the canvas of the atlas page has changed.
+   * Monotonically increasing across all atlas pages globally. Used to detect when the texture
+   * unit at a given index needs to be re-uploaded — both for content changes within the same
+   * page and for a page object swap at the same index (which happens after a page merge,
+   * where a per-page counter could coincide with the previously-bound page's value).
    */
-  public version = 0;
+  public static nextVersion: number = 0;
+  public version = ++AtlasPage.nextVersion;
 
   // Texture atlas current positioning data. The texture packing strategy used is to fill from
   // left-to-right and top-to-bottom. When the glyph being written is less than half of the current
@@ -1092,7 +1098,7 @@ class AtlasPage {
     this.currentRow.y = 0;
     this.currentRow.height = 0;
     this.fixedRows.length = 0;
-    this.version++;
+    this.version = ++AtlasPage.nextVersion;
   }
 }
 

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -29,13 +29,7 @@ import { combinedDisposable, Disposable, MutableDisposable, toDisposable } from 
 import { createRenderDimensions } from 'browser/renderer/shared/RendererUtils';
 
 const enum Constants {
-  /**
-   * Upper bound on how many times `renderRows` re-runs `_updateModel` after detecting a
-   * mid-update atlas page merge. A single retry should always suffice once every glyph
-   * needed by the frame is cached; the cap exists purely as a safety net against an
-   * unexpected runaway, not as a tuned value.
-   */
-  MERGE_RETRY_LIMIT = 3
+  MERGE_RETRY_LIMIT = 32
 }
 
 export class WebglRenderer extends Disposable implements IRenderer {
@@ -385,12 +379,17 @@ export class WebglRenderer extends Disposable implements IRenderer {
       this._updateModel(start, end);
     }
 
-    // A mid-update atlas page merge shifts cached glyphs to new texture pages, leaving
-    // stale texturePage values in the vertex buffer. Re-run a full update if that happened.
+    // A mid-update atlas page merge invalidates vertex data and may not bump the host
+    // page's version, so re-run the update and force a full texture rebind.
+    let merged = false;
     let mergeRetries = 0;
     while (this._charAtlas && this._glyphRenderer.value.beginFrame() && mergeRetries++ < Constants.MERGE_RETRY_LIMIT) {
+      merged = true;
       this._clearModel(true);
       this._updateModel(0, this._terminal.rows - 1);
+    }
+    if (merged) {
+      this._glyphRenderer.value.invalidateAtlasTextures();
     }
 
     // Render

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -28,6 +28,16 @@ import { addDisposableListener } from 'browser/Dom';
 import { combinedDisposable, Disposable, MutableDisposable, toDisposable } from 'common/Lifecycle';
 import { createRenderDimensions } from 'browser/renderer/shared/RendererUtils';
 
+const enum Constants {
+  /**
+   * Upper bound on how many times `renderRows` re-runs `_updateModel` after detecting a
+   * mid-update atlas page merge. A single retry should always suffice once every glyph
+   * needed by the frame is cached; the cap exists purely as a safety net against an
+   * unexpected runaway, not as a tuned value.
+   */
+  MERGE_RETRY_LIMIT = 3
+}
+
 export class WebglRenderer extends Disposable implements IRenderer {
   private _renderLayers: IRenderLayer[];
   private _cursorBlinkStateManager: MutableDisposable<CursorBlinkStateManager> = this._register(new MutableDisposable());
@@ -373,6 +383,14 @@ export class WebglRenderer extends Disposable implements IRenderer {
     } else {
       // just update changed lines to draw
       this._updateModel(start, end);
+    }
+
+    // A mid-update atlas page merge shifts cached glyphs to new texture pages, leaving
+    // stale texturePage values in the vertex buffer. Re-run a full update if that happened.
+    let mergeRetries = 0;
+    while (this._charAtlas && this._glyphRenderer.value.beginFrame() && mergeRetries++ < Constants.MERGE_RETRY_LIMIT) {
+      this._clearModel(true);
+      this._updateModel(0, this._terminal.rows - 1);
     }
 
     // Render


### PR DESCRIPTION
Two bugs in the webgl renderer cause the corruption from #5847.

**1. Texture binding stale after a same-index page swap.** `GlyphRenderer.render` only rebinds a texture unit on `version` mismatch, but after `_createNewPage` merges 4 pages into 1, the page object at the merged index swaps to a fresh `mergedPage`. With per-page counters the new page's `version` often coincided with the version we last bound at that index (the freshly-pushed mergedPage always landed on `1`). The rebind was skipped and the texture kept the old page's canvas, so glyphs sampling that unit got garbage.

Make `AtlasPage.version` monotonic across all pages and the existing comparison detects a same-index swap, no extra bookkeeping required.

**2. Stale `texturePage` in the vertex buffer after a mid-update merge.** When a merge fires inside `_updateModel`, cached glyphs get a new `texturePage`. Cells already written in this pass (or carried over via the model-unchanged early-exit) still point at the pre-merge index. `_requestClearModel` was set on merge but `beginFrame` never reset it, so it stayed true forever; and `renderRows` only checked it before `_updateModel`, so a mid-pass merge went unhandled.

- reset `_requestClearModel` when `beginFrame` reads it
- after `_updateModel`, re-run a full update if a merge fired during the pass (capped at `MERGE_RETRY_LIMIT`)

Before:
<img width="146" height="73" alt="issue" src="https://github.com/user-attachments/assets/b299a61c-7218-4c5f-b5e4-1665bdb72660" />
After:
<img width="322" height="110" alt="image" src="https://github.com/user-attachments/assets/88d303f2-12f3-44a0-a743-b51fe08dc21d" />

Stress repro with the script from #5847 (full-screen rewrite, many colors, frequent merges):

Before this PR:

<img width="1728" height="992" alt="repro-master-no-fix" src="https://github.com/user-attachments/assets/32815aa2-b094-475a-80b7-5a50956e1bea" />

After this PR:

<img width="1728" height="992" alt="repro-with-fix" src="https://github.com/user-attachments/assets/f61e67bd-f2d6-4b93-a36b-62d124c387a7" />
