### PR TITLE
fix(terminal): always run clear() at cursor home

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -1072,10 +1072,6 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
    * Clear the entire buffer, making the prompt line the new first line.
    */
   public clear(): void {
-    if (this.buffer.ybase === 0 && this.buffer.y === 0) {
-      // Don't clear if it's already clear
-      return;
-    }
     this.buffer.clearAllMarkers();
     this.buffer.lines.set(0, this.buffer.lines.get(this.buffer.ybase + this.buffer.y)!);
     this.buffer.lines.length = 1;

--- a/src/headless/Terminal.ts
+++ b/src/headless/Terminal.ts
@@ -99,10 +99,6 @@ export class Terminal extends CoreTerminal {
    * Clear the entire buffer, making the prompt line the new first line.
    */
   public clear(): void {
-    if (this.buffer.ybase === 0 && this.buffer.y === 0) {
-      // Don't clear if it's already clear
-      return;
-    }
     this.buffer.clearAllMarkers();
     this.buffer.lines.set(0, this.buffer.lines.get(this.buffer.ybase + this.buffer.y)!);
     this.buffer.lines.length = 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`clear()` assumed that when the cursor was already at the top of the buffer (`ybase === 0 && y === 0`), the terminal was empty and returned early. That skipped:

- `clearAllMarkers()`
- Resetting buffer lines and scrollback trim
- Refilling the viewport with blank lines

Content could remain on screen below the cursor, or markers and scroll state could be left inconsistent.

## Fix

Remove the early return in both browser and headless implementations so `clear()` always:

1. Calls `clearAllMarkers()`
2. Resets lines (prompt line becomes the new first line)
3. Refills the viewport with blanks
4. Fires scroll and refresh (browser)

**Files:** `src/browser/CoreBrowserTerminal.ts`, `src/headless/Terminal.ts`

## User-visible behavior

RIS/home-style clear and `terminal.clear()` now work when the cursor is already at the top but content remains (e.g. lines written below the cursor, or buffer state that was not fully empty).

## Risk / changelog

Behavior change for callers that relied on `clear()` being a no-op at home with leftover content. Worth a changelog note.

**Suggested manual check:** Write several lines, move cursor home (`\x1b[H` or equivalent), then call `clear()` API or trigger clear via escape—viewport should fully clear.

## Testing

- `npm run build && npm run esbuild`
- Unit: Terminal tests (browser + headless), including `clear` cases
- Integration: `test/playwright/Terminal.test.ts` (207 tests, all browsers)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c4a0c6d-2f79-4e50-8029-e159904736ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c4a0c6d-2f79-4e50-8029-e159904736ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

