### PR TITLE
chore(benchmark): remove trailing whitespace in benchmark.json

### DIFF
--- a/test/benchmark/benchmark.json
+++ b/test/benchmark/benchmark.json
@@ -15,5 +15,5 @@
       "EscapeSequenceParser.benchmark.js.*.averageRuntime",
       "Terminal.benchmark.js.*.averageRuntime"
     ]
-  } 
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Whitespace-only change in `test/benchmark/benchmark.json`: removes a stray trailing space after the `evalConfig` closing brace.

**Validation**
- `git diff master..HEAD --ignore-all-space --ignore-blank-lines test/benchmark/benchmark.json` is empty (no non-whitespace changes)
- `JSON.parse` succeeds on the updated file
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad030cd1-48fa-49bc-a0cf-a7046eff160a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad030cd1-48fa-49bc-a0cf-a7046eff160a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

