### PR TITLE
perf: use single loop for cellsNeeded sum in BufferReflow

### DIFF
--- a/src/common/buffer/BufferReflow.ts
+++ b/src/common/buffer/BufferReflow.ts
@@ -178,7 +178,10 @@ export function reflowLargerApplyNewLayout(lines: CircularList<IBufferLine>, new
  */
 export function reflowSmallerGetNewLineLengths(wrappedLines: BufferLine[], oldCols: number, newCols: number): number[] {
   const newLineLengths: number[] = [];
-  const cellsNeeded = wrappedLines.map((l, i) => getWrappedLineTrimmedLength(wrappedLines, i, oldCols)).reduce((p, c) => p + c);
+  let cellsNeeded = 0;
+  for (let i = 0; i < wrappedLines.length; i++) {
+    cellsNeeded += getWrappedLineTrimmedLength(wrappedLines, i, oldCols);
+  }
 
   // Use srcCol and srcLine to find the new wrapping point, use that to get the cellsAvailable and
   // linesNeeded


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces `map().reduce()` with a single accumulator loop when computing `cellsNeeded` in `reflowSmallerGetNewLineLengths`. This avoids allocating an intermediate array during buffer reflow when the terminal is resized to fewer columns.

Fixes #5942

## Test plan

- [x] `npm run test-unit -- **/out-esbuild/**/BufferReflow.test.js` (5 passing)
- [x] `npm run lint-changes`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0efc152b-b661-4bf6-91f5-7028dcfd705e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0efc152b-b661-4bf6-91f5-7028dcfd705e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

