### PR TITLE
addon-image: Kitty graphics q=2 should suppress OK responses too

### DIFF
--- a/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
+++ b/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
@@ -533,8 +533,8 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
 
   private _sendResponse(id: number, message: string, quiet: number, placementId?: number): void {
     const isOk = message === 'OK';
-    if (isOk && quiet === 1) return;
-    if (!isOk && quiet === 2) return;
+    if (isOk && quiet >= 1) return;
+    if (!isOk && quiet >= 2) return;
 
     const pPart = placementId ? `,p=${placementId}` : '';
     const response = `\x1b_Gi=${id}${pPart};${message}\x1b\\`;

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -617,6 +617,18 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
     });
 
+    test('suppresses OK response when q=2', async () => {
+      await ctx.page.evaluate(() => {
+        (window as any).kittyGotResponse = false;
+        (window as any).term.onData(() => { (window as any).kittyGotResponse = true; });
+      });
+
+      await ctx.proxy.write(`\x1b_Gi=81,a=q,q=2,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
+    });
+
     test('suppresses error response when q=2', async () => {
       await ctx.page.evaluate(() => {
         (window as any).kittyGotResponse = false;
@@ -793,6 +805,30 @@ test.describe('Kitty Graphics Protocol', () => {
       });
 
       await ctx.proxy.write(`\x1b_Gi=190,a=T,q=1,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
+    });
+
+    test('a=t OK suppressed by q=2', async () => {
+      await ctx.page.evaluate(() => {
+        (window as any).kittyGotResponse = false;
+        (window as any).term.onData(() => { (window as any).kittyGotResponse = true; });
+      });
+
+      await ctx.proxy.write(`\x1b_Gi=181,a=t,q=2,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
+    });
+
+    test('a=T OK suppressed by q=2', async () => {
+      await ctx.page.evaluate(() => {
+        (window as any).kittyGotResponse = false;
+        (window as any).term.onData(() => { (window as any).kittyGotResponse = true; });
+      });
+
+      await ctx.proxy.write(`\x1b_Gi=191,a=T,q=2,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await timeout(100);
 
       strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
@@ -1140,6 +1176,22 @@ test.describe('Kitty Graphics Protocol', () => {
       });
 
       await ctx.proxy.write(`\x1b_Ga=p,i=220,q=1\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
+      strictEqual(await getImageStorageLength(), 1);
+    });
+
+    test('OK response suppressed by q=2', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=221;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      await ctx.page.evaluate(() => {
+        (window as any).kittyGotResponse = false;
+        (window as any).term.onData(() => { (window as any).kittyGotResponse = true; });
+      });
+
+      await ctx.proxy.write(`\x1b_Ga=p,i=221,q=2\x1b\\`);
       await timeout(100);
 
       strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);


### PR DESCRIPTION
Per the [Kitty graphics protocol spec](https://sw.kovidgoyal.net/kitty/graphics-protocol/#suppressing-responses-from-the-terminal):

> If you wish, you can suppress all responses by setting `q=2`. To suppress responses only for the `OK` status, set `q=1`.

The current `_sendResponse` implementation in `KittyGraphicsHandler.ts` only matches `quiet === 1` for OK and `quiet === 2` for errors, so a transmission with `q=2` still emits an `OK` response — a violation of the spec and a real-world breakage for crossterm-based clients (e.g. [yazi](https://github.com/sxyazi/yazi)) that send `q=2` precisely to get silence and whose input parser misinterprets the unsolicited APC response as keystrokes. Concretely, hovering over an image in yazi pumps `ESC _ G i = N ; O K ESC \` into stdin, which crossterm reads as `;` (open shell command line), `G` (jump to bottom), `O` (open with).

Changes `quiet === 1` → `quiet >= 1` for OK and `quiet === 2` → `quiet >= 2` for errors, making q=2 suppress both. Adds 4 tests mirroring the existing q=1 OK-suppression coverage:

- Query (`a=q`): "suppresses OK response when q=2"
- Transmit-only (`a=t`): "a=t OK suppressed by q=2"
- Transmit-display (`a=T`): "a=T OK suppressed by q=2"
- Placement (`a=p`): "OK response suppressed by q=2"

The 2-character behavior change has been validated end-to-end in a downstream xterm.js consumer where yazi previews now work cleanly.