### PR TITLE
Rename headless core addMarker → registerMarker

### DIFF
--- a/src/headless/Terminal.ts
+++ b/src/headless/Terminal.ts
@@ -69,7 +69,7 @@ export class Terminal extends CoreTerminal {
     return this.buffer.markers;
   }
 
-  public addMarker(cursorYOffset: number): IMarker | undefined {
+  public registerMarker(cursorYOffset: number): IMarker | undefined {
     // Disallow markers on the alt buffer
     if (this.buffer !== this.buffers.normal) {
       return;

--- a/src/headless/public/Terminal.ts
+++ b/src/headless/public/Terminal.ts
@@ -141,7 +141,7 @@ export class Terminal extends Disposable implements ITerminalApi {
   }
   public registerMarker(cursorYOffset: number = 0): IMarker | undefined {
     this._verifyIntegers(cursorYOffset);
-    return this._core.addMarker(cursorYOffset);
+    return this._core.registerMarker(cursorYOffset);
   }
   public addMarker(cursorYOffset: number): IMarker | undefined {
     return this.registerMarker(cursorYOffset);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renames `addMarker` to `registerMarker` on the headless core `Terminal` so it matches `CoreBrowserTerminal` and the public API.

The headless public `Terminal` already exposed `registerMarker`; it now delegates to `_core.registerMarker`. The legacy `addMarker` alias on the public headless API is unchanged.

Fixes #5938
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc70e3c6-8409-482c-932e-90527a3f22c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc70e3c6-8409-482c-932e-90527a3f22c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

