### PR TITLE
Use StringBuilder in BufferLine.translateToString

### DIFF
--- a/src/common/buffer/BufferLine.ts
+++ b/src/common/buffer/BufferLine.ts
@@ -8,6 +8,7 @@ import { AttributeData } from 'common/buffer/AttributeData';
 import { CellData } from 'common/buffer/CellData';
 import { Attributes, BgFlags, CHAR_DATA_ATTR_INDEX, CHAR_DATA_CHAR_INDEX, CHAR_DATA_WIDTH_INDEX, Content, NULL_CELL_CHAR, NULL_CELL_CODE, NULL_CELL_WIDTH, WHITESPACE_CELL_CHAR } from 'common/buffer/Constants';
 import { stringFromCodePoint } from 'common/input/TextDecoder';
+import { StringBuilder } from 'common/StringBuilder';
 
 // Buffer memory layout:
 //
@@ -570,12 +571,12 @@ export class BufferLine implements IBufferLine {
     if (outColumns) {
       outColumns.length = 0;
     }
-    let result = '';
+    const resultBuilder = new StringBuilder();
     while (startCol < endCol) {
       const content = this._data[startCol * Constants.CELL_INDICIES + Cell.CONTENT];
       const cp = content & Content.CODEPOINT_MASK;
       const chars = (content & Content.IS_COMBINED_MASK) ? this._combined[startCol] : (cp) ? stringFromCodePoint(cp) : WHITESPACE_CELL_CHAR;
-      result += chars;
+      resultBuilder.append(chars);
       if (outColumns) {
         for (let i = 0; i < chars.length; ++i) {
           outColumns.push(startCol);
@@ -586,6 +587,7 @@ export class BufferLine implements IBufferLine {
     if (outColumns) {
       outColumns.push(startCol);
     }
+    const result = resultBuilder.toString();
     if (isCanonicalRequest) {
       const cacheEntry = this._getStringCacheEntry(true)!;
       cacheEntry.value = result;

--- a/src/common/buffer/BufferLine.ts
+++ b/src/common/buffer/BufferLine.ts
@@ -42,6 +42,7 @@ export const DEFAULT_ATTR_DATA = Object.freeze(new AttributeData());
 // Work variables to avoid garbage collection
 let $startIndex = 0;
 const $workCell = new CellData();
+const $translateToStringBuilder = new StringBuilder();
 
 export interface IBufferLineStringCacheEntry {
   value: string | undefined;
@@ -571,12 +572,12 @@ export class BufferLine implements IBufferLine {
     if (outColumns) {
       outColumns.length = 0;
     }
-    const resultBuilder = new StringBuilder();
+    $translateToStringBuilder.reset();
     while (startCol < endCol) {
       const content = this._data[startCol * Constants.CELL_INDICIES + Cell.CONTENT];
       const cp = content & Content.CODEPOINT_MASK;
       const chars = (content & Content.IS_COMBINED_MASK) ? this._combined[startCol] : (cp) ? stringFromCodePoint(cp) : WHITESPACE_CELL_CHAR;
-      resultBuilder.append(chars);
+      $translateToStringBuilder.append(chars);
       if (outColumns) {
         for (let i = 0; i < chars.length; ++i) {
           outColumns.push(startCol);
@@ -587,7 +588,8 @@ export class BufferLine implements IBufferLine {
     if (outColumns) {
       outColumns.push(startCol);
     }
-    const result = resultBuilder.toString();
+    const result = $translateToStringBuilder.toString();
+    $translateToStringBuilder.reset();
     if (isCanonicalRequest) {
       const cacheEntry = this._getStringCacheEntry(true)!;
       cacheEntry.value = result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BufferLine.translateToString` built the result with `result += chars` inside a loop, which is O(n²) for long lines. This change uses the existing `StringBuilder` utility so chunks are accumulated in an array and joined once.

A module-level `$translateToStringBuilder` work variable is reset before and after each translation to avoid allocating a new builder when many lines are translated in sequence (same pattern as `$workCell`).

## Changes

- Import `StringBuilder` from `common/StringBuilder`
- Replace string concatenation in the translate loop with `$translateToStringBuilder.append(chars)`
- Reuse a shared module-level `StringBuilder`, reset before and after each call
- Call `toString()` once after the loop for cache storage and return value

Fixes #5939

## Test plan

- [x] `npm run build && npm run esbuild`
- [x] `npm run test-unit -- **/BufferLine.test.js` (102 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-934ea500-ace2-41a9-818f-9dfba60979f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-934ea500-ace2-41a9-818f-9dfba60979f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

