### PR TITLE
fix(parser): Params error grammar and ESC prefix precedence

### DIFF
--- a/src/common/parser/ApcParser.test.ts
+++ b/src/common/parser/ApcParser.test.ts
@@ -21,7 +21,7 @@ function identifier(id: IFunctionIdentifier): number {
       throw new Error('only one byte as prefix supported');
     }
     res = id.prefix.charCodeAt(0);
-    if (res && 0x3c > res || res > 0x3f) {
+    if (res < 0x3c || res > 0x3f) {
       throw new Error('prefix must be in range 0x3c .. 0x3f');
     }
   }

--- a/src/common/parser/DcsParser.test.ts
+++ b/src/common/parser/DcsParser.test.ts
@@ -22,7 +22,7 @@ function identifier(id: IFunctionIdentifier): number {
       throw new Error('only one byte as prefix supported');
     }
     res = id.prefix.charCodeAt(0);
-    if (res && 0x3c > res || res > 0x3f) {
+    if (res < 0x3c || res > 0x3f) {
       throw new Error('prefix must be in range 0x3c .. 0x3f');
     }
   }

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -342,7 +342,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
         throw new Error('only one byte as prefix supported');
       }
       res = id.prefix.charCodeAt(0);
-      if (res && 0x3c > res || res > 0x3f) {
+      if (res < 0x3c || res > 0x3f) {
         throw new Error('prefix must be in range 0x3c .. 0x3f');
       }
     }

--- a/src/common/parser/Params.test.ts
+++ b/src/common/parser/Params.test.ts
@@ -199,13 +199,13 @@ describe('Params', () => {
     it('reject params lesser -1', () => {
       const params = new Params();
       params.addParam(-1);
-      assert.throws(() => params.addParam(-2), 'values lesser than -1 are not allowed');
+      assert.throws(() => params.addParam(-2), 'values less than -1 are not allowed');
     });
     it('reject subparams lesser -1', () => {
       const params = new Params();
       params.addParam(-1);
       params.addSubParam(-1);
-      assert.throws(() => params.addSubParam(-2), 'values lesser than -1 are not allowed');
+      assert.throws(() => params.addSubParam(-2), 'values less than -1 are not allowed');
       assert.deepEqual(params.toArray(), [-1, [-1]]);
     });
     it('clamp parsed params', () => {

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -162,7 +162,7 @@ export class Params implements IParams {
       return;
     }
     if (value < -1) {
-      throw new Error('values lesser than -1 are not allowed');
+      throw new Error('values less than -1 are not allowed');
     }
     this._subParamsIdx[this.length] = this._subParamsLength << 8 | this._subParamsLength;
     this.params[this.length++] = value > Constants.MAX_VALUE ? Constants.MAX_VALUE : value;
@@ -185,7 +185,7 @@ export class Params implements IParams {
       return;
     }
     if (value < -1) {
-      throw new Error('values lesser than -1 are not allowed');
+      throw new Error('values less than -1 are not allowed');
     }
     this._subParams[this._subParamsLength++] = value > Constants.MAX_VALUE ? Constants.MAX_VALUE : value;
     this._subParamsIdx[this.length - 1]++;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small parser validation fixes with matching test updates.

### Params validation messages

`addParam` and `addSubParam` throw when a value is below `-1`. The error text used non-standard wording (`values lesser than -1`). This updates the messages to `values less than -1`, which matches normal English for numeric comparisons and what the unit tests assert.

### ESC prefix byte range check

When building escape-sequence function identifiers, the ESC prefix must be in `0x3c`–`0x3f`. The condition was written as `res && 0x3c > res || res > 0x3f`, which parsed as `(res && 0x3c > res) || (res > 0x3f)` because `&&` binds tighter than `||`. That skipped the lower-bound check whenever `res` was truthy (including valid prefixes such as `0x3c`), so only the upper bound was enforced.

The check is now `res < 0x3c || res > 0x3f`, so both bounds apply for all prefix byte values.

## Tests

- `Params.test.ts` — expected throw messages
- `ApcParser.test.ts`, `DcsParser.test.ts` — test helper `identifier()` mirrors production validation
- `EscapeSequenceParser.ts` — production `identifier()` implementation

Validated with:

```bash
npm run test-unit -- out-esbuild/common/parser/Params.test.js out-esbuild/common/parser/ApcParser.test.js out-esbuild/common/parser/DcsParser.test.js out-esbuild/common/parser/EscapeSequenceParser.test.js
```

(218 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d376d09-d358-4ee5-b1ce-f34b9d4932e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d376d09-d358-4ee5-b1ce-f34b9d4932e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

