### PR TITLE
fix(addon-webgl): skip missing buffer lines in _updateModel

### DIFF
--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -456,7 +456,22 @@ export class WebglRenderer extends Disposable implements IRenderer {
 
     for (y = start; y <= end; y++) {
       row = y + terminal.buffer.ydisp;
-      line = terminal.buffer.lines.get(row)!;
+      const bufferLine = terminal.buffer.lines.get(row);
+      if (!bufferLine) {
+        this._model.lineLengths[y] = 0;
+        for (x = 0; x < terminal.cols; x++) {
+          j = ((y * terminal.cols) + x) * RenderModelConstants.INDICIES_PER_CELL;
+          modelUpdated = true;
+          this._glyphRenderer.value!.updateCell(x, y, NULL_CELL_CODE, 0, 0, 0, NULL_CELL_CHAR, 0, 0);
+          this._model.cells[j] = NULL_CELL_CODE;
+          this._model.cells[j + RenderModelConstants.BG_OFFSET] = 0;
+          this._model.cells[j + RenderModelConstants.FG_OFFSET] = 0;
+          this._model.cells[j + RenderModelConstants.EXT_OFFSET] = 0;
+        }
+        this._setRowBlinkState(y, false);
+        continue;
+      }
+      line = bufferLine;
       let rowHasBlinkingCells = false;
       this._model.lineLengths[y] = 0;
       isCursorRow = cursorY === row;

--- a/addons/addon-webgl/src/WebglRenderer.ts
+++ b/addons/addon-webgl/src/WebglRenderer.ts
@@ -462,11 +462,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
         for (x = 0; x < terminal.cols; x++) {
           j = ((y * terminal.cols) + x) * RenderModelConstants.INDICIES_PER_CELL;
           modelUpdated = true;
-          this._glyphRenderer.value!.updateCell(x, y, NULL_CELL_CODE, 0, 0, 0, NULL_CELL_CHAR, 0, 0);
-          this._model.cells[j] = NULL_CELL_CODE;
-          this._model.cells[j + RenderModelConstants.BG_OFFSET] = 0;
-          this._model.cells[j + RenderModelConstants.FG_OFFSET] = 0;
-          this._model.cells[j + RenderModelConstants.EXT_OFFSET] = 0;
+          this._nullModelCell(x, y, j, 0, 0, 0);
         }
         this._setRowBlinkState(y, false);
         continue;
@@ -602,13 +598,9 @@ export class WebglRenderer extends Disposable implements IRenderer {
           // Null out non-first cells
           for (x++; x <= lastCharX; x++) {
             j = ((y * terminal.cols) + x) * RenderModelConstants.INDICIES_PER_CELL;
-            this._glyphRenderer.value!.updateCell(x, y, NULL_CELL_CODE, 0, 0, 0, NULL_CELL_CHAR, 0, 0);
-            this._model.cells[j] = NULL_CELL_CODE;
             // Don't re-resolve the cell color since multi-colored ligature backgrounds are not
             // supported
-            this._model.cells[j + RenderModelConstants.BG_OFFSET] = this._cellColorResolver.result.bg;
-            this._model.cells[j + RenderModelConstants.FG_OFFSET] = this._cellColorResolver.result.fg;
-            this._model.cells[j + RenderModelConstants.EXT_OFFSET] = this._cellColorResolver.result.ext;
+            this._nullModelCell(x, y, j, this._cellColorResolver.result.bg, this._cellColorResolver.result.fg, this._cellColorResolver.result.ext);
           }
           x--; // Go back to the previous update cell for next iteration
         }
@@ -620,6 +612,14 @@ export class WebglRenderer extends Disposable implements IRenderer {
     }
     this._rectangleRenderer.value!.updateCursor(this._model);
     this._updateTextBlinkState();
+  }
+
+  private _nullModelCell(x: number, y: number, cellIndex: number, bg: number, fg: number, ext: number): void {
+    this._glyphRenderer.value!.updateCell(x, y, NULL_CELL_CODE, bg, fg, ext, NULL_CELL_CHAR, 0, 0);
+    this._model.cells[cellIndex] = NULL_CELL_CODE;
+    this._model.cells[cellIndex + RenderModelConstants.BG_OFFSET] = bg;
+    this._model.cells[cellIndex + RenderModelConstants.FG_OFFSET] = fg;
+    this._model.cells[cellIndex + RenderModelConstants.EXT_OFFSET] = ext;
   }
 
   private _resetBlinkingRowState(): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`lines.get(row)!` could throw during trim/resize gaps, leaving stale glyphs rendered below the affected region.

## Solution

When a buffer line is missing for a viewport row:

- Clear the model row (line length 0)
- Fill cells with null/empty values via `updateCell` and model cell arrays
- Set row blink state to false
- `continue` to the next row

This aligns with the DomRenderer approach (see DomRenderer PR 5).

## Manual verification

WebGL addon enabled on the demo; heavy scroll + resize.

## Tests

- `npm run build && npm run esbuild`
- `npm run test-unit -- addons/addon-webgl/out-esbuild/*.test.js`
- `npm run test-integration -- --suite=addon-webgl`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47e23328-2d20-45cd-8c15-0beb059d841d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47e23328-2d20-45cd-8c15-0beb059d841d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

