### PR TITLE
Remove duplicate Object.defineProperty loop in headless Terminal

### DIFF
--- a/src/headless/public/Terminal.ts
+++ b/src/headless/public/Terminal.ts
@@ -40,15 +40,6 @@ export class Terminal extends Disposable implements ITerminalApi {
     };
 
     for (const propName in this._core.options) {
-      Object.defineProperty(this._publicOptions, propName, {
-        get: () => {
-          return this._core.options[propName];
-        },
-        set: (value: any) => {
-          this._checkReadonlyOptions(propName);
-          this._core.options[propName] = value;
-        }
-      });
       const desc = {
         get: getter.bind(this, propName),
         set: setter.bind(this, propName)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5935

## Summary

The headless public `Terminal` constructor defined getters/setters on `_publicOptions` twice in the same loop. The first `Object.defineProperty` call was immediately overwritten by the second, leaving dead and confusing code.

This change removes the redundant first block so the implementation matches `src/browser/public/Terminal.ts`.

## Testing

- `npm run build && npm run esbuild`
- `npm run test-unit -- **/headless/public/Terminal.test.js` (88 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f256bf1f-95d8-4b37-8962-c628b0c957b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f256bf1f-95d8-4b37-8962-c628b0c957b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

