### PR TITLE
fix(webgl): include texture size and cell dimensions in atlas cache equality

### DIFF
--- a/addons/addon-webgl/src/CharAtlasUtils.test.ts
+++ b/addons/addon-webgl/src/CharAtlasUtils.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { configEquals } from './CharAtlasUtils';
+import { ICharAtlasConfig } from './Types';
+import { NULL_COLOR } from 'common/Color';
+import { IColor } from 'common/Types';
+
+function createTestConfig(overrides: Partial<ICharAtlasConfig> = {}): ICharAtlasConfig {
+  const color: IColor = { css: '#ffffff', rgba: 0xffffffff };
+  const contrastCache = {
+    clear: () => {},
+    setCss: () => {},
+    getCss: () => undefined,
+    setColor: () => {},
+    getColor: () => undefined
+  };
+  const colors = {
+    foreground: color,
+    background: color,
+    cursor: NULL_COLOR,
+    cursorAccent: NULL_COLOR,
+    selectionForeground: undefined,
+    selectionBackgroundTransparent: NULL_COLOR,
+    selectionBackgroundOpaque: NULL_COLOR,
+    selectionInactiveBackgroundTransparent: NULL_COLOR,
+    selectionInactiveBackgroundOpaque: NULL_COLOR,
+    overviewRulerBorder: NULL_COLOR,
+    scrollbarSliderBackground: NULL_COLOR,
+    scrollbarSliderHoverBackground: NULL_COLOR,
+    scrollbarSliderActiveBackground: NULL_COLOR,
+    ansi: new Array(256).fill(color),
+    contrastCache,
+    halfContrastCache: contrastCache
+  };
+  return {
+    customGlyphs: true,
+    devicePixelRatio: 1,
+    deviceMaxTextureSize: 4096,
+    letterSpacing: 0,
+    lineHeight: 1,
+    fontSize: 15,
+    fontFamily: 'monospace',
+    fontWeight: 'normal',
+    fontWeightBold: 'bold',
+    deviceCellWidth: 10,
+    deviceCellHeight: 20,
+    deviceCharWidth: 8,
+    deviceCharHeight: 16,
+    allowTransparency: false,
+    drawBoldTextInBrightColors: true,
+    minimumContrastRatio: 1,
+    colors,
+    ...overrides
+  };
+}
+
+describe('CharAtlasUtils', () => {
+  describe('configEquals', () => {
+    it('should return true for identical configs', () => {
+      const a = createTestConfig();
+      const b = createTestConfig();
+      assert.ok(configEquals(a, b));
+    });
+
+    it('should return false when deviceMaxTextureSize differs', () => {
+      const a = createTestConfig();
+      const b = createTestConfig({ deviceMaxTextureSize: 8192 });
+      assert.ok(!configEquals(a, b));
+    });
+
+    it('should return false when deviceCellWidth differs', () => {
+      const a = createTestConfig();
+      const b = createTestConfig({ deviceCellWidth: 11 });
+      assert.ok(!configEquals(a, b));
+    });
+
+    it('should return false when deviceCellHeight differs', () => {
+      const a = createTestConfig();
+      const b = createTestConfig({ deviceCellHeight: 21 });
+      assert.ok(!configEquals(a, b));
+    });
+  });
+});

--- a/addons/addon-webgl/src/CharAtlasUtils.ts
+++ b/addons/addon-webgl/src/CharAtlasUtils.ts
@@ -59,6 +59,7 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
     }
   }
   return a.devicePixelRatio === b.devicePixelRatio &&
+      a.deviceMaxTextureSize === b.deviceMaxTextureSize &&
       a.customGlyphs === b.customGlyphs &&
       a.lineHeight === b.lineHeight &&
       a.letterSpacing === b.letterSpacing &&
@@ -67,6 +68,8 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
       a.fontWeight === b.fontWeight &&
       a.fontWeightBold === b.fontWeightBold &&
       a.allowTransparency === b.allowTransparency &&
+      a.deviceCellWidth === b.deviceCellWidth &&
+      a.deviceCellHeight === b.deviceCellHeight &&
       a.deviceCharWidth === b.deviceCharWidth &&
       a.deviceCharHeight === b.deviceCharHeight &&
       a.drawBoldTextInBrightColors === b.drawBoldTextInBrightColors &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5915

`configEquals` in `CharAtlasUtils.ts` did not compare `deviceMaxTextureSize`, `deviceCellWidth`, or `deviceCellHeight` when deciding whether a cached char atlas could be reused. That could return an atlas built for a different GPU texture limit or cell dimensions.

## Changes

- Add `deviceMaxTextureSize`, `deviceCellWidth`, and `deviceCellHeight` to the `configEquals` comparison
- Add unit tests covering these fields

## Testing

- `npm run test-unit -- addons/addon-webgl/out-esbuild/CharAtlasUtils.test.js` (4 passing)

## Why this change is low risk

This only tightens an internal cache equality check. It cannot cause two terminals with genuinely matching configs to start sharing incorrectly, and it cannot change how an atlas is built or drawn.

### What `configEquals` controls

`configEquals` is only used in `CharAtlasCache.acquireTextureAtlas` to decide whether an existing `TextureAtlas` may be reused. If it returns `false`, the code allocates a new atlas with `new TextureAtlas(document, newConfig, ...)`. No other renderer logic changes.

| Outcome | Effect |
|--------|--------|
| Was `true`, still `true` | Identical behavior (still share) |
| Was `true`, now `false` | Stop incorrect sharing; build another atlas |
| Was `false`, now `true` | Impossible — we only added comparisons |

The old bug was **false positives** (reuse when we should not). This fix only removes those. The worst case is **extra memory** (one more atlas), not wrong pixels.

### These fields already define atlas behavior

`generateConfig` already stores `deviceMaxTextureSize`, `deviceCellWidth`, and `deviceCellHeight`. `TextureAtlas` uses them at construction and rasterization time (temp canvas size, glyph clipping, overflow page size via `deviceMaxTextureSize`, etc.). Reusing an atlas built with different values was structurally wrong; omitting them from equality was inconsistent with how the atlas is built.

### Completing an existing pattern

`deviceCharWidth` and `deviceCharHeight` were already required to match before reuse. Cell dimensions come from the same `dimensions.device` snapshot passed into `acquireTextureAtlas` alongside char dimensions. Including cell size in equality aligns with the existing char-metric checks rather than introducing a new policy.

### When users would notice a difference

Only when all previously compared fields matched but one of these differed:

- `deviceMaxTextureSize` (e.g. different WebGL contexts / `MAX_TEXTURE_SIZE`)
- `deviceCellWidth` / `deviceCellHeight` (e.g. resize where cell size changes but other compared fields still matched)

In the common case (one terminal, or multiple terminals with the same dimensions and GPU limits), all fields including the new ones are equal and behavior is unchanged.

### Tests

Unit tests assert that differing `deviceMaxTextureSize`, `deviceCellWidth`, or `deviceCellHeight` yields `configEquals === false`, documenting the intended cache contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-814ade92-1220-4476-80a6-d7b0dc357cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-814ade92-1220-4476-80a6-d7b0dc357cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

