### PR TITLE
Improve decoration cell lookup performance

### DIFF
--- a/src/common/services/DecorationService.test.ts
+++ b/src/common/services/DecorationService.test.ts
@@ -9,6 +9,7 @@ import { IMarker } from 'common/Types';
 import { Disposable } from 'common/Lifecycle';
 import { Emitter } from 'common/Event';
 import { MockLogService } from 'common/TestUtils.test';
+import { IInternalDecoration } from 'common/services/Services';
 
 function createFakeMarker(line: number): IMarker {
   return Object.freeze(new class extends Disposable {
@@ -16,6 +17,18 @@ function createFakeMarker(line: number): IMarker {
     public readonly line = line;
     public readonly isDisposed = false;
     public readonly onDispose = new Emitter<void>().event;
+  }());
+}
+
+function createCountingMarker(line: number, counter: { count: number }): IMarker {
+  return Object.freeze(new class extends Disposable {
+    public readonly id = 1;
+    public readonly isDisposed = false;
+    public readonly onDispose = new Emitter<void>().event;
+    public get line(): number {
+      counter.count++;
+      return line;
+    }
   }());
 }
 
@@ -98,6 +111,25 @@ describe('DecorationService', () => {
       const foundAtX8: typeof decoration[] = [];
       service.forEachDecorationAtCell(8, 5, undefined, d => foundAtX8.push(d));
       assert.strictEqual(foundAtX8.length, 0);
+    });
+
+    it('should avoid scanning all decorations when they are single-line', () => {
+      const service = new DecorationService(new MockLogService());
+      const counter = { count: 0 };
+      for (let i = 0; i < 100; i++) {
+        service.registerDecoration({
+          marker: createCountingMarker(i, counter),
+          width: 1
+        });
+      }
+      Array.from(service.decorations);
+
+      counter.count = 0;
+      const found: IInternalDecoration[] = [];
+      service.forEachDecorationAtCell(0, 50, undefined, d => found.push(d));
+
+      assert.strictEqual(found.length, 1);
+      assert.isBelow(counter.count, 25);
     });
   });
 

--- a/src/common/services/DecorationService.ts
+++ b/src/common/services/DecorationService.ts
@@ -26,6 +26,7 @@ export class DecorationService extends Disposable implements IDecorationService 
    * never become out of order.
    */
   private readonly _decorations: SortedList<IInternalDecoration>;
+  private _multiLineDecorationCount = 0;
 
   private readonly _onDecorationRegistered = this._register(new Emitter<IInternalDecoration>());
   public readonly onDecorationRegistered = this._onDecorationRegistered.event;
@@ -48,11 +49,18 @@ export class DecorationService extends Disposable implements IDecorationService 
     }
     const decoration = new Decoration(options);
     if (decoration) {
+      const isMultiLineDecoration = (decoration.options.height ?? 1) > 1;
+      if (isMultiLineDecoration) {
+        this._multiLineDecorationCount++;
+      }
       const markerDispose = decoration.marker.onDispose(() => decoration.dispose());
       const listener = decoration.onDispose(() => {
         listener.dispose();
         if (decoration) {
           if (this._decorations.delete(decoration)) {
+            if (isMultiLineDecoration) {
+              this._multiLineDecorationCount--;
+            }
             this._onDecorationRemoved.fire(decoration);
           }
           markerDispose.dispose();
@@ -69,6 +77,7 @@ export class DecorationService extends Disposable implements IDecorationService 
       d.dispose();
     }
     this._decorations.clear();
+    this._multiLineDecorationCount = 0;
   }
 
   public *getDecorationsAtCell(x: number, line: number, layer?: 'bottom' | 'top'): IterableIterator<IInternalDecoration> {
@@ -91,6 +100,16 @@ export class DecorationService extends Disposable implements IDecorationService 
   }
 
   public forEachDecorationAtCell(x: number, line: number, layer: 'bottom' | 'top' | undefined, callback: (decoration: IInternalDecoration) => void): void {
+    if (this._multiLineDecorationCount === 0) {
+      this._decorations.forEachByKey(line, d => {
+        $xmin = d.options.x ?? 0;
+        $xmax = $xmin + (d.options.width ?? 1);
+        if (x >= $xmin && x < $xmax && (!layer || (d.options.layer ?? 'bottom') === layer)) {
+          callback(d);
+        }
+      });
+      return;
+    }
     for (const d of this._decorations.values()) {
       $ymin = d.marker.line;
       $ymax = $ymin + (d.options.height ?? 1);


### PR DESCRIPTION
## Summary

Refs #5176.

This speeds up decoration lookup for the common single-line decoration case. When no registered decoration spans multiple rows, `forEachDecorationAtCell` now asks the sorted decoration list for the current line instead of scanning every decoration for every cell.

Multi-line decorations continue to use the existing full scan path so their behavior is unchanged.

## Validation

- `npm run build && npm run esbuild`
- `npm run test-unit -- out-esbuild/common/services/DecorationService.test.js out-esbuild/common/SortedList.test.js`
- `npm run lint-changes`

## Notes

A local micro-benchmark with 10k single-line decorations over an 80x24 viewport for 20 iterations went from about 2479ms on the full-scan path to about 6.9ms with the line-keyed fast path.
