### PR TITLE
docs(src): fix comment and JSDoc typos

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -102,7 +102,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   private _keyDownHandled: boolean = false;
 
   /**
-   * Records whether a keydown event has occured since the last keyup event, i.e. whether a key
+   * Records whether a keydown event has occurred since the last keyup event, i.e. whether a key
    * is currently "pressed".
    */
   private _keyDownSeen: boolean = false;

--- a/src/browser/TimeBasedDebouncer.ts
+++ b/src/browser/TimeBasedDebouncer.ts
@@ -47,7 +47,7 @@ export class TimeBasedDebouncer implements IRenderDebouncer {
     // enough time to pass before refreshing again.
     const refreshRequestTime: number = performance.now();
     if (refreshRequestTime - this._lastRefreshMs >= this._debounceThresholdMS) {
-      // Enough time has lapsed since the last refresh; refresh immediately
+      // Enough time has elapsed since the last refresh; refresh immediately
       this._lastRefreshMs = refreshRequestTime;
       this._innerRefresh();
     } else if (!this._additionalRefreshRequested) {

--- a/src/browser/input/Mouse.ts
+++ b/src/browser/input/Mouse.ts
@@ -31,7 +31,7 @@ export function getCoordsRelativeToElement(window: Pick<Window, 'getComputedStyl
  * select that cell and the right half will select the next cell.
  */
 export function getCoords(window: Pick<Window, 'getComputedStyle'>, event: Pick<MouseEvent, 'clientX' | 'clientY'>, element: HTMLElement, colCount: number, rowCount: number, hasValidCharSize: boolean, cssCellWidth: number, cssCellHeight: number, isSelection?: boolean): [number, number] | undefined {
-  // Coordinates cannot be measured if there are no valid
+  // Coordinates cannot be measured if there is no valid character size.
   if (!hasValidCharSize) {
     return undefined;
   }
@@ -45,7 +45,7 @@ export function getCoords(window: Pick<Window, 'getComputedStyle'>, event: Pick<
   coords[1] = Math.ceil(coords[1] / cssCellHeight);
 
   // Ensure coordinates are within the terminal viewport. Note that selections
-  // need an addition point of precision to cover the end point (as characters
+  // need an additional point of precision to cover the end point (as characters
   // cover half of one char and half of the next).
   coords[0] = Math.min(Math.max(coords[0], 1), colCount + (isSelection ? 1 : 0));
   coords[1] = Math.min(Math.max(coords[1], 1), rowCount);

--- a/src/browser/services/ThemeService.ts
+++ b/src/browser/services/ThemeService.ts
@@ -132,7 +132,7 @@ export class ThemeService extends Disposable implements IThemeService {
         colors.ansi[i + 16] = parseColor(theme.extendedAnsi[i], DEFAULT_ANSI_COLORS[i + 16]);
       }
     }
-    // Clear our the cache
+    // Clear the cache
     this._contrastCache.clear();
     this._halfContrastCache.clear();
     this._updateRestoreColors();

--- a/src/common/Color.ts
+++ b/src/common/Color.ts
@@ -373,7 +373,7 @@ export function toPaddedHex(c: number): string {
 /**
  * Gets the contrast ratio between two relative luminance values.
  * @param l1 The first relative luminance.
- * @param l2 The first relative luminance.
+ * @param l2 The second relative luminance.
  * @see https://www.w3.org/TR/WCAG20/#contrast-ratiodef
  */
 export function contrastRatio(l1: number, l2: number): number {

--- a/src/common/Platform.ts
+++ b/src/common/Platform.ts
@@ -44,7 +44,7 @@ export function getSafariVersion(): number {
   return parseInt(majorVersion[1], 10);
 }
 
-// Find the users platform. We use this to interpret the meta key
+// Find the user's platform. We use this to interpret the meta key
 // and ISO third level shifts.
 // http://stackoverflow.com/q/19877924/577598
 export const isMac = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'].includes(platform);

--- a/src/common/TaskQueue.ts
+++ b/src/common/TaskQueue.ts
@@ -8,7 +8,7 @@ import type { ILogService } from './services/Services';
 interface ITaskQueue {
   /**
    * Adds a task to the queue which will run in a future idle callback.
-   * To avoid perceivable stalls on the mainthread, tasks with heavy workload
+   * To avoid perceivable stalls on the main thread, tasks with heavy workload
    * should split their work into smaller pieces and return `true` to get
    * called again until the work is done (on falsy return value).
    */

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -181,7 +181,7 @@ export interface ICoreMouseEvent {
   x: number;
   y: number;
   /**
-   * Button the action occured. Due to restrictions of the tracking protocols
+   * Button the action occurred. Due to restrictions of the tracking protocols
    * it is not possible to report multiple buttons at once.
    * Wheel is treated as a button.
    * There are invalid combinations of buttons and actions possible

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -197,7 +197,7 @@ export class Buffer extends Disposable implements IBuffer {
         for (let y = this._rows; y < newRows; y++) {
           if (this.lines.length < newRows + this.ybase) {
             if (this._optionsService.rawOptions.windowsPty.backend !== undefined || this._optionsService.rawOptions.windowsPty.buildNumber !== undefined) {
-              // Just add the new missing rows on Windows as conpty reprints the screen with it's
+              // Just add the new missing rows on Windows as conpty reprints the screen with its
               // view of the world. Once a line enters scrollback for conpty it remains there
               this.lines.push(new BufferLine(this._stringCache, newCols, nullCell, false));
             } else {

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -142,7 +142,7 @@ export class Buffer extends Disposable implements IBuffer {
   }
 
   /**
-   * Clears the buffer to it's initial state, discarding all previous data.
+   * Clears the buffer to its initial state, discarding all previous data.
    */
   public clear(): void {
     this._stringCache.clear();

--- a/src/common/buffer/Constants.ts
+++ b/src/common/buffer/Constants.ts
@@ -24,7 +24,7 @@ export const NULL_CELL_CODE = 0;
 /**
  * Whitespace cell.
  * This is meant as a replacement for empty cells when needed
- * during rendering lines to preserve correct aligment.
+ * during rendering lines to preserve correct alignment.
  */
 export const WHITESPACE_CELL_CHAR = ' ';
 export const WHITESPACE_CELL_WIDTH = 1;

--- a/src/common/buffer/Constants.ts
+++ b/src/common/buffer/Constants.ts
@@ -36,18 +36,18 @@ export const WHITESPACE_CELL_CODE = 32;
 export const enum Content {
   /**
    * bit 1..21    codepoint, max allowed in UTF32 is 0x10FFFF (21 bits taken)
-   *              read:   `codepoint = content & Content.codepointMask;`
-   *              write:  `content |= codepoint & Content.codepointMask;`
+   *              read:   `codepoint = content & Content.CODEPOINT_MASK;`
+   *              write:  `content |= codepoint & Content.CODEPOINT_MASK;`
    *                      shortcut if precondition `codepoint <= 0x10FFFF` is met:
    *                      `content |= codepoint;`
    */
   CODEPOINT_MASK = 0x1FFFFF,
 
   /**
-   * bit 22       flag indication whether a cell contains combined content
-   *              read:   `isCombined = content & Content.isCombined;`
-   *              set:    `content |= Content.isCombined;`
-   *              clear:  `content &= ~Content.isCombined;`
+   * bit 22       flag indicating whether a cell contains combined content
+   *              read:   `isCombined = content & Content.IS_COMBINED_MASK;`
+   *              set:    `content |= Content.IS_COMBINED_MASK;`
+   *              clear:  `content &= ~Content.IS_COMBINED_MASK;`
    */
   IS_COMBINED_MASK = 0x200000,  // 1 << 21
 
@@ -55,19 +55,19 @@ export const enum Content {
    * bit 1..22    mask to check whether a cell contains any string data
    *              we need to check for codepoint and isCombined bits to see
    *              whether a cell contains anything
-   *              read:   `isEmpty = !(content & Content.hasContent)`
+   *              read:   `isEmpty = !(content & Content.HAS_CONTENT_MASK)`
    */
   HAS_CONTENT_MASK = 0x3FFFFF,
 
   /**
    * bit 23..24   wcwidth value of cell, takes 2 bits (ranges from 0..2)
-   *              read:   `width = (content & Content.widthMask) >> Content.widthShift;`
-   *                      `hasWidth = content & Content.widthMask;`
+   *              read:   `width = (content & Content.WIDTH_MASK) >> Content.WIDTH_SHIFT;`
+   *                      `hasWidth = content & Content.WIDTH_MASK;`
    *                      as long as wcwidth is highest value in `content`:
-   *                      `width = content >> Content.widthShift;`
-   *              write:  `content |= (width << Content.widthShift) & Content.widthMask;`
+   *                      `width = content >> Content.WIDTH_SHIFT;`
+   *              write:  `content |= (width << Content.WIDTH_SHIFT) & Content.WIDTH_MASK;`
    *                      shortcut if precondition `0 <= width <= 3` is met:
-   *                      `content |= width << Content.widthShift;`
+   *                      `content |= width << Content.WIDTH_SHIFT;`
    */
   WIDTH_MASK = 0xC00000,   // 3 << 22
   WIDTH_SHIFT = 22

--- a/src/common/buffer/Marker.ts
+++ b/src/common/buffer/Marker.ts
@@ -30,7 +30,7 @@ export class Marker implements IMarker {
     }
     this.isDisposed = true;
     this.line = -1;
-    // Emit before super.dispose such that dispose listeners get a change to react
+    // Emit before super.dispose such that dispose listeners get a chance to react
     this._onDispose.fire();
     dispose(this._disposables);
     this._disposables.length = 0;

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -46,7 +46,7 @@ export function evaluateKeyboardEvent(
     // Whether to cancel event propagation (NOTE: this may not be needed since the event is
     // canceled at the end of keyDown
     cancel: false,
-    // The new key even to emit
+    // The new key event to emit
     key: undefined
   };
   const modifiers = (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0) | (ev.metaKey ? 8 : 0);

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -267,7 +267,7 @@ export class WriteBuffer extends Disposable {
          * this condition here, also the renderer has no way to spot nonsense updates either.
          * FIXME: A proper fix for this would track the FPS at the renderer entry level separately.
          *
-         * If favoring of FPS shows bad throughtput impact, use the following instead. It favors
+         * If favoring of FPS shows bad throughput impact, use the following instead. It favors
          * throughput by eval'ing `startTime` upfront pulling at least one more chunk into the
          * current microtask queue (executed before setTimeout).
          */

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -243,7 +243,7 @@ export const VT500_TRANSITION_TABLE = (function (): TransitionTable {
  *
  * This parser is currently hardcoded to operate in ZDM (Zero Default Mode)
  * as suggested by the original parser, thus empty parameters are set to 0.
- * This this is not in line with the latest ECMA-48 specification
+ * This is not in line with the latest ECMA-48 specification
  * (ZDM was part of the early specs and got completely removed later on).
  *
  * Other than the original parser from vt100.net this parser supports

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -18,7 +18,7 @@ import { ApcParser } from './ApcParser';
 // @vt: #Y   ESC   CSI   "Control Sequence Introducer"   "ESC ["   "Start of a CSI sequence."
 // @vt: #Y   ESC   OSC   "Operating System Command"      "ESC ]"   "Start of an OSC sequence."
 // @vt: #Y   ESC   DCS   "Device Control String"         "ESC P"   "Start of a DCS sequence."
-// @vt: #Y   ESC   ST    "String Terminator"             "ESC \"   "Terminator used for string type sequences."
+// @vt: #Y   ESC   ST    "String Terminator"             "ESC \\"   "Terminator used for string type sequences."
 // @vt: #Y   ESC   PM    "Privacy Message"               "ESC ^"   "Start of a privacy message."
 // @vt: #Y   ESC   APC   "Application Program Command"   "ESC _"   "Start of an APC sequence."
 // @vt: #Y   C1    CSI   "Control Sequence Introducer"   "\x9B"    "Start of a CSI sequence."

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -18,7 +18,7 @@ import { ApcParser } from './ApcParser';
 // @vt: #Y   ESC   CSI   "Control Sequence Introducer"   "ESC ["   "Start of a CSI sequence."
 // @vt: #Y   ESC   OSC   "Operating System Command"      "ESC ]"   "Start of an OSC sequence."
 // @vt: #Y   ESC   DCS   "Device Control String"         "ESC P"   "Start of a DCS sequence."
-// @vt: #Y   ESC   ST    "String Terminator"             "ESC \\"   "Terminator used for string type sequences."
+// @vt: #Y   ESC   ST    "String Terminator"             "ESC \\"  "Terminator used for string type sequences."
 // @vt: #Y   ESC   PM    "Privacy Message"               "ESC ^"   "Start of a privacy message."
 // @vt: #Y   ESC   APC   "Application Program Command"   "ESC _"   "Start of an APC sequence."
 // @vt: #Y   C1    CSI   "Control Sequence Introducer"   "\x9B"    "Start of a CSI sequence."

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -172,7 +172,7 @@ export class Params implements IParams {
    * Add a sub parameter value.
    * The sub parameter is automatically associated with the last parameter value.
    * Thus it is not possible to add a subparameter without any parameter added yet.
-   * `Params` only stores up to `subParamsLength` sub parameters, any later
+   * `Params` only stores up to `maxSubParamsLength` sub parameters, any later
    * sub parameter will be ignored.
    */
   public addSubParam(value: number): void {

--- a/src/common/parser/Types.ts
+++ b/src/common/parser/Types.ts
@@ -234,8 +234,8 @@ export interface IApcParser extends ISubParser<IApcHandler, ApcFallbackHandlerTy
 
 /**
  * Interface to denote a specific ESC, CSI or DCS handler slot.
- * The values are used to create an integer respresentation during handler
- * regristation before passed to the subparsers as `ident`.
+ * The values are used to create an integer representation during handler
+ * registration before passed to the subparsers as `ident`.
  * The integer translation is made to allow a faster handler access
  * in `EscapeSequenceParser.parse`.
  */

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -344,7 +344,7 @@ export type UnicodeCharWidth = 0 | 1 | 2;
 export const IUnicodeService = createDecorator<IUnicodeService>('UnicodeService');
 export interface IUnicodeService {
   serviceBrand: undefined;
-  /** Register an Unicode version provider. */
+  /** Register a Unicode version provider. */
   register(provider: IUnicodeVersionProvider): void;
   /** Registered Unicode versions. */
   readonly versions: string[];

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -350,7 +350,7 @@ export interface IUnicodeService {
   readonly versions: string[];
   /** Currently active version. */
   activeVersion: string;
-  /** Event triggered, when activate version changed. */
+  /** Event triggered when the active version changes. */
   readonly onChange: IEvent<string>;
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Comment and JSDoc-only fixes under `src/` — no runtime or test behavior changes.

- Correct ST sequence metadata and assorted comment spelling/grammar typos
- Align `Content` enum JSDoc examples with actual member names (`CODEPOINT_MASK`, `IS_COMBINED_MASK`, etc.)
- Fix incomplete or misleading comments in `Mouse.ts`, parser types, and service interfaces

**Validation:** `npm run lint-changes` (no uncommitted TS after cherry-picks); oxlint/eslint on all 17 changed `.ts` files vs `master` — clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4888f446-3ddc-460f-b475-6bc1a4020755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4888f446-3ddc-460f-b475-6bc1a4020755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

