### PR TITLE
Add space-unary-ops lint rule to prevent space after !

### DIFF
--- a/addons/addon-image/src/SixelHandler.ts
+++ b/addons/addon-image/src/SixelHandler.ts
@@ -91,7 +91,7 @@ export class SixelHandler implements IDcsHandler, IResetHandler {
     const height = this._dec.height;
 
     // partial fix for https://github.com/jerch/xterm-addon-image/issues/37
-    if (!width || ! height) {
+    if (!width || !height) {
       if (height) {
         this._storage.advanceCursor(height);
       }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default tseslint.config(
         singleline: { delimiter: 'comma', requireLast: false }
       }],
       '@stylistic/type-annotation-spacing': 'warn',
+      '@stylistic/space-unary-ops': 'warn',
 
       '@typescript-eslint/array-type': ['warn', { default: 'array', readonly: 'generic' }],
       '@typescript-eslint/consistent-type-assertions': 'warn',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5898 by enabling `@stylistic/space-unary-ops` as a warning in the main ESLint config. This flags patterns like `if (! foo)` where there is an unexpected space after unary `!`.

## Changes

- Add `@stylistic/space-unary-ops: warn` to `eslint.config.mjs`
- Fix the only existing violation in `addons/addon-image/src/SixelHandler.ts` (`! height` → `!height`)

## Verification

- `npx eslint '**/*.ts' --max-warnings 0` passes on the full TypeScript tree
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caafde38-4053-4082-aeb6-1c7fea9a604c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caafde38-4053-4082-aeb6-1c7fea9a604c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

