### PR TITLE
Avoid spread when merging decoration line buckets

### DIFF
--- a/src/common/services/DecorationService.ts
+++ b/src/common/services/DecorationService.ts
@@ -225,12 +225,7 @@ export class DecorationLineCache extends Disposable {
       if (newLine < 0) {
         continue;
       }
-      const existing = newMap.get(newLine);
-      if (existing) {
-        existing.push(...bucket);
-      } else {
-        newMap.set(newLine, bucket.slice());
-      }
+      this._mergeLineBucket(newMap, newLine, bucket);
     }
     this._decorationsByLine.clear();
     for (const [line, bucket] of newMap) {
@@ -254,7 +249,9 @@ export class DecorationLineCache extends Disposable {
   private _mergeLineBucket(newMap: Map<number, IInternalDecoration[]>, line: number, bucket: IInternalDecoration[]): void {
     const existing = newMap.get(line);
     if (existing) {
-      existing.push(...bucket);
+      for (let i = 0, len = bucket.length; i < len; i++) {
+        existing.push(bucket[i]);
+      }
     } else {
       newMap.set(line, bucket.slice());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5941 by replacing `existing.push(...bucket)` with an indexed loop when merging decoration line buckets during buffer trim, insert, and delete re-indexing. Spread creates a temporary arguments array for each merge, which adds avoidable allocation pressure on hot buffer paths.

`_handleBufferLinesTrim` now delegates to `_mergeLineBucket` (same as insert/delete) so all merge paths share one implementation.

## Testing

- `npm run build && npm run esbuild`
- `npm run test-unit -- **/DecorationService.test.js` (20 passing)
- `npm run lint-changes`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aad5a88f-eb27-4f39-b99d-8a546f987132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aad5a88f-eb27-4f39-b99d-8a546f987132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

