### PR TITLE
Fix duplicate buildNumber guard in Windows ConPTY logic

### DIFF
--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -263,7 +263,7 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
   private _handleWindowsPtyOptionChange(): void {
     let value = false;
     const windowsPty = this.optionsService.rawOptions.windowsPty;
-    if (windowsPty && windowsPty.buildNumber !== undefined && windowsPty.buildNumber !== undefined) {
+    if (windowsPty && windowsPty.backend !== undefined && windowsPty.buildNumber !== undefined) {
       value = !!(windowsPty.backend === 'conpty' && windowsPty.buildNumber < 21376);
     }
     if (value) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5934

In `_handleWindowsPtyOptionChange()`, the guard for enabling Windows ConPTY wrapping heuristics checked `buildNumber` twice instead of requiring both `backend` and `buildNumber` to be defined. This matches the pattern used in `Buffer.ts` and ensures the ConPTY reflow heuristic is only evaluated when both fields are present.

## Changes

- `src/common/CoreTerminal.ts`: Replace duplicate `windowsPty.buildNumber !== undefined` check with `windowsPty.backend !== undefined`.

## Test plan

- [x] `npm run build` passes
- [ ] Existing Windows Pty integration tests in `test/playwright/Terminal.test.ts` (not run in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ec765e5-c124-47d1-9533-33e7639acbb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ec765e5-c124-47d1-9533-33e7639acbb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

