### PR TITLE
Fix flushSync() to fire onWriteParsed

### DIFF
--- a/src/common/input/WriteBuffer.test.ts
+++ b/src/common/input/WriteBuffer.test.ts
@@ -125,5 +125,20 @@ describe('WriteBuffer', () => {
       assert.deepEqual(stack, []);
       assert.deepEqual(cbStack, []);
     });
+    it('flushSync fires onWriteParsed', () => {
+      let parsed = 0;
+      wb.onWriteParsed(() => parsed++);
+      wb.write('a');
+      wb.write('b');
+      assert.equal(parsed, 0);
+      wb.flushSync();
+      assert.equal(parsed, 1);
+    });
+    it('flushSync with no pending writes does not fire onWriteParsed', () => {
+      let parsed = 0;
+      wb.onWriteParsed(() => parsed++);
+      wb.flushSync();
+      assert.equal(parsed, 0);
+    });
   });
 });

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -71,7 +71,9 @@ export class WriteBuffer extends Disposable {
 
     // Process all pending chunks synchronously
     let chunk: string | Uint8Array | undefined;
+    let didProcess = false;
     while (chunk = this._writeBuffer.shift()) {
+      didProcess = true;
       this._action(chunk);
       const cb = this._callbacks.shift();
       if (cb) cb();
@@ -84,6 +86,9 @@ export class WriteBuffer extends Disposable {
     this._callbacks.length = 0;
 
     this._isSyncWriting = false;
+    if (didProcess) {
+      this._onWriteParsed.fire();
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`WriteBuffer.flushSync()` drains pending writes synchronously (for example during `CoreTerminal.resize()`) but did not emit `onWriteParsed`, unlike the async `_innerWrite` path. Addons that listen for parse completion (such as search) could miss updates after a resize.

## Changes

- Fire `onWriteParsed` from `flushSync()` after processing pending chunks
- Only emit when at least one chunk was processed (empty `flushSync()` remains a no-op for this event)
- Add unit tests for both cases

Fixes #5912
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6560f72c-caa7-4385-aba8-f30001637a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6560f72c-caa7-4385-aba8-f30001637a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

