### PR TITLE
fix: remove aria-hidden from DOM renderer row container

### DIFF
--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -80,7 +80,6 @@ export class DomRenderer extends Disposable implements IRenderer {
     this._rowContainer = this._document.createElement('div');
     this._rowContainer.classList.add(Constants.ROW_CONTAINER_CLASS);
     this._rowContainer.style.lineHeight = 'normal';
-    this._rowContainer.setAttribute('aria-hidden', 'true');
     this._refreshRowElements(this._bufferService.cols, this._bufferService.rows);
     this._selectionContainer = this._document.createElement('div');
     this._selectionContainer.classList.add(Constants.SELECTION_CLASS);


### PR DESCRIPTION
## Summary

- Removes `aria-hidden="true"` from `_rowContainer` (`.xterm-rows`) in `DomRenderer.ts`
- The DOM renderer renders actual text in the DOM as divs/spans — screen readers can read it directly once the attribute is removed
- `_selectionContainer` keeps its `aria-hidden="true"` (correct — it is a visual-only overlay)
- The `screenReaderMode` option and `AccessibilityManager` are unchanged and continue to provide an enhanced experience (live region, structured accessible tree) when explicitly enabled

## Motivation

`aria-hidden="true"` was unconditionally set on the row container, making all terminal output completely invisible to screen readers when `screenReaderMode` is `false` (the default). Since `AccessibilityManager` only activates when `screenReaderMode: true`, the default configuration left screen reader users with zero access to terminal output.

Accessibility should not depend on the embedding developer knowing to opt in via `screenReaderMode`.

Closes #5881