### PR TITLE
Ignore .cursor/*.log files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test-results/
 
 # Tracing/debug files
 .cursor/nal-trace/
+.cursor/*.log
 
 # Keep bundled code out of Git
 dist/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.cursor/*.log` to the root `.gitignore`, directly below the existing `.cursor/nal-trace/` rule, so Cursor log files under `.cursor/` are not tracked by git.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-263032f1-e8e5-46cb-b2b0-db4704c15a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-263032f1-e8e5-46cb-b2b0-db4704c15a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

