### PR TITLE
fix(addon-progress): stabilize flaky WebKit integration test harness

### DIFF
--- a/addons/addon-progress/test/ProgressAddon.test.ts
+++ b/addons/addon-progress/test/ProgressAddon.test.ts
@@ -9,15 +9,18 @@ import { ITestContext, createTestContext, openTerminal } from '../../../test/pla
 
 
 let ctx: ITestContext;
-test.beforeAll(async ({ browser }) => {
-  ctx = await createTestContext(browser);
-  ctx.page.setViewportSize({ width: 1024, height: 768 });
-  await openTerminal(ctx);
-});
-test.afterAll(async () => await ctx.page.close());
-
 
 test.describe('ProgressAddon', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(async ({ browser }) => {
+    ctx = await createTestContext(browser);
+    await openTerminal(ctx);
+  });
+  test.afterAll(async () => {
+    await ctx?.page?.close();
+  });
+
   test.beforeEach(async function(): Promise<any> {
     await ctx.page.evaluate(`
       window.progressStack = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes flaky `[WebKit] ProgressAddon › invalid sequences should not emit anything` failures reported in #5956.

The CI error pointed at `page.setViewportSize` in `beforeAll` (`Target page, context or browser has been closed`), not at the invalid-sequence assertions. ProgressAddon tests do not depend on viewport size (unlike FitAddon).

## Changes

- Remove unnecessary, unawaited `setViewportSize` call
- Move `beforeAll` / `afterAll` inside the `ProgressAddon` describe block
- Enable `test.describe.configure({ mode: 'serial' })` for the shared-page pattern
- Guard `afterAll` with `ctx?.page?.close()` when setup fails

## Verification

- Chromium: ProgressAddon suite passed 50+ runs locally with `--workers=50%` (CI-like)
- WebKit: should be validated in CI (`npm run test-integration-webkit -- --workers=50% --suite=addon-progress`)

Fixes #5956
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb2d05bd-3f77-4962-a6d3-1798ba535577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb2d05bd-3f77-4962-a6d3-1798ba535577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

