### PR TITLE
docs(addons): fix comment and README typos (webgl, web-links, unicode-graphemes)

### DIFF
--- a/addons/addon-clipboard/typings/addon-clipboard.d.ts
+++ b/addons/addon-clipboard/typings/addon-clipboard.d.ts
@@ -82,7 +82,7 @@ declare module '@xterm/addon-clipboard' {
   /**
    * The clipboard provider interface that enables xterm.js to access the browser clipboard.
    *
-   * Note this this clipboard provider does not implement own cut buffers as xterm does,
+   * Note that this clipboard provider does not implement own cut buffers as xterm does,
    * but redirect the selection parameter always to navigator.clipboard.
    */
   export class BrowserClipboardProvider implements IClipboardProvider{

--- a/addons/addon-ligatures/src/index.ts
+++ b/addons/addon-ligatures/src/index.ts
@@ -21,7 +21,7 @@ const CACHE_SIZE = 100000;
 
 /**
  * Enable ligature support for the provided Terminal instance. To function
- * properly, this must be called after `open()` is called on the therminal. If
+ * properly, this must be called after `open()` is called on the terminal. If
  * the font currently in use supports ligatures, the terminal will automatically
  * start to render them.
  * @param term Terminal instance from xterm.js

--- a/addons/addon-serialize/src/SerializeAddon.ts
+++ b/addons/addon-serialize/src/SerializeAddon.ts
@@ -173,7 +173,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
   private _thisRowLastSecondChar: IBufferCell = this._buffer.getNullCell();
   private _nextRowFirstChar: IBufferCell = this._buffer.getNullCell();
   protected _rowEnd(row: number, isLastRow: boolean): void {
-    // if there is colorful empty cell at line end, whe must pad it back, or the the color block
+    // if there is colorful empty cell at line end, we must pad it back, or the color block
     // will missing
     if (this._nullCellCount > 0 && !equalBg(this._cursorStyle, this._backgroundCell)) {
       // use clear right to set background.

--- a/addons/addon-serialize/src/SerializeAddon.ts
+++ b/addons/addon-serialize/src/SerializeAddon.ts
@@ -221,7 +221,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
             // you can't use control sequence to move cursor to (x === row)
             (thisRowLastChar.getChars() || thisRowLastChar.getWidth() === 0) &&
             // change background of the first wrapped cell also affects BCE
-            // so we mark it as invalid to simply the process to determine line separator
+            // so we mark it as invalid to simplify the process to determine line separator
             equalBg(thisRowLastChar, nextRowFirstChar)
           ) {
             isValid = true;
@@ -233,7 +233,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
             isNextRowFirstCharDoubleWidth &&
             (thisRowLastSecondChar.getChars() || thisRowLastSecondChar.getWidth() === 0) &&
             // change background of the first wrapped cell also affects BCE
-            // so we mark it as invalid to simply the process to determine line separator
+            // so we mark it as invalid to simplify the process to determine line separator
             equalBg(thisRowLastChar, nextRowFirstChar) &&
             equalBg(thisRowLastSecondChar, nextRowFirstChar)
           ) {

--- a/addons/addon-serialize/test/SerializeAddon.test.ts
+++ b/addons/addon-serialize/test/SerializeAddon.test.ts
@@ -192,7 +192,7 @@ test.describe('SerializeAddon', () => {
     const cols = 10;
     const line = '+'.repeat(cols);
     const lines: string[] = [
-      sgr(FG_P16_GREEN) + line,  // Workaround: If we clear all flags a the end, serialize will use \x1b[0m to clear instead of the sepcific disable sequence
+      sgr(FG_P16_GREEN) + line,  // Workaround: If we clear all flags at the end, serialize will use \x1b[0m to clear instead of the specific disable sequence
       sgr(INVERSE) + line,
       sgr(BOLD) + line,
       sgr(UNDERLINED) + line,

--- a/addons/addon-unicode-graphemes/src/UnicodeGraphemesAddon.ts
+++ b/addons/addon-unicode-graphemes/src/UnicodeGraphemesAddon.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 The xterm.js authors. All rights reserved.
  * @license MIT
  *
- * UnicodeVersionProvider for V15 with grapeme cluster handleing.
+ * UnicodeVersionProvider for V15 with grapheme cluster handling.
  */
 
 import type { Terminal, ITerminalAddon, IUnicodeHandling } from '@xterm/xterm';

--- a/addons/addon-web-links/src/WebLinksAddon.ts
+++ b/addons/addon-web-links/src/WebLinksAddon.ts
@@ -13,7 +13,7 @@ import { ILinkProviderOptions, WebLinkProvider } from './WebLinkProvider';
 // resembling the old (...)*([^:"\'\\s]) final path clause
 // additionally exclude early + final:
 // - unsafe from rfc3986: !*'()
-// - unsafe chars from rfc1738: {}|\^~[]` (minus [] as we need them for ipv6 addresses, also allow ~)
+// - unsafe chars from rfc1738: {}|\^~[]` (minus [] for ipv6 addresses, also allow ~)
 // also exclude as finals:
 // - final interpunction like ,.!?
 // - any sort of brackets <>()[]{} (not spec conform, but often used to enclose urls)

--- a/addons/addon-web-links/src/WebLinksAddon.ts
+++ b/addons/addon-web-links/src/WebLinksAddon.ts
@@ -7,13 +7,13 @@ import type { Terminal, ITerminalAddon, IDisposable } from '@xterm/xterm';
 import type { WebLinksAddon as IWebLinksApi } from '@xterm/addon-web-links';
 import { ILinkProviderOptions, WebLinkProvider } from './WebLinkProvider';
 
-// consider everthing starting with http:// or https://
+// consider everything starting with http:// or https://
 // up to first whitespace, `"` or `'` as url
 // NOTE: The repeated end clause is needed to not match a dangling `:`
 // resembling the old (...)*([^:"\'\\s]) final path clause
 // additionally exclude early + final:
 // - unsafe from rfc3986: !*'()
-// - unsafe chars from rfc1738: {}|\^~[]` (minus [] as we need them for ipv6 adresses, also allow ~)
+// - unsafe chars from rfc1738: {}|\^~[]` (minus [] as we need them for ipv6 addresses, also allow ~)
 // also exclude as finals:
 // - final interpunction like ,.!?
 // - any sort of brackets <>()[]{} (not spec conform, but often used to enclose urls)

--- a/addons/addon-webgl/README.md
+++ b/addons/addon-webgl/README.md
@@ -23,7 +23,7 @@ See the full [API](https://github.com/xtermjs/xterm.js/blob/master/addons/addon-
 
 ### Handling Context Loss
 
-The browser may drop WebGL contexts for various reasons like OOM or after the system has been suspended. There is an API exposed that fires the `webglcontextlost` event fired on the canvas so embedders can handle it however they wish. An easy, but suboptimal way, to handle this is by disposing of WebglAddon when the event fires:
+The browser may drop WebGL contexts for various reasons like OOM or after the system has been suspended. There is an API exposed that fires the `webglcontextlost` event on the canvas so embedders can handle it however they wish. An easy, but suboptimal way, to handle this is by disposing of WebglAddon when the event fires:
 
 ```ts
 const terminal = new Terminal();

--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -220,7 +220,7 @@ export class GlyphRenderer extends Disposable {
   public updateCell(x: number, y: number, code: number, bg: number, fg: number, ext: number, chars: string, width: number, lastBg: number): void {
     // Since this function is called for every cell (`rows*cols`), it must be very optimized. It
     // should not instantiate any variables unless a new glyph is drawn to the cache where the
-    // slight slowdown is acceptable for the developer ergonomics provided as it's a once of for
+    // slight slowdown is acceptable for the developer ergonomics provided as it's a one-off for
     // each glyph.
     this._updateCell(this._vertices.attributes, x, y, code, bg, fg, ext, chars, width, lastBg);
   }

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -1125,7 +1125,7 @@ function clearColor(imageData: ImageData, bg: IColor, fg: IColor, enableThreshol
   // were covered (fg=#8ae234, bg=#c4a000).
   const threshold = Math.floor((Math.abs(r - fgR) + Math.abs(g - fgG) + Math.abs(b - fgB)) / 12);
 
-  // Set alpha channel of relevent pixels to 0
+  // Set alpha channel of relevant pixels to 0
   let isEmpty = true;
   for (let offset = 0; offset < imageData.data.length; offset += 4) {
     // Check exact match

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -69,7 +69,7 @@ export class TextureAtlas implements ITextureAtlas {
   private _overflowSizePage: AtlasPage | undefined;
 
   private _tmpCanvas: HTMLCanvasElement;
-  // A temporary context that glyphs are drawn to before being transfered to the atlas.
+  // A temporary context that glyphs are drawn to before being transferred to the atlas.
   private _tmpCtx: CanvasRenderingContext2D;
 
   private _workBoundingBox: IBoundingBox = { top: 0, left: 0, bottom: 0, right: 0 };
@@ -152,7 +152,7 @@ export class TextureAtlas implements ITextureAtlas {
   }
 
   private _createNewPage(): AtlasPage {
-    // Try merge the set of the 4 most used pages of the largest size. This is is deferred to a
+    // Try merge the set of the 4 most used pages of the largest size. This is deferred to a
     // microtask to ensure it does not interrupt textures that will be rendered in the current
     // animation frame which would result in blank rendered areas. This is actually not that
     // expensive relative to drawing the glyphs, so there is no need to wait for an idle callback.

--- a/addons/addon-webgl/src/WebglAddon.ts
+++ b/addons/addon-webgl/src/WebglAddon.ts
@@ -40,7 +40,7 @@ export class WebglAddon extends Disposable implements ITerminalAddon, IWebglApi 
       };
       const gl = document.createElement('canvas').getContext('webgl2', contextAttributes) as IWebGL2RenderingContext;
       if (!gl) {
-        throw new Error('Webgl2 is only supported on Safari 16 and above');
+        throw new Error('WebGL2 is only supported on Safari 16 and above');
       }
     }
     super();

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -664,7 +664,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this.dimensions.device.canvas.height = this._terminal.rows * this.dimensions.device.cell.height;
     this.dimensions.device.canvas.width = this._terminal.cols * this.dimensions.device.cell.width;
 
-    // The the size of the canvas on the page. It's important that this rounds to nearest integer
+    // The size of the canvas on the page. It's important that this rounds to nearest integer
     // and not ceils as browsers often have floating point precision issues where
     // `window.devicePixelRatio` ends up being something like `1.100000023841858` for example, when
     // it's actually 1.1. Ceiling may cause blurriness as the backing canvas image is 1 pixel too

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -667,7 +667,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     // The the size of the canvas on the page. It's important that this rounds to nearest integer
     // and not ceils as browsers often have floating point precision issues where
     // `window.devicePixelRatio` ends up being something like `1.100000023841858` for example, when
-    // it's actually 1.1. Ceiling may causes blurriness as the backing canvas image is 1 pixel too
+    // it's actually 1.1. Ceiling may cause blurriness as the backing canvas image is 1 pixel too
     // large for the canvas element size.
     this.dimensions.css.canvas.height = Math.round(this.dimensions.device.canvas.height / this._devicePixelRatio);
     this.dimensions.css.canvas.width = Math.round(this.dimensions.device.canvas.width / this._devicePixelRatio);

--- a/addons/addon-webgl/typings/addon-webgl.d.ts
+++ b/addons/addon-webgl/typings/addon-webgl.d.ts
@@ -23,12 +23,12 @@ declare module '@xterm/addon-webgl' {
     public readonly onChangeTextureAtlas: IEvent<HTMLCanvasElement>;
 
     /**
-     * An event that is fired when the a new page is added to the texture atlas.
+     * An event that is fired when a new page is added to the texture atlas.
      */
     public readonly onAddTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 
     /**
-     * An event that is fired when the a page is removed from the texture atlas.
+     * An event that is fired when a page is removed from the texture atlas.
      */
     public readonly onRemoveTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only comment, JSDoc, and README typo fixes across addons.

## Addons touched

- **addon-unicode-graphemes** — comment typos
- **addon-web-links** — comment typos
- **addon-webgl** — comment typos in `TextureAtlas`, `GlyphRenderer`, `WebglRenderer`; duplicate word in context-loss README; typings JSDoc; Safari WebGL2 error message casing
- **addon-serialize** — comment typos and test comment
- **addon-clipboard** — typings JSDoc
- **addon-ligatures** — JSDoc typo

## Validation

- `oxlint` on changed `.ts` sources
- `oxlint` with typings config on changed addon `.d.ts` files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10777318-6271-425e-ba10-ea0c0fdf7eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10777318-6271-425e-ba10-ea0c0fdf7eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

