### PR TITLE
docs: fix cross-cutting comment and typo cleanups

### DIFF
--- a/addons/addon-clipboard/typings/addon-clipboard.d.ts
+++ b/addons/addon-clipboard/typings/addon-clipboard.d.ts
@@ -82,7 +82,7 @@ declare module '@xterm/addon-clipboard' {
   /**
    * The clipboard provider interface that enables xterm.js to access the browser clipboard.
    *
-   * Note this this clipboard provider does not implement own cut buffers as xterm does,
+   * Note that this clipboard provider does not implement own cut buffers as xterm does,
    * but redirect the selection parameter always to navigator.clipboard.
    */
   export class BrowserClipboardProvider implements IClipboardProvider{

--- a/addons/addon-ligatures/src/index.ts
+++ b/addons/addon-ligatures/src/index.ts
@@ -21,7 +21,7 @@ const CACHE_SIZE = 100000;
 
 /**
  * Enable ligature support for the provided Terminal instance. To function
- * properly, this must be called after `open()` is called on the therminal. If
+ * properly, this must be called after `open()` is called on the terminal. If
  * the font currently in use supports ligatures, the terminal will automatically
  * start to render them.
  * @param term Terminal instance from xterm.js

--- a/addons/addon-serialize/src/SerializeAddon.ts
+++ b/addons/addon-serialize/src/SerializeAddon.ts
@@ -173,7 +173,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
   private _thisRowLastSecondChar: IBufferCell = this._buffer.getNullCell();
   private _nextRowFirstChar: IBufferCell = this._buffer.getNullCell();
   protected _rowEnd(row: number, isLastRow: boolean): void {
-    // if there is colorful empty cell at line end, whe must pad it back, or the the color block
+    // if there is colorful empty cell at line end, we must pad it back, or the color block
     // will missing
     if (this._nullCellCount > 0 && !equalBg(this._cursorStyle, this._backgroundCell)) {
       // use clear right to set background.

--- a/addons/addon-serialize/src/SerializeAddon.ts
+++ b/addons/addon-serialize/src/SerializeAddon.ts
@@ -221,7 +221,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
             // you can't use control sequence to move cursor to (x === row)
             (thisRowLastChar.getChars() || thisRowLastChar.getWidth() === 0) &&
             // change background of the first wrapped cell also affects BCE
-            // so we mark it as invalid to simply the process to determine line separator
+            // so we mark it as invalid to simplify the process to determine line separator
             equalBg(thisRowLastChar, nextRowFirstChar)
           ) {
             isValid = true;
@@ -233,7 +233,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
             isNextRowFirstCharDoubleWidth &&
             (thisRowLastSecondChar.getChars() || thisRowLastSecondChar.getWidth() === 0) &&
             // change background of the first wrapped cell also affects BCE
-            // so we mark it as invalid to simply the process to determine line separator
+            // so we mark it as invalid to simplify the process to determine line separator
             equalBg(thisRowLastChar, nextRowFirstChar) &&
             equalBg(thisRowLastSecondChar, nextRowFirstChar)
           ) {

--- a/addons/addon-serialize/test/SerializeAddon.test.ts
+++ b/addons/addon-serialize/test/SerializeAddon.test.ts
@@ -192,7 +192,7 @@ test.describe('SerializeAddon', () => {
     const cols = 10;
     const line = '+'.repeat(cols);
     const lines: string[] = [
-      sgr(FG_P16_GREEN) + line,  // Workaround: If we clear all flags a the end, serialize will use \x1b[0m to clear instead of the sepcific disable sequence
+      sgr(FG_P16_GREEN) + line,  // Workaround: If we clear all flags at the end, serialize will use \x1b[0m to clear instead of the specific disable sequence
       sgr(INVERSE) + line,
       sgr(BOLD) + line,
       sgr(UNDERLINED) + line,

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -1125,7 +1125,7 @@ function clearColor(imageData: ImageData, bg: IColor, fg: IColor, enableThreshol
   // were covered (fg=#8ae234, bg=#c4a000).
   const threshold = Math.floor((Math.abs(r - fgR) + Math.abs(g - fgG) + Math.abs(b - fgB)) / 12);
 
-  // Set alpha channel of relevent pixels to 0
+  // Set alpha channel of relevant pixels to 0
   let isEmpty = true;
   for (let offset = 0; offset < imageData.data.length; offset += 4) {
     // Check exact match

--- a/addons/addon-webgl/src/WebglAddon.ts
+++ b/addons/addon-webgl/src/WebglAddon.ts
@@ -40,7 +40,7 @@ export class WebglAddon extends Disposable implements ITerminalAddon, IWebglApi 
       };
       const gl = document.createElement('canvas').getContext('webgl2', contextAttributes) as IWebGL2RenderingContext;
       if (!gl) {
-        throw new Error('Webgl2 is only supported on Safari 16 and above');
+        throw new Error('WebGL2 is only supported on Safari 16 and above');
       }
     }
     super();

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -664,7 +664,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this.dimensions.device.canvas.height = this._terminal.rows * this.dimensions.device.cell.height;
     this.dimensions.device.canvas.width = this._terminal.cols * this.dimensions.device.cell.width;
 
-    // The the size of the canvas on the page. It's important that this rounds to nearest integer
+    // The size of the canvas on the page. It's important that this rounds to nearest integer
     // and not ceils as browsers often have floating point precision issues where
     // `window.devicePixelRatio` ends up being something like `1.100000023841858` for example, when
     // it's actually 1.1. Ceiling may cause blurriness as the backing canvas image is 1 pixel too

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -667,7 +667,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     // The the size of the canvas on the page. It's important that this rounds to nearest integer
     // and not ceils as browsers often have floating point precision issues where
     // `window.devicePixelRatio` ends up being something like `1.100000023841858` for example, when
-    // it's actually 1.1. Ceiling may causes blurriness as the backing canvas image is 1 pixel too
+    // it's actually 1.1. Ceiling may cause blurriness as the backing canvas image is 1 pixel too
     // large for the canvas element size.
     this.dimensions.css.canvas.height = Math.round(this.dimensions.device.canvas.height / this._devicePixelRatio);
     this.dimensions.css.canvas.width = Math.round(this.dimensions.device.canvas.width / this._devicePixelRatio);

--- a/addons/addon-webgl/typings/addon-webgl.d.ts
+++ b/addons/addon-webgl/typings/addon-webgl.d.ts
@@ -23,12 +23,12 @@ declare module '@xterm/addon-webgl' {
     public readonly onChangeTextureAtlas: IEvent<HTMLCanvasElement>;
 
     /**
-     * An event that is fired when the a new page is added to the texture atlas.
+     * An event that is fired when a new page is added to the texture atlas.
      */
     public readonly onAddTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 
     /**
-     * An event that is fired when the a page is removed from the texture atlas.
+     * An event that is fired when a page is removed from the texture atlas.
      */
     public readonly onRemoveTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -430,7 +430,7 @@ export class DomRenderer extends Disposable implements IRenderer {
         documentFragment.appendChild(this._createSelectionElement(viewportCappedStartRow + 1, 0, this._bufferService.cols, middleRowsCount));
         // Draw final row
         if (viewportCappedStartRow !== viewportCappedEndRow) {
-          // Only draw viewportEndRow if it's not the same as viewporttartRow
+          // Only draw viewportEndRow if it's not the same as viewportStartRow
           const finalEndCol = viewportEndRow === viewportCappedEndRow ? end[0] : this._bufferService.cols;
           documentFragment.appendChild(this._createSelectionElement(viewportCappedEndRow, 0, finalEndCol));
         }

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -33,7 +33,7 @@ let nextTerminalId = 1;
 
 /**
  * The standard renderer and fallback for when the webgl addon is slow. This is not meant to be
- * particularly fast and will even lack some features such as custom glyphs, hoever this is more
+ * particularly fast and will even lack some features such as custom glyphs, however this is more
  * reliable as webgl may not work on some machines.
  */
 export class DomRenderer extends Disposable implements IRenderer {

--- a/src/browser/renderer/dom/DomRendererRowFactory.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.ts
@@ -380,7 +380,7 @@ export class DomRendererRowFactory {
       if (!isTop && isInSelection) {
         // If in the selection, force the element to be above the selection to improve contrast and
         // support opaque selections. The applies background is not actually needed here as
-        // selection is drawn in a seperate container, the main purpose of this to ensuring minimum
+        // selection is drawn in a separate container; the main purpose of this is to ensure minimum
         // contrast ratio
         bgOverride = this._coreBrowserService.isFocused ? colors.selectionBackgroundOpaque : colors.selectionInactiveBackgroundOpaque;
         bg = bgOverride.rgba >> 8 & 0xFFFFFF;

--- a/src/browser/selection/SelectionModel.ts
+++ b/src/browser/selection/SelectionModel.ts
@@ -88,7 +88,7 @@ export class SelectionModel {
       return [startPlusLength, this.selectionStart[1]];
     }
 
-    // Ensure the the word/line is selected after a double/triple click
+    // Ensure the word/line is selected after a double/triple click
     if (this.selectionStartLength) {
       // Select the larger of the two when start and end are on the same line
       if (this.selectionEnd[1] === this.selectionStart[1]) {

--- a/src/browser/services/MouseService.test.ts
+++ b/src/browser/services/MouseService.test.ts
@@ -176,7 +176,7 @@ describe('MouseService _triggerMouseEvent', () => {
       for (let i = 0; i < bufferService.cols; ++i) {
         assert.equal(trigger({ col: i, row: 0, x: 0, y: 0, button: CoreMouseButton.LEFT, action: CoreMouseAction.DOWN }), true);
         if (i > 222) {
-          // supress mouse reports if we are out of addressible range (max. 222)
+          // suppress mouse reports if we are out of addressable range (max. 222)
           assert.deepEqual(toBytes(reports.pop()), []);
         } else {
           assert.deepEqual(toBytes(reports.pop()), [0x1b, 0x5b, 0x4d, 0x20, i + 33, 0x21]);

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -927,7 +927,7 @@ export class SelectionService extends Disposable implements ISelectionService {
     // Incremenet the end index so it is at the start of the next character
     endIndex++;
 
-    // Calculate the start _column_, converting the the string indexes back to
+    // Calculate the start _column_, converting the string indexes back to
     // column coordinates.
     let start =
       startIndex // The index of the selection's start char in the line string
@@ -935,7 +935,7 @@ export class SelectionService extends Disposable implements ISelectionService {
       - leftWideCharCount // The number of wide chars left of the initial char
       + leftLongCharOffset; // The number of additional chars left of the initial char added by columns with strings longer than 1 (emojis)
 
-    // Calculate the length in _columns_, converting the the string indexes back
+    // Calculate the length in _columns_, converting the string indexes back
     // to column coordinates.
     let length = Math.min(this._bufferService.cols, // Disallow lengths larger than the terminal cols
       endIndex // The index of the selection's end char in the line string

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -1241,7 +1241,7 @@ describe('InputHandler', () => {
       await inputHandler.parseP('\x1b[e');
       assert.deepEqual(getCursor(bufferService), [8, 5]);
     });
-    describe('should clamp cursor into addressible range', () => {
+    describe('should clamp cursor into addressable range', () => {
       it('CUF', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -273,7 +273,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._parser.setExecuteHandler(C0.HT, () => this.tab());
     this._parser.setExecuteHandler(C0.SO, () => this.shiftOut());
     this._parser.setExecuteHandler(C0.SI, () => this.shiftIn());
-    // FIXME:   What do to with missing? Old code just added those to print.
+    // FIXME:   What to do with missing? Old code just added those to print.
 
     this._parser.setExecuteHandler(C1.IND, () => this.index());
     this._parser.setExecuteHandler(C1.NEL, () => this.nextLine());

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -550,7 +550,7 @@ export class InputHandler extends Disposable implements IInputHandler {
 
       // get charset replacement character
       // charset is only defined for ASCII, therefore we only
-      // search for an replacement char if code < 127
+      // search for a replacement char if code < 127
       if (code < 127 && charset) {
         const ch = charset[String.fromCharCode(code)];
         if (ch) {

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -236,7 +236,7 @@ export interface ICoreMouseProtocol {
  * The tracking encoding can be registered and activated at the MouseStateService.
  * If a ICoreMouseEvent passes all protocol restrictions it will be encoded
  * with the active encoding and sent out.
- * Note: Returning an empty string will supress sending a mouse report,
+ * Note: Returning an empty string will suppress sending a mouse report,
  * which can be used to skip creating falsey reports in limited encodings
  * (DEFAULT only supports up to 223 1-based as coord value).
  */

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -234,7 +234,7 @@ export interface ICoreMouseProtocol {
 /**
  * CoreMouseEncoding
  * The tracking encoding can be registered and activated at the MouseStateService.
- * If a ICoreMouseEvent passes all procotol restrictions it will be encoded
+ * If a ICoreMouseEvent passes all protocol restrictions it will be encoded
  * with the active encoding and sent out.
  * Note: Returning an empty string will supress sending a mouse report,
  * which can be used to skip creating falsey reports in limited encodings

--- a/src/common/buffer/AttributeData.ts
+++ b/src/common/buffer/AttributeData.ts
@@ -204,7 +204,7 @@ export class ExtendedAttrs implements IExtendedAttrs {
 
   /**
    * Convenient method to indicate whether the object holds no additional information,
-   * that needs to be persistant in the buffer.
+   * that needs to be persistent in the buffer.
    */
   public isEmpty(): boolean {
     return this.underlineStyle === UnderlineStyle.NONE && this._urlId === 0;

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -578,7 +578,7 @@ export class Buffer extends Disposable implements IBuffer {
    * @param i The index to start setting up tab stops from.
    */
   public setupTabStops(i?: number): void {
-    if (i !== null && i !== undefined) {
+    if (i !== undefined) {
       if (!this.tabs[i]) {
         i = this.prevStop(i);
       }

--- a/src/common/buffer/BufferReflow.ts
+++ b/src/common/buffer/BufferReflow.ts
@@ -13,7 +13,7 @@ export interface INewLayoutResult {
 }
 
 /**
- * Evaluates and returns indexes to be removed after a reflow larger occurs. Lines will be removed
+ * Evaluates and returns indexes to be removed after reflowLarger occurs. Lines will be removed
  * when a wrapped line unwraps.
  * @param lines The buffer lines.
  * @param oldCols The columns before resize
@@ -109,7 +109,7 @@ export function reflowLargerGetLinesToRemove(lines: CircularList<IBufferLine>, o
 }
 
 /**
- * Creates and return the new layout for lines given an array of indexes to be removed.
+ * Creates and returns the new layout for lines given an array of indexes to be removed.
  * @param lines The buffer lines.
  * @param toRemove The indexes to remove.
  */

--- a/src/common/buffer/Constants.ts
+++ b/src/common/buffer/Constants.ts
@@ -44,7 +44,7 @@ export const enum Content {
   CODEPOINT_MASK = 0x1FFFFF,
 
   /**
-   * bit 22       flag indication whether a cell contains combined content
+   * bit 22       flag indicating whether a cell contains combined content
    *              read:   `isCombined = content & Content.isCombined;`
    *              set:    `content |= Content.isCombined;`
    *              clear:  `content &= ~Content.isCombined;`

--- a/src/common/services/MouseStateService.ts
+++ b/src/common/services/MouseStateService.ts
@@ -126,7 +126,7 @@ const DEFAULT_ENCODINGS: { [key: string]: CoreMouseEncoding } = {
    */
   DEFAULT: (e: ICoreMouseEvent) => {
     const params = [eventCode(e, false) + 32, e.col + 32, e.row + 32];
-    // supress mouse report if we exceed addressible range
+    // suppress mouse report if we exceed addressable range
     // Note this is handled differently by emulators
     // - xterm:         sends 0;0 coords instead
     // - vte, konsole:  no report

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -324,7 +324,7 @@ export interface IOscLinkService {
  * bit 0: shouldJoin - should combine with preceding character.
  * bit 1..2: wcwidth - see UnicodeCharWidth.
  * bit 3..31: class of character (currently only 4 bits are used).
- *   This is used to determined grapheme clustering - i.e. which codepoints
+ *   This is used to determine grapheme clustering - i.e. which codepoints
  *   are to be combined into a single compound character.
  *
  * Use the UnicodeService static function createPropertyValue to create a

--- a/test/playwright/SharedRendererTests.ts
+++ b/test/playwright/SharedRendererTests.ts
@@ -980,7 +980,7 @@ export function injectSharedRendererTests(ctx: ISharedRendererTestContext): void
   });
 
   test.describe('selectionInactiveBackground', async () => {
-    test('should render the the inactive selection when not focused', async () => {
+    test('should render the inactive selection when not focused', async () => {
       const theme: ITheme = {
         selectionBackground: '#FF000080',
         selectionInactiveBackground: '#0000FF80'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment, documentation, and typo fixes that touch `src/`, `addons/`, and `test/` in the same maintenance batch. These were kept in one PR because the original commits each span multiple trees; splitting by path would map to the src-only, addons-only, and test-comment PRs in the same series.

## Changes

- Fix comment typos across DOM/WebGL renderers, selection, `InputHandler`, buffer types, mouse protocol docs, and addon typings.
- Correct spelling in test descriptions and comments (`suppress`, `addressable`, serialize workaround note, Playwright test title).
- Minor non-comment cleanups from one commit in the batch:
  - `WebglAddon`: capitalize **WebGL2** in the Safari error message.
  - `Buffer.setupTabStops`: drop redundant `null` check (`i !== undefined` only).

## File mapping (if maintainers prefer strict separation)

| Path | Suggested PR |
|------|----------------|
| `src/**` (except `*.test.ts` under `src/`) | PR 7 (src) |
| `addons/**` | PR 8 (addons) |
| `test/**`, `src/**/*.test.ts`, `addons/**/test/**` | PR 12 (test comments) |

## Testing

- `npm run build`
- No behavior changes expected beyond the `setupTabStops` guard simplification (equivalent for `number | undefined`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd205d7a-bb33-48a7-a93b-125cbf08cf99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd205d7a-bb33-48a7-a93b-125cbf08cf99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

