### PR TITLE
Clear WebGL context-loss timeout on WebglRenderer dispose

### DIFF
--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -158,6 +158,8 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._isAttached = this._core.screenElement!.isConnected;
 
     this._register(toDisposable(() => {
+      clearTimeout(this._contextRestorationTimeout);
+      this._contextRestorationTimeout = undefined;
       for (const l of this._renderLayers) {
         l.dispose();
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5919

## Problem

When the WebGL context is lost, `WebglRenderer` starts a 3 second timeout to fire `onContextLoss` if the context is not restored. That timeout was not cleared when the renderer was disposed, so it could still run after teardown and fire `onContextLoss` on a disposed renderer.

## Solution

Clear `_contextRestorationTimeout` in the renderer's dispose hook (same `toDisposable` callback that removes the canvas and disposes render layers).

## Test plan

- [x] `npm run build`
- [x] `npm run lint-changes`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e3a0ad4-3047-48f8-902a-2be920243f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e3a0ad4-3047-48f8-902a-2be920243f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

