### PR TITLE
fix(CharacterJoiner): bound join ranges to trimmed line length

### DIFF
--- a/src/browser/services/CharacterJoinerService.ts
+++ b/src/browser/services/CharacterJoinerService.ts
@@ -100,6 +100,7 @@ export class CharacterJoinerService implements ICharacterJoinerService {
 
     const ranges: [number, number][] = [];
     const lineStr = line.translateToString(true);
+    const trimmedLength = line.getTrimmedLength();
 
     // Because some cells can be represented by multiple javascript characters,
     // we track the cell and the string indexes separately. This allows us to
@@ -111,7 +112,7 @@ export class CharacterJoinerService implements ICharacterJoinerService {
     let rangeAttrFG = line.getFg(0);
     let rangeAttrBG = line.getBg(0);
 
-    for (let x = 0; x < line.getTrimmedLength(); x++) {
+    for (let x = 0; x < trimmedLength; x++) {
       line.loadCell(x, this._workCell);
 
       if (this._workCell.getWidth() === 0) {
@@ -147,7 +148,7 @@ export class CharacterJoinerService implements ICharacterJoinerService {
     }
 
     // Process any trailing ranges.
-    if (this._bufferService.cols - rangeStartColumn > 1) {
+    if (trimmedLength - rangeStartColumn > 1) {
       const joinedRanges = this._getJoinedRanges(
         lineStr,
         rangeStartStringIndex,
@@ -216,7 +217,8 @@ export class CharacterJoinerService implements ICharacterJoinerService {
       return;
     }
 
-    for (let x = startCol; x < this._bufferService.cols; x++) {
+    const trimmedLength = line.getTrimmedLength();
+    for (let x = startCol; x < trimmedLength; x++) {
       const width = line.getWidth(x);
       const length = line.getString(x).length || WHITESPACE_CELL_CHAR.length;
 
@@ -264,7 +266,7 @@ export class CharacterJoinerService implements ICharacterJoinerService {
     // If there is still a range left at the end, it must extend all the way to
     // the end of the line.
     if (currentRange) {
-      currentRange[1] = this._bufferService.cols;
+      currentRange[1] = trimmedLength;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Character joiner scanning already iterated cells with `getTrimmedLength()`, but trailing attribute runs and `_stringRangesToCellRanges` used buffer `cols`. On short lines that could run joiners on a single trailing cell and extend open ranges through empty tail columns, affecting ligature/join rendering.

## Changes

- Use `trimmedLength` consistently for trailing-run detection, the cell-range walk, and the final range end column.

## Risk

Rendering only. Repro with a short line plus a custom joiner that matches trailing empty cells.

## Testing

- `npm run build && npm run esbuild`
- `npm run test-unit -- **/CharacterJoiner*.test.js` (48 passing)
- `oxlint` on `CharacterJoinerService.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35b2f35a-11c2-4ff3-b4c8-712438258ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35b2f35a-11c2-4ff3-b4c8-712438258ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

