### PR TITLE
Cancel WriteBuffer innerWrite timers on dispose

### DIFF
--- a/src/common/input/WriteBuffer.test.ts
+++ b/src/common/input/WriteBuffer.test.ts
@@ -140,5 +140,34 @@ describe('WriteBuffer', () => {
       wb.flushSync();
       assert.equal(parsed, 0);
     });
+    it('dispose cancels scheduled innerWrite', done => {
+      wb.write('a');
+      wb.dispose();
+      setTimeout(() => {
+        assert.deepEqual(stack, []);
+        done();
+      }, 20);
+    });
+    it('dispose does not fire onWriteParsed for pending writes', done => {
+      let parsed = 0;
+      wb.onWriteParsed(() => parsed++);
+      wb.write('a');
+      wb.dispose();
+      setTimeout(() => {
+        assert.equal(parsed, 0);
+        done();
+      }, 20);
+    });
+    it('write after dispose is a no-op', done => {
+      wb.dispose();
+      wb.write('a', () => {
+        assert.deepEqual(stack, []);
+        done();
+      });
+      setTimeout(() => {
+        assert.deepEqual(stack, []);
+        done();
+      }, 20);
+    });
   });
 });

--- a/src/common/input/WriteBuffer.test.ts
+++ b/src/common/input/WriteBuffer.test.ts
@@ -160,14 +160,51 @@ describe('WriteBuffer', () => {
     });
     it('write after dispose is a no-op', done => {
       wb.dispose();
-      wb.write('a', () => {
-        assert.deepEqual(stack, []);
-        done();
-      });
+      wb.write('a');
       setTimeout(() => {
         assert.deepEqual(stack, []);
         done();
       }, 20);
+    });
+    it('dispose is idempotent', done => {
+      wb.write('a');
+      wb.dispose();
+      wb.dispose();
+      setTimeout(() => {
+        assert.deepEqual(stack, []);
+        done();
+      }, 20);
+    });
+    it('async handler continuation is skipped after dispose', done => {
+      let resolve!: (value: boolean) => void;
+      const pending = new Promise<boolean>(r => { resolve = r; });
+      wb = new WriteBuffer(() => pending);
+      wb.write('a');
+      wb.dispose();
+      resolve(true);
+      setTimeout(() => {
+        assert.deepEqual(stack, []);
+        done();
+      }, 20);
+    });
+    it('handleUserInput still processes first chunk synchronously', () => {
+      wb.handleUserInput();
+      wb.write('a');
+      assert.deepEqual(stack, ['a']);
+    });
+    it('flushSync after dispose is a no-op', done => {
+      wb.write('a');
+      wb.dispose();
+      wb.flushSync();
+      setTimeout(() => {
+        assert.deepEqual(stack, []);
+        done();
+      }, 20);
+    });
+    it('writeSync after dispose is a no-op', () => {
+      wb.dispose();
+      wb.writeSync('a');
+      assert.deepEqual(stack, []);
     });
   });
 });

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -5,7 +5,7 @@
  */
 
 import { TimeoutTimer } from 'common/Async';
-import { Disposable } from 'common/Lifecycle';
+import { Disposable, toDisposable } from 'common/Lifecycle';
 import { Emitter } from 'common/Event';
 
 const enum Constants {
@@ -48,17 +48,12 @@ export class WriteBuffer extends Disposable {
 
   constructor(private _action: (data: string | Uint8Array, promiseResult?: boolean) => void | Promise<boolean>) {
     super();
-  }
-
-  public override dispose(): void {
-    if (this._store.isDisposed) {
-      return;
-    }
-    this._writeBuffer.length = 0;
-    this._callbacks.length = 0;
-    this._pendingData = 0;
-    this._bufferOffset = 0;
-    super.dispose();
+    this._register(toDisposable(() => {
+      this._writeBuffer.length = 0;
+      this._callbacks.length = 0;
+      this._pendingData = 0;
+      this._bufferOffset = 0;
+    }));
   }
 
   public handleUserInput(): void {

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -41,7 +41,6 @@ export class WriteBuffer extends Disposable {
   private _isSyncWriting = false;
   private _syncCalls = 0;
   private _didUserInput = false;
-  private _isDisposed = false;
 
   private readonly _innerWriteTimer = this._register(new TimeoutTimer());
   private readonly _onWriteParsed = this._register(new Emitter<void>());
@@ -52,10 +51,9 @@ export class WriteBuffer extends Disposable {
   }
 
   public override dispose(): void {
-    if (this._isDisposed) {
+    if (this._store.isDisposed) {
       return;
     }
-    this._isDisposed = true;
     this._writeBuffer.length = 0;
     this._callbacks.length = 0;
     this._pendingData = 0;
@@ -76,7 +74,7 @@ export class WriteBuffer extends Disposable {
    * promises to resolve.
    */
   public flushSync(): void {
-    if (this._isDisposed) {
+    if (this._store.isDisposed) {
       return;
     }
     // exit early if another sync write loop is active
@@ -111,7 +109,7 @@ export class WriteBuffer extends Disposable {
    * @deprecated Unreliable, to be removed soon.
    */
   public writeSync(data: string | Uint8Array, maxSubsequentCalls?: number): void {
-    if (this._isDisposed) {
+    if (this._store.isDisposed) {
       return;
     }
     // stop writeSync recursions with maxSubsequentCalls argument
@@ -157,7 +155,7 @@ export class WriteBuffer extends Disposable {
   }
 
   public write(data: string | Uint8Array, callback?: () => void): void {
-    if (this._isDisposed) {
+    if (this._store.isDisposed) {
       return;
     }
     if (this._pendingData > Constants.DISCARD_WATERMARK) {
@@ -217,14 +215,14 @@ export class WriteBuffer extends Disposable {
    * Note, for pure sync code `lastTime` and `promiseResult` have no meaning.
    */
   private _scheduleInnerWrite(lastTime: number = 0, promiseResult: boolean = true): void {
-    if (this._isDisposed) {
+    if (this._store.isDisposed) {
       return;
     }
     this._innerWriteTimer.cancelAndSet(() => this._innerWrite(lastTime, promiseResult), 0);
   }
 
   protected _innerWrite(lastTime: number = 0, promiseResult: boolean = true): void {
-    if (this._isDisposed) {
+    if (this._store.isDisposed) {
       return;
     }
     const startTime = lastTime || performance.now();
@@ -256,7 +254,7 @@ export class WriteBuffer extends Disposable {
          * gain control.
          */
         const continuation: (r: boolean) => void = (r: boolean) => {
-          if (this._isDisposed) {
+          if (this._store.isDisposed) {
             return;
           }
           if (performance.now() - startTime >= Constants.WRITE_TIMEOUT_MS) {

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -4,10 +4,9 @@
  * @license MIT
  */
 
+import { TimeoutTimer } from 'common/Async';
 import { Disposable } from 'common/Lifecycle';
 import { Emitter } from 'common/Event';
-
-declare const setTimeout: (handler: () => void, timeout?: number) => void;
 
 const enum Constants {
   /**
@@ -42,12 +41,26 @@ export class WriteBuffer extends Disposable {
   private _isSyncWriting = false;
   private _syncCalls = 0;
   private _didUserInput = false;
+  private _isDisposed = false;
 
+  private readonly _innerWriteTimer = this._register(new TimeoutTimer());
   private readonly _onWriteParsed = this._register(new Emitter<void>());
   public readonly onWriteParsed = this._onWriteParsed.event;
 
   constructor(private _action: (data: string | Uint8Array, promiseResult?: boolean) => void | Promise<boolean>) {
     super();
+  }
+
+  public override dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._writeBuffer.length = 0;
+    this._callbacks.length = 0;
+    this._pendingData = 0;
+    this._bufferOffset = 0;
+    super.dispose();
   }
 
   public handleUserInput(): void {
@@ -63,6 +76,9 @@ export class WriteBuffer extends Disposable {
    * promises to resolve.
    */
   public flushSync(): void {
+    if (this._isDisposed) {
+      return;
+    }
     // exit early if another sync write loop is active
     if (this._isSyncWriting) {
       return;
@@ -95,6 +111,9 @@ export class WriteBuffer extends Disposable {
    * @deprecated Unreliable, to be removed soon.
    */
   public writeSync(data: string | Uint8Array, maxSubsequentCalls?: number): void {
+    if (this._isDisposed) {
+      return;
+    }
     // stop writeSync recursions with maxSubsequentCalls argument
     // This is dangerous to use as it will lose the current data chunk
     // and return immediately.
@@ -138,6 +157,9 @@ export class WriteBuffer extends Disposable {
   }
 
   public write(data: string | Uint8Array, callback?: () => void): void {
+    if (this._isDisposed) {
+      return;
+    }
     if (this._pendingData > Constants.DISCARD_WATERMARK) {
       throw new Error('write data discarded, use flow control to avoid losing data');
     }
@@ -158,7 +180,7 @@ export class WriteBuffer extends Disposable {
         return;
       }
 
-      setTimeout(() => this._innerWrite());
+      this._scheduleInnerWrite();
     }
 
     this._pendingData += data.length;
@@ -194,7 +216,17 @@ export class WriteBuffer extends Disposable {
    *
    * Note, for pure sync code `lastTime` and `promiseResult` have no meaning.
    */
+  private _scheduleInnerWrite(lastTime: number = 0, promiseResult: boolean = true): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._innerWriteTimer.cancelAndSet(() => this._innerWrite(lastTime, promiseResult), 0);
+  }
+
   protected _innerWrite(lastTime: number = 0, promiseResult: boolean = true): void {
+    if (this._isDisposed) {
+      return;
+    }
     const startTime = lastTime || performance.now();
     while (this._writeBuffer.length > this._bufferOffset) {
       const data = this._writeBuffer[this._bufferOffset];
@@ -223,9 +255,16 @@ export class WriteBuffer extends Disposable {
          * responsibility to slice hard work), but we can at least schedule a screen update as we
          * gain control.
          */
-        const continuation: (r: boolean) => void = (r: boolean) => performance.now() - startTime >= Constants.WRITE_TIMEOUT_MS
-          ? setTimeout(() => this._innerWrite(0, r))
-          : this._innerWrite(startTime, r);
+        const continuation: (r: boolean) => void = (r: boolean) => {
+          if (this._isDisposed) {
+            return;
+          }
+          if (performance.now() - startTime >= Constants.WRITE_TIMEOUT_MS) {
+            this._scheduleInnerWrite(0, r);
+          } else {
+            this._innerWrite(startTime, r);
+          }
+        };
 
         /**
          * Optimization considerations:
@@ -272,7 +311,7 @@ export class WriteBuffer extends Disposable {
         this._callbacks = this._callbacks.slice(this._bufferOffset);
         this._bufferOffset = 0;
       }
-      setTimeout(() => this._innerWrite());
+      this._scheduleInnerWrite();
     } else {
       this._writeBuffer.length = 0;
       this._callbacks.length = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5936

`WriteBuffer` scheduled `_innerWrite` via `setTimeout` without canceling those timers on dispose. A disposed terminal could still process pending writes and fire `onWriteParsed`.

## Changes

- Route all `_innerWrite` macrotask scheduling through a registered `TimeoutTimer` that is canceled on dispose
- Guard `_innerWrite`, `write`, `writeSync`, and `flushSync` after disposal
- Clear pending buffer state in `dispose()`
- Add unit tests for dispose behavior

## Test plan

- [x] `npm run test-unit -- **/out-esbuild/**/WriteBuffer.test.js` (14 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c571b365-b319-428b-aae3-13921f21124c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c571b365-b319-428b-aae3-13921f21124c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

