### PR TITLE
Log onWillOpen handler errors instead of swallowing them

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -563,8 +563,9 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
     try {
       this._onWillOpen.fire(this.element);
+    } catch (e) {
+      this._logService.error('onWillOpen handler threw an exception', e);
     }
-    catch { /* fails to load addon for some reason */ }
     if (!this._renderService.hasRenderer()) {
       this._renderService.setRenderer(this._createRenderer());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5920.

When `terminal.open()` fires `onWillOpen`, addon handlers (for example WebGL activation deferred until the element exists) can throw. Those exceptions were caught and discarded with no logging, which made addon failures hard to diagnose.

This change logs handler failures through `_logService.error` so they appear in the console when `logLevel` allows it (default `info` includes errors).

## Test plan

- [x] `npm run build`
- [ ] Manual: load WebGL addon before `open()`, trigger a handler error, confirm `xterm.js: onWillOpen handler threw an exception` appears in the console
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a12867e7-39d6-4994-ae2b-248d264f7e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a12867e7-39d6-4994-ae2b-248d264f7e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

