### PR TITLE
Register BufferNamespaceApi onBufferActivate listener with disposables

### DIFF
--- a/src/common/public/BufferNamespaceApi.ts
+++ b/src/common/public/BufferNamespaceApi.ts
@@ -20,7 +20,7 @@ export class BufferNamespaceApi extends Disposable implements IBufferNamespaceAp
     super();
     this._normal = new BufferApiView(this._core.buffers.normal, 'normal');
     this._alternate = new BufferApiView(this._core.buffers.alt, 'alternate');
-    this._core.buffers.onBufferActivate(() => this._onBufferChange.fire(this.active));
+    this._register(this._core.buffers.onBufferActivate(() => this._onBufferChange.fire(this.active)));
   }
   public get active(): IBufferApi {
     if (this._core.buffers.active === this._core.buffers.normal) { return this.normal; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BufferNamespaceApi` already forwards `IBufferSet.onBufferActivate` to the public `onBufferChange` event. This change registers that subscription with `this._register()` so it is disposed when `BufferNamespaceApi` is disposed, consistent with other listeners in the codebase (for example `InputHandler`, `BufferService`, and `SelectionService`).

## Changes

- Wrap `this._core.buffers.onBufferActivate(...)` in `this._register(...)` in `BufferNamespaceApi`.

## Testing

- `npm run build`
- `npm run lint-changes`
- `npm run test-unit -- out-esbuild/headless/public/Terminal.test.js` (43 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcd1d209-19cc-44f2-a988-d949a7b2e91c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcd1d209-19cc-44f2-a988-d949a7b2e91c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

