### PR TITLE
test: search, parser title, and attach suite fixes

### DIFF
--- a/addons/addon-attach/test/AttachAddon.test.ts
+++ b/addons/addon-attach/test/AttachAddon.test.ts
@@ -15,7 +15,7 @@ test.beforeAll(async ({ browser }) => {
 });
 test.afterAll(async () => await ctx.page.close());
 
-test.describe('Search Tests', () => {
+test.describe('AttachAddon', () => {
 
   test.beforeEach(async () => {
     await ctx.proxy.reset();

--- a/addons/addon-search/test/SearchAddon.test.ts
+++ b/addons/addon-search/test/SearchAddon.test.ts
@@ -501,7 +501,7 @@ test.describe('Search Tests', () => {
         window.search.onDidChangeResults(e => window.calls.push(e));
       `);
       // Move cursor forward 1 time to create a null character, as opposed to regular whitespace
-      await ctx.proxy.write('\\x1b[CHi Hi');
+      await ctx.proxy.write('\x1b[CHi Hi');
       strictEqual(await ctx.page.evaluate(`window.search.findPrevious('h', { decorations: { activeMatchColorOverviewRuler: '#ff0000' } })`), true);
       deepStrictEqual(await ctx.page.evaluate('window.calls'), [
         { resultCount: 2, resultIndex: 1 }

--- a/addons/addon-search/test/SearchAddon.test.ts
+++ b/addons/addon-search/test/SearchAddon.test.ts
@@ -417,7 +417,7 @@ test.describe('Search Tests', () => {
     test.describe('#2444 wrapped line content not being found', () => {
       let fixture: string;
       test.beforeAll(async () => {
-        fixture = (await new Promise<Buffer>(r => readFile(resolve(__dirname, '../fixtures/issue-2444'), (err, data) => r(data)))).toString();
+        fixture = (await new Promise<Buffer>((res, rej) => readFile(resolve(__dirname, '../fixtures/issue-2444'), (err, data) => err ? rej(err) : res(data)))).toString();
         if (process.platform !== 'win32') {
           fixture = fixture.replace(/\n/g, '\n\r');
         }

--- a/addons/addon-serialize/test/SerializeAddon.test.ts
+++ b/addons/addon-serialize/test/SerializeAddon.test.ts
@@ -192,7 +192,7 @@ test.describe('SerializeAddon', () => {
     const cols = 10;
     const line = '+'.repeat(cols);
     const lines: string[] = [
-      sgr(FG_P16_GREEN) + line,  // Workaround: If we clear all flags a the end, serialize will use \x1b[0m to clear instead of the sepcific disable sequence
+      sgr(FG_P16_GREEN) + line,  // Workaround: If we clear all flags at the end, serialize will use \x1b[0m to clear instead of the specific disable sequence
       sgr(INVERSE) + line,
       sgr(BOLD) + line,
       sgr(UNDERLINED) + line,

--- a/src/browser/services/MouseService.test.ts
+++ b/src/browser/services/MouseService.test.ts
@@ -176,7 +176,7 @@ describe('MouseService _triggerMouseEvent', () => {
       for (let i = 0; i < bufferService.cols; ++i) {
         assert.equal(trigger({ col: i, row: 0, x: 0, y: 0, button: CoreMouseButton.LEFT, action: CoreMouseAction.DOWN }), true);
         if (i > 222) {
-          // supress mouse reports if we are out of addressible range (max. 222)
+          // suppress mouse reports if we are out of addressable range (max. 222)
           assert.deepEqual(toBytes(reports.pop()), []);
         } else {
           assert.deepEqual(toBytes(reports.pop()), [0x1b, 0x5b, 0x4d, 0x20, i + 33, 0x21]);

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -1241,7 +1241,7 @@ describe('InputHandler', () => {
       await inputHandler.parseP('\x1b[e');
       assert.deepEqual(getCursor(bufferService), [8, 5]);
     });
-    describe('should clamp cursor into addressible range', () => {
+    describe('should clamp cursor into addressable range', () => {
       it('CUF', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;

--- a/src/common/parser/EscapeSequenceParser.test.ts
+++ b/src/common/parser/EscapeSequenceParser.test.ts
@@ -243,7 +243,7 @@ describe('EscapeSequenceParser', () => {
       p = new TestEscapeSequenceParser(tansitions);
       assert.deepEqual(p.transitions, tansitions);
     });
-    it('inital states', () => {
+    it('initial states', () => {
       assert.equal(parser.initialState, ParserState.GROUND);
       assert.equal(parser.currentState, ParserState.GROUND);
       assert.equal(parser.osc, '');

--- a/test/playwright/SharedRendererTests.ts
+++ b/test/playwright/SharedRendererTests.ts
@@ -980,7 +980,7 @@ export function injectSharedRendererTests(ctx: ISharedRendererTestContext): void
   });
 
   test.describe('selectionInactiveBackground', async () => {
-    test('should render the the inactive selection when not focused', async () => {
+    test('should render the inactive selection when not focused', async () => {
       const theme: ITheme = {
         selectionBackground: '#FF000080',
         selectionInactiveBackground: '#0000FF80'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects several test harness issues so integration and unit tests exercise the scenarios they describe and fail clearly when setup breaks.

## Changes

### Search addon integration tests (`SearchAddon.test.ts`)

- **#3834 null-character case**: Use a single-escaped `'\x1b[CHi Hi'` so the terminal receives a real CSI CUP (cursor forward) sequence instead of the literal characters `\x1b[C`. The test is meant to create a null cell before the search term (e.g. starship/conpty prompt behavior).
- **#2444 fixture loader**: Reject the `readFile` promise when `err` is set instead of always resolving with `data` (which could be `undefined` and throw on `.toString()`). Use `res`/`rej` callback names to avoid shadowing `path.resolve`.

### Parser unit test (`EscapeSequenceParser.test.ts`)

- Rename Mocha case title from `inital states` to `initial states`.

### Attach addon integration tests (`AttachAddon.test.ts`)

- Rename Playwright `test.describe` from `'Search Tests'` (copied from addon-search) to `'AttachAddon'` so reports and `--suite=addon-attach` filtering match the addon under test.

### Additional test-only typo fixes

- `SharedRendererTests.ts`: remove duplicate "the" in a test title.
- `SerializeAddon.test.ts`: fix workaround comment spelling.
- `MouseService.test.ts` / `InputHandler.test.ts`: fix "suppress"/"addressable" in comments and describe titles.

## Validation

- `npm run build && npm run esbuild`
- `npm run test-unit -- addons/addon-search/out-esbuild/*.test.js`
- `npm run test-unit -- out-esbuild/common/parser/EscapeSequenceParser.test.js`
- `npm run esbuild-demo-client && npm run esbuild-demo-server`
- `npm run test-integration -- --suite=addon-search` (78 passed)
- `npm run test-integration -- --suite=addon-attach` (6 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c850439-521b-494a-b5c8-989e878ae565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c850439-521b-494a-b5c8-989e878ae565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

