### PR TITLE
fix(InputHandler): isWrapped correctness after erase and column ops

### DIFF
--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -475,6 +475,13 @@ describe('InputHandler', () => {
       inputHandler.eraseInLine(Params.fromArray([1]));
       assert.equal(bufferService.buffer.lines.get(2)!.isWrapped, true);
 
+      // params[1] - full line erase at last column clears wrap on next line
+      await resetToBaseState();
+      bufferService.buffer.y = 1;
+      bufferService.buffer.x = bufferService.cols - 1;
+      inputHandler.eraseInLine(Params.fromArray([1]));
+      assert.equal(bufferService.buffer.lines.get(2)!.isWrapped, false);
+
       // params[2] - erase complete line
       await resetToBaseState();
       bufferService.buffer.y = 2;

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -1246,7 +1246,7 @@ export class InputHandler extends Disposable implements IInputHandler {
         this._eraseInBufferLine(j, 0, this._activeBuffer.x + 1, true, respectProtect);
         if (this._activeBuffer.x + 1 >= this._bufferService.cols) {
           // Deleted entire previous line. This next line can no longer be wrapped.
-          const nextLine = this._activeBuffer.lines.get(j + 1);
+          const nextLine = this._activeBuffer.lines.get(this._activeBuffer.ybase + j + 1);
           if (nextLine) {
             nextLine.isWrapped = false;
           }

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -1203,6 +1203,21 @@ export class InputHandler extends Disposable implements IInputHandler {
   }
 
   /**
+   * Scroll-margin column operations clear isWrapped on lines inside the margins.
+   * Also clear the line below the bottom margin when it still continues a wrap chain.
+   */
+  private _clearWrapBelowScrollMargins(): void {
+    const rowBelowMargin = this._activeBuffer.scrollBottom + 1;
+    if (rowBelowMargin >= this._bufferService.rows) {
+      return;
+    }
+    const lineBelow = this._activeBuffer.lines.get(this._activeBuffer.ybase + rowBelowMargin);
+    if (lineBelow) {
+      lineBelow.isWrapped = false;
+    }
+  }
+
+  /**
    * CSI Ps J  Erase in Display (ED).
    *     Ps = 0  -> Erase Below (default).
    *     Ps = 1  -> Erase Above.
@@ -1521,6 +1536,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       line.deleteCells(0, param, this._activeBuffer.getNullCell(this._eraseAttrData()));
       line.isWrapped = false;
     }
+    this._clearWrapBelowScrollMargins();
     this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom);
     return true;
   }
@@ -1554,6 +1570,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       line.insertCells(0, param, this._activeBuffer.getNullCell(this._eraseAttrData()));
       line.isWrapped = false;
     }
+    this._clearWrapBelowScrollMargins();
     this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom);
     return true;
   }
@@ -1577,6 +1594,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       line.insertCells(this._activeBuffer.x, param, this._activeBuffer.getNullCell(this._eraseAttrData()));
       line.isWrapped = false;
     }
+    this._clearWrapBelowScrollMargins();
     this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom);
     return true;
   }
@@ -1600,6 +1618,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       line.deleteCells(this._activeBuffer.x, param, this._activeBuffer.getNullCell(this._eraseAttrData()));
       line.isWrapped = false;
     }
+    this._clearWrapBelowScrollMargins();
     this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom);
     return true;
   }

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -1324,6 +1324,12 @@ export class InputHandler extends Disposable implements IInputHandler {
         break;
       case 1:
         this._eraseInBufferLine(this._activeBuffer.y, 0, this._activeBuffer.x + 1, false, respectProtect);
+        if (this._activeBuffer.x + 1 >= this._bufferService.cols) {
+          const nextLine = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y + 1);
+          if (nextLine) {
+            nextLine.isWrapped = false;
+          }
+        }
         break;
       case 2:
         this._eraseInBufferLine(this._activeBuffer.y, 0, this._bufferService.cols, true, respectProtect);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Keeps soft-wrap chain integrity after erase sequences and scroll-margin column operations.

### Changes

1. **ED Ps=1** — When clearing wrap on the line below the cursor at end-of-line, use `ybase + j + 1` instead of `lines.get(j + 1)` so scrollback does not point at the wrong buffer line.
2. **EL Ps=1** — Mirror ED when a full line is erased at the last column; clear `isWrapped` on the following line (with unit test).
3. **Column ops** — After `scrollLeft` / `scrollRight`, `insertColumns`, and `deleteColumns`, call new `_clearWrapBelowScrollMargins()` to clear stale wrap on the first line below the bottom scroll margin.

### Repro ideas

- Scrollback present + **ED 1** at EOL on a wrapped row.
- **EL 1** at last column on a line that continues a wrap on the next row.
- Wrapped line spanning the bottom margin + **DECSTBM** + **DECIC** / **DECDC** / **SL** / **SR**.

### Risk

Touches CSI erase and margin column behavior. Spec ambiguity: whether clearing wrap below the margin is always required vs. only when the margin line was part of a wrap chain—current approach matches xterm-style conservative clearing (same spirit as existing in-margin `isWrapped = false`).

### Commits (cherry-picked from `tyriar/explore-correctness`)

- `0383787` — ED Ps=1: ybase when clearing wrap on line below cursor at EOL
- `b679cdc` — EL Ps=1: same wrap clear at last column (+ unit test)
- `32ef836` — scroll L/R, insert/delete columns: clear wrap below scroll bottom margin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a369aa14-fca3-4b57-b0bd-766c55ee2c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a369aa14-fca3-4b57-b0bd-766c55ee2c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

