### PR TITLE
fix(selection): drag-scroll end row and trim start clamp

### DIFF
--- a/src/browser/selection/SelectionModel.test.ts
+++ b/src/browser/selection/SelectionModel.test.ts
@@ -64,6 +64,13 @@ describe('SelectionModel', () => {
       assert.deepEqual(model.finalSelectionStart, undefined);
       assert.deepEqual(model.finalSelectionEnd, undefined);
     });
+    it('should reset selection start to origin when start row is trimmed', () => {
+      model.selectionStart = [50, 0];
+      model.selectionEnd = [10, 2];
+      assert.equal(model.handleTrim(1), true);
+      assert.deepEqual(model.finalSelectionStart, [0, 0]);
+      assert.deepEqual(model.finalSelectionEnd, [10, 1]);
+    });
   });
 
   describe('finalSelectionStart', () => {

--- a/src/browser/selection/SelectionModel.ts
+++ b/src/browser/selection/SelectionModel.ts
@@ -135,9 +135,10 @@ export class SelectionModel {
       return true;
     }
 
-    // If the selection start is trimmed, ensure the start column is 0.
+    // If the selection start row is trimmed away, reset to the buffer origin.
     if (this.selectionStart && this.selectionStart[1] < 0) {
-      this.selectionStart[1] = 0;
+      this.selectionStart = [0, 0];
+      return true;
     }
     return false;
   }

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -704,7 +704,7 @@ export class SelectionService extends Disposable implements ISelectionService {
         if (this._activeSelectionMode !== SelectionMode.COLUMN) {
           this._model.selectionEnd[0] = this._bufferService.cols;
         }
-        this._model.selectionEnd[1] = Math.min(buffer.ydisp + this._bufferService.rows, buffer.lines.length - 1);
+        this._model.selectionEnd[1] = Math.min(buffer.ydisp + this._bufferService.rows - 1, buffer.lines.length - 1);
       } else {
         if (this._activeSelectionMode !== SelectionMode.COLUMN) {
           this._model.selectionEnd[0] = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Selection correctness fixes cherry-picked from `tyriar/explore-correctness` (commits not available on remote; equivalent changes applied).

### Drag-scroll

When dragging below the viewport during selection, `selectionEnd` row is now `ydisp + rows - 1` (last visible buffer line), matching `finalSelectionEnd` for select-all instead of one row past the viewport.

### Trim

When `handleTrim` removes the selection start row, start is reset to `[0, 0]` and callers refresh; a stale column on row 0 is no longer kept.

### Tests

- `SelectionModel.test.ts`: new case for start row trimmed away → `[0, 0]`.

### Out of scope

Image render change from the same explore branch lives in a separate **addon-image** PR (7b); not included here.

## Source commits (reference)

1. `ad4e40c` — drag-scroll: `selectionEnd` row = `ydisp + rows - 1`
2. Partial `0ff7ec39` — `SelectionModel.handleTrim` only (not `ImageStorage`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf486a92-88d0-468a-b26b-aa6b4dc6ff7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf486a92-88d0-468a-b26b-aa6b4dc6ff7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

