### PR TITLE
fix(webgl): avoid glyph atlas mipmaps

### DIFF
--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -389,8 +389,9 @@ export class GlyphRenderer extends Disposable {
     gl.bindTexture(gl.TEXTURE_2D, this._atlasTextures[i].texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, atlas.pages[i].canvas);
-    gl.generateMipmap(gl.TEXTURE_2D);
     this._atlasTextures[i].version = atlas.pages[i].version;
   }
 


### PR DESCRIPTION
## Summary

Fixes #5986.

This removes mipmap generation from the WebGL glyph atlas upload path and explicitly sets non-mipmapped linear filters for atlas pages:

```ts
gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
```

The goal is to avoid glyph atlas corruption seen in downstream Linux + Wayland WebGL terminals while preserving the WebGL renderer.

## Context

Two downstream applications have hit the same failure class: dense terminal text can turn into black cell blocks, smears, or corrupted glyphs on Linux + Wayland GPU stacks when the WebGL addon is active.

- xterm.js issue: https://github.com/xtermjs/xterm.js/issues/5986
- Orca downstream issue: https://github.com/stablyai/orca/issues/1579
- Orca downstream fix: https://github.com/stablyai/orca/pull/1743
- Hermes Agent downstream issue: https://github.com/NousResearch/hermes-agent/issues/37203
- Hermes Agent downstream workaround PR: https://github.com/NousResearch/hermes-agent/pull/37205

In the Orca case, Electron/ANGLE logged `GL_INVALID_OPERATION` while allocating mipmaps for generation. Removing `gl.generateMipmap(gl.TEXTURE_2D)` and using explicit non-mipmapped filters resolved the corruption there. The Hermes downstream workaround applies the same change to its installed `@xterm/addon-webgl` package.

I have not reduced this to a standalone xterm.js demo repro; it appears GPU/driver/backend-specific. This PR is intentionally narrow so the exact WebGL state change can be reviewed directly.

## Testing

Ran in a clean `/tmp/xterm.js-pr` checkout to avoid parent-directory `node_modules` pollution:

- `npm ci`
- `npm run build`
- `npm run lint-changes`
- `npm run setup`
- `npm run test-unit` — 2367 passing
- Started the demo with `PORT=3310 npm start`
- Built the demo client with `npm run esbuild-demo-client`
- Loaded `http://127.0.0.1:3310/` in Chromium and opened the `webgl` panel; confirmed the page loaded and a WebGL2 canvas was present
- Verified the built demo bundle contains `TEXTURE_MIN_FILTER` / `TEXTURE_MAG_FILTER` and no `generateMipmap`

## Notes

The repository contribution guide asks for tests when changes are easy to test or likely to regress. I did not add a new automated test because this failure is GPU/driver-specific and the existing unit test surface does not directly exercise browser WebGL texture state. The focused build, lint, unit test suite, and demo smoke test are included above.
