### PR TITLE
fix(browser): debounce, render, mouse coords, and CoreBrowserTerminal

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -505,7 +505,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       this.textarea,
       parent.ownerDocument.defaultView ?? window,
       // Force unsafe null in node.js environment for tests
-      this._document ?? (typeof window !== 'undefined') ? window.document : null as any
+      this._document ?? ((typeof window !== 'undefined') ? window.document : null as any)
     ));
     this._instantiationService.setService(ICoreBrowserService, this._coreBrowserService);
 

--- a/src/browser/RenderDebouncer.ts
+++ b/src/browser/RenderDebouncer.ts
@@ -23,7 +23,7 @@ export class RenderDebouncer implements IRenderDebouncerWithCallback {
   }
 
   public dispose(): void {
-    if (this._animationFrame) {
+    if (this._animationFrame !== undefined) {
       this._coreBrowserService.window.cancelAnimationFrame(this._animationFrame);
       this._animationFrame = undefined;
     }
@@ -31,7 +31,7 @@ export class RenderDebouncer implements IRenderDebouncerWithCallback {
 
   public addRefreshCallback(callback: FrameRequestCallback): number {
     this._refreshCallbacks.push(callback);
-    if (!this._animationFrame) {
+    if (this._animationFrame === undefined) {
       this._animationFrame = this._coreBrowserService.window.requestAnimationFrame(() => this._innerRefresh());
     }
     return this._animationFrame;
@@ -46,7 +46,7 @@ export class RenderDebouncer implements IRenderDebouncerWithCallback {
     this._rowStart = this._rowStart !== undefined ? Math.min(this._rowStart, rowStart) : rowStart;
     this._rowEnd = this._rowEnd !== undefined ? Math.max(this._rowEnd, rowEnd) : rowEnd;
 
-    if (this._animationFrame) {
+    if (this._animationFrame !== undefined) {
       return;
     }
 

--- a/src/browser/TimeBasedDebouncer.ts
+++ b/src/browser/TimeBasedDebouncer.ts
@@ -49,7 +49,12 @@ export class TimeBasedDebouncer implements IRenderDebouncer {
     // enough time to pass before refreshing again.
     const refreshRequestTime: number = performance.now();
     if (refreshRequestTime - this._lastRefreshMs >= this._debounceThresholdMS) {
-      // Enough time has lapsed since the last refresh; refresh immediately
+      // Enough time has elapsed since the last refresh; refresh immediately
+      if (this._refreshTimeoutID !== undefined) {
+        clearTimeout(this._refreshTimeoutID);
+        this._refreshTimeoutID = undefined;
+        this._additionalRefreshRequested = false;
+      }
       this._lastRefreshMs = refreshRequestTime;
       this._innerRefresh();
     } else if (!this._additionalRefreshRequested) {

--- a/src/browser/TimeBasedDebouncer.ts
+++ b/src/browser/TimeBasedDebouncer.ts
@@ -3,9 +3,9 @@
  * @license MIT
  */
 
-const RENDER_DEBOUNCE_THRESHOLD_MS = 1000; // 1 Second
-
 import { IRenderDebouncer } from './Types';
+
+const RENDER_DEBOUNCE_THRESHOLD_MS = 1000; // 1 Second
 
 /**
  * Debounces calls to update screen readers to update at most once configurable interval of time.

--- a/src/browser/TimeBasedDebouncer.ts
+++ b/src/browser/TimeBasedDebouncer.ts
@@ -31,7 +31,9 @@ export class TimeBasedDebouncer implements IRenderDebouncer {
   public dispose(): void {
     if (this._refreshTimeoutID) {
       clearTimeout(this._refreshTimeoutID);
+      this._refreshTimeoutID = undefined;
     }
+    this._additionalRefreshRequested = false;
   }
 
   public refresh(rowStart: number | undefined, rowEnd: number | undefined, rowCount: number): void {

--- a/src/browser/input/Mouse.ts
+++ b/src/browser/input/Mouse.ts
@@ -37,10 +37,6 @@ export function getCoords(window: Pick<Window, 'getComputedStyle'>, event: Pick<
   }
 
   const coords = getCoordsRelativeToElement(window, event, element);
-  if (!coords) {
-    return undefined;
-  }
-
   coords[0] = Math.ceil((coords[0] + (isSelection ? cssCellWidth / 2 : 0)) / cssCellWidth);
   coords[1] = Math.ceil(coords[1] / cssCellHeight);
 

--- a/src/browser/input/MoveToCell.ts
+++ b/src/browser/input/MoveToCell.ts
@@ -156,7 +156,7 @@ function wrappedRowsForRow(currentRow: number, bufferService: IBufferService): n
  */
 function horizontalDirection(startX: number, startY: number, targetX: number, targetY: number, bufferService: IBufferService, applicationCursor: boolean): Direction {
   let startRow;
-  if (moveToRequestedRow(targetX, targetY, bufferService, applicationCursor).length > 0) {
+  if (moveToRequestedRow(startY, targetY, bufferService, applicationCursor).length > 0) {
     startRow = targetY - wrappedRowsForRow(targetY, bufferService);
   } else {
     startRow = startY;

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -694,7 +694,7 @@ class CursorBlinkStateManager {
   }
 
   private _clearIdleTimer(): void {
-    if (this._idleTimeout) {
+    if (this._idleTimeout !== undefined) {
       this._coreBrowserService.window.clearTimeout(this._idleTimeout);
       this._idleTimeout = undefined;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-picks browser-layer functional fixes for debouncing, rendering, mouse coordinate handling, and related services.

## Changes

- **RenderDebouncer**: Treat `requestAnimationFrame` id `0` as a valid scheduled frame (not falsy).
- **DomRenderer**: Clear the idle blink timer when the timeout handle is `0`.
- **TimeBasedDebouncer**: Reset trailing-debounce state on `dispose`; cancel a pending trailing timeout when an immediate refresh runs after the debounce window elapses; move imports above the module-level constant.
- **MoveToCell**: Pass `startY` (not `startX`) into the horizontal-direction row helper.
- **CoreBrowserService**: Parenthesize the `document` fallback so `??` binds correctly.
- **Mouse.getCoords**: Remove an unreachable coordinates guard after early returns.

## Testing

- `npm run build && npm run esbuild`
- `npm run test-unit -- out-esbuild/browser/input/Mouse.test.js out-esbuild/browser/renderer/shared/TextBlinkStateManager.test.js`
- `npm run test-integration -- test/playwright/MouseTracking.test.ts` (16 passed; 8 WebKit skipped in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-881fc306-70a1-4db2-aaf1-1cba27ca473a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-881fc306-70a1-4db2-aaf1-1cba27ca473a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

