### PR TITLE
fix: pass radix 10 to parseInt across core and addons

### DIFF
--- a/addons/addon-fit/src/FitAddon.ts
+++ b/addons/addon-fit/src/FitAddon.ts
@@ -74,8 +74,8 @@ export class FitAddon implements ITerminalAddon, IFitApi {
       : (this._terminal.options.scrollbar?.width ?? ViewportConstants.DEFAULT_SCROLL_BAR_WIDTH));
 
     const parentElementStyle = _getComputedStyle(this._terminal.element.parentElement);
-    const parentElementHeight = parseInt(parentElementStyle.getPropertyValue('height'));
-    const parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width')));
+    const parentElementHeight = Math.max(0, parseInt(parentElementStyle.getPropertyValue('height'), 10) || 0);
+    const parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width'), 10) || 0);
     const elementStyle = _getComputedStyle(this._terminal.element);
     const elementPadding = {
       top: parseInt(elementStyle.getPropertyValue('padding-top')),

--- a/addons/addon-fit/src/FitAddon.ts
+++ b/addons/addon-fit/src/FitAddon.ts
@@ -78,10 +78,10 @@ export class FitAddon implements ITerminalAddon, IFitApi {
     const parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width'), 10) || 0);
     const elementStyle = _getComputedStyle(this._terminal.element);
     const elementPadding = {
-      top: parseInt(elementStyle.getPropertyValue('padding-top')),
-      bottom: parseInt(elementStyle.getPropertyValue('padding-bottom')),
-      right: parseInt(elementStyle.getPropertyValue('padding-right')),
-      left: parseInt(elementStyle.getPropertyValue('padding-left'))
+      top: parseInt(elementStyle.getPropertyValue('padding-top'), 10) || 0,
+      bottom: parseInt(elementStyle.getPropertyValue('padding-bottom'), 10) || 0,
+      right: parseInt(elementStyle.getPropertyValue('padding-right'), 10) || 0,
+      left: parseInt(elementStyle.getPropertyValue('padding-left'), 10) || 0
     };
     const elementPaddingVer = elementPadding.top + elementPadding.bottom;
     const elementPaddingHor = elementPadding.right + elementPadding.left;

--- a/addons/addon-image/src/IIPHandler.ts
+++ b/addons/addon-image/src/IIPHandler.ts
@@ -222,8 +222,8 @@ export class IIPHandler implements IOscHandler, IResetHandler {
 
   private _dim(s: string, total: number, cdim: number): number {
     if (s === 'auto') return 0;
-    if (s.endsWith('%')) return parseInt(s.slice(0, -1)) * total / 100;
-    if (s.endsWith('px')) return parseInt(s.slice(0, -2));
-    return parseInt(s) * cdim;
+    if (s.endsWith('%')) return parseInt(s.slice(0, -1), 10) * total / 100;
+    if (s.endsWith('px')) return parseInt(s.slice(0, -2), 10);
+    return parseInt(s, 10) * cdim;
   }
 }

--- a/addons/addon-image/src/kitty/KittyGraphicsTypes.ts
+++ b/addons/addon-image/src/kitty/KittyGraphicsTypes.ts
@@ -168,7 +168,7 @@ export function parseKittyCommand(data: string): IKittyCommand {
       cmd.deleteSelector = value;
       continue;
     }
-    const numValue = parseInt(value);
+    const numValue = parseInt(value, 10);
     switch (key) {
       case KittyKey.FORMAT: cmd.format = numValue; break;
       case KittyKey.ID: cmd.id = numValue; break;

--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
@@ -221,8 +221,8 @@ function drawPathDefinitionCharacter(
       const rx = parseFloat(args[0]) * deviceCellWidth;
       const ry = parseFloat(args[1]) * deviceCellHeight;
       const xAxisRotation = parseFloat(args[2]) * Math.PI / 180;
-      const largeArcFlag = parseInt(args[3]);
-      const sweepFlag = parseInt(args[4]);
+      const largeArcFlag = parseInt(args[3], 10);
+      const sweepFlag = parseInt(args[4], 10);
       const x = xOffset + parseFloat(args[5]) * deviceCellWidth;
       const y = yOffset + parseFloat(args[6]) * deviceCellHeight;
       drawSvgArc(ctx, currentX, currentY, rx, ry, xAxisRotation, largeArcFlag, sweepFlag, x, y);

--- a/src/browser/input/Mouse.ts
+++ b/src/browser/input/Mouse.ts
@@ -6,8 +6,8 @@
 export function getCoordsRelativeToElement(window: Pick<Window, 'getComputedStyle'>, event: {clientX: number, clientY: number}, element: HTMLElement): [number, number] {
   const rect = element.getBoundingClientRect();
   const elementStyle = window.getComputedStyle(element);
-  const leftPadding = parseInt(elementStyle.getPropertyValue('padding-left'));
-  const topPadding = parseInt(elementStyle.getPropertyValue('padding-top'));
+  const leftPadding = parseInt(elementStyle.getPropertyValue('padding-left'), 10);
+  const topPadding = parseInt(elementStyle.getPropertyValue('padding-top'), 10);
   return [
     event.clientX - rect.left - leftPadding,
     event.clientY - rect.top - topPadding
@@ -22,7 +22,7 @@ export function getCoordsRelativeToElement(window: Pick<Window, 'getComputedStyl
  * @param event The mouse event.
  * @param element The terminal's container element.
  * @param colCount The number of columns in the terminal.
- * @param rowCount The number of rows n the terminal.
+ * @param rowCount The number of rows in the terminal.
  * @param hasValidCharSize Whether there is a valid character size available.
  * @param cssCellWidth The cell width device pixel render dimensions.
  * @param cssCellHeight The cell height device pixel render dimensions.

--- a/src/browser/scrollable/mouseEvent.ts
+++ b/src/browser/scrollable/mouseEvent.ts
@@ -217,7 +217,7 @@ export class StandardWheelEvent {
     let shouldFactorDPR: boolean = false;
     if (platform.isChrome) {
       const chromeVersionMatch = navigator.userAgent.match(/Chrome\/(\d+)/);
-      const chromeMajorVersion = chromeVersionMatch ? parseInt(chromeVersionMatch[1]) : 123;
+      const chromeMajorVersion = chromeVersionMatch ? parseInt(chromeVersionMatch[1], 10) : 123;
       shouldFactorDPR = chromeMajorVersion <= 122;
     }
 

--- a/src/common/Color.ts
+++ b/src/common/Color.ts
@@ -177,9 +177,9 @@ export namespace css {
     // Formats: rgb() or rgba()
     const rgbaMatch = css.match(/rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(,\s*(0|1|\d?\.(\d+))\s*)?\)/);
     if (rgbaMatch) {
-      $r = parseInt(rgbaMatch[1]);
-      $g = parseInt(rgbaMatch[2]);
-      $b = parseInt(rgbaMatch[3]);
+      $r = parseInt(rgbaMatch[1], 10);
+      $g = parseInt(rgbaMatch[2], 10);
+      $b = parseInt(rgbaMatch[3], 10);
       $a = Math.round((rgbaMatch[5] === undefined ? 1 : parseFloat(rgbaMatch[5])) * 0xFF);
       return channels.toColor($r, $g, $b, $a);
     }

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -3065,7 +3065,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       const idx = slots.shift() as string;
       const spec = slots.shift() as string;
       if (/^\d+$/.exec(idx)) {
-        const index = parseInt(idx);
+        const index = parseInt(idx, 10);
         if (isValidColorIndex(index)) {
           if (spec === '?') {
             event.push({ type: ColorRequestType.REPORT, index });
@@ -3228,7 +3228,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     const slots = data.split(';');
     for (let i = 0; i < slots.length; ++i) {
       if (/^\d+$/.exec(slots[i])) {
-        const index = parseInt(slots[i]);
+        const index = parseInt(slots[i], 10);
         if (isValidColorIndex(index)) {
           event.push({ type: ColorRequestType.RESTORE, index });
         }

--- a/src/common/Platform.ts
+++ b/src/common/Platform.ts
@@ -41,7 +41,7 @@ export function getSafariVersion(): number {
   if (majorVersion === null || majorVersion.length < 2) {
     return 0;
   }
-  return parseInt(majorVersion[1]);
+  return parseInt(majorVersion[1], 10);
 }
 
 // Find the users platform. We use this to interpret the meta key


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pass explicit radix `10` to `parseInt` calls across core and addons so numeric strings are always interpreted as decimal. This aligns with the `prefer-parseint-radix` lint rule and avoids legacy octal interpretation when values have leading zeros (for example CSS dimensions or version substrings).

## Touched areas

- **browser**: mouse padding and scrollable mouse events; Chrome major version detection
- **common**: Safari version parsing, `rgb()`/`rgba()` color components, OSC palette color indices
- **addon-fit**: parent element width/height and terminal padding from computed styles (with `|| 0` fallbacks where appropriate)
- **addon-image**: IIP dimension parsing and kitty graphics numeric keys
- **addon-webgl**: SVG arc flag parsing in custom glyph rasterization

## Notes

- Fit addon parent dimension parsing also applies `Math.max(0, … || 0)` for height to match width handling and avoid `NaN` from non-numeric CSS values.

## Testing

- `npm run build && npm run esbuild`
- Unit tests: `Mouse.test.js`, `Color.test.js`, `InputHandler.test.js`, addon-image and addon-webgl esbuild test bundles
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b2145f5-e193-4876-bc26-d740cac8cdeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b2145f5-e193-4876-bc26-d740cac8cdeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

