### PR TITLE
fix(addon-webgl): delete VAOs on renderer dispose

### DIFF
--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -136,9 +136,9 @@ export class GlyphRenderer extends Disposable {
     this._textureLocation = throwIfFalsy(gl.getUniformLocation(this._program, 'u_texture'));
 
     // Create and set the vertex array object
-    this._vertexArrayObject = gl.createVertexArray();
-    this._register(toDisposable(() => gl.deleteVertexArray(this._vertexArrayObject)));
-    gl.bindVertexArray(this._vertexArrayObject);
+    const vertexArrayObject = this._vertexArrayObject = gl.createVertexArray();
+    this._register(toDisposable(() => gl.deleteVertexArray(vertexArrayObject)));
+    gl.bindVertexArray(vertexArrayObject);
 
     // Setup a_unitquad, this defines the 4 vertices of a rectangle
     const unitQuadVertices = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]);

--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -137,6 +137,7 @@ export class GlyphRenderer extends Disposable {
 
     // Create and set the vertex array object
     this._vertexArrayObject = gl.createVertexArray();
+    this._register(toDisposable(() => gl.deleteVertexArray(this._vertexArrayObject)));
     gl.bindVertexArray(this._vertexArrayObject);
 
     // Setup a_unitquad, this defines the 4 vertices of a rectangle

--- a/addons/addon-webgl/src/RectangleRenderer.ts
+++ b/addons/addon-webgl/src/RectangleRenderer.ts
@@ -102,9 +102,9 @@ export class RectangleRenderer extends Disposable {
     this._projectionLocation = throwIfFalsy(gl.getUniformLocation(this._program, 'u_projection'));
 
     // Create and set the vertex array object
-    this._vertexArrayObject = gl.createVertexArray();
-    this._register(toDisposable(() => gl.deleteVertexArray(this._vertexArrayObject)));
-    gl.bindVertexArray(this._vertexArrayObject);
+    const vertexArrayObject = this._vertexArrayObject = gl.createVertexArray();
+    this._register(toDisposable(() => gl.deleteVertexArray(vertexArrayObject)));
+    gl.bindVertexArray(vertexArrayObject);
 
     // Setup a_unitquad, this defines the 4 vertices of a rectangle
     const unitQuadVertices = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]);

--- a/addons/addon-webgl/src/RectangleRenderer.ts
+++ b/addons/addon-webgl/src/RectangleRenderer.ts
@@ -103,6 +103,7 @@ export class RectangleRenderer extends Disposable {
 
     // Create and set the vertex array object
     this._vertexArrayObject = gl.createVertexArray();
+    this._register(toDisposable(() => gl.deleteVertexArray(this._vertexArrayObject)));
     gl.bindVertexArray(this._vertexArrayObject);
 
     // Setup a_unitquad, this defines the 4 vertices of a rectangle

--- a/addons/addon-webgl/src/Types.ts
+++ b/addons/addon-webgl/src/Types.ts
@@ -28,8 +28,8 @@ export interface ICursorRenderModel {
 export interface IWebGL2RenderingContext extends WebGLRenderingContext {
   vertexAttribDivisor(index: number, divisor: number): void;
   createVertexArray(): IWebGLVertexArrayObject;
-  deleteVertexArray(vao: IWebGLVertexArrayObject | null): void;
-  bindVertexArray(vao: IWebGLVertexArrayObject | null): void;
+  deleteVertexArray(vao: IWebGLVertexArrayObject): void;
+  bindVertexArray(vao: IWebGLVertexArrayObject): void;
   drawElementsInstanced(mode: number, count: number, type: number, offset: number, instanceCount: number): void;
 }
 

--- a/addons/addon-webgl/src/Types.ts
+++ b/addons/addon-webgl/src/Types.ts
@@ -28,7 +28,8 @@ export interface ICursorRenderModel {
 export interface IWebGL2RenderingContext extends WebGLRenderingContext {
   vertexAttribDivisor(index: number, divisor: number): void;
   createVertexArray(): IWebGLVertexArrayObject;
-  bindVertexArray(vao: IWebGLVertexArrayObject): void;
+  deleteVertexArray(vao: IWebGLVertexArrayObject | null): void;
+  bindVertexArray(vao: IWebGLVertexArrayObject | null): void;
   drawElementsInstanced(mode: number, count: number, type: number, offset: number, instanceCount: number): void;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

WebGL vertex array objects (VAOs) created in `GlyphRenderer` and `RectangleRenderer` were not deleted when those renderers were disposed. Buffers, textures, and programs were already cleaned up via `toDisposable` registrations; this change applies the same pattern to VAOs.

## Changes

- Register `gl.deleteVertexArray` on dispose for each renderer's `_vertexArrayObject`
- Extend `IWebGL2RenderingContext` with `deleteVertexArray` and allow `null` for `bindVertexArray` (WebGL2 API)

Fixes #5918
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da37ab5e-a3c0-46ad-93e9-7c565517ef2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da37ab5e-a3c0-46ad-93e9-7c565517ef2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

