### PR TITLE
fix(addon-image): ImageStorage correctness (viewport widen, render, resize)

### DIFF
--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -514,6 +514,9 @@ export class ImageStorage implements IDisposable {
     const oldCol = this._viewportMetrics.cols - 1;
     for (let row = 0; row < rows; ++row) {
       const line = buffer.lines.get(row) as IBufferLineExt;
+      if (!line) {
+        continue;
+      }
       if (line.getBg(oldCol) & BgFlags.HAS_EXTENDED) {
         const e: IExtendedAttrsImage = line._extendedAttrs[oldCol] ?? EMPTY_ATTRS;
         const imageId = e.imageId;

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -531,7 +531,7 @@ export class ImageStorage implements IDisposable {
         }
         // expand only if right side is empty (nothing got wrapped from below)
         let hasData = false;
-        for (let rightCol = oldCol + 1; rightCol > metrics.cols; ++rightCol) {
+        for (let rightCol = oldCol + 1; rightCol < metrics.cols; ++rightCol) {
           if (line._data[rightCol * Cell.SIZE + Cell.CONTENT] & Content.HAS_CONTENT_MASK) {
             hasData = true;
             break;

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -431,7 +431,7 @@ export class ImageStorage implements IDisposable {
     // because text writes clear the BG flag but leave image tile data intact.
     // This lets top-layer images survive text overwrites (kitty C=1 behavior).
     for (let row = start; row <= end; ++row) {
-      const line = buffer.lines.get(row + buffer.ydisp) as IBufferLineExt;
+      const line = buffer.lines.get(row + buffer.ydisp) as IBufferLineExt | undefined;
       if (!line) continue;
       for (let col = 0; col < cols; ++col) {
         let e: IExtendedAttrsImage;
@@ -513,7 +513,7 @@ export class ImageStorage implements IDisposable {
     const rows = buffer.lines.length;
     const oldCol = this._viewportMetrics.cols - 1;
     for (let row = 0; row < rows; ++row) {
-      const line = buffer.lines.get(row) as IBufferLineExt;
+      const line = buffer.lines.get(row) as IBufferLineExt | undefined;
       if (!line) {
         continue;
       }

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -432,7 +432,7 @@ export class ImageStorage implements IDisposable {
     // This lets top-layer images survive text overwrites (kitty C=1 behavior).
     for (let row = start; row <= end; ++row) {
       const line = buffer.lines.get(row + buffer.ydisp) as IBufferLineExt;
-      if (!line) return;
+      if (!line) continue;
       for (let col = 0; col < cols; ++col) {
         let e: IExtendedAttrsImage;
         if (line.getBg(col) & BgFlags.HAS_EXTENDED) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three independent correctness bugs in `addons/addon-image/src/ImageStorage.ts`. Selection changes from the same upstream commit (`0ff7ec3`) are omitted here and tracked in PR 4.

## 1. Viewport widen: inverted loop bound (`viewportResize`)

**Bug:** When the terminal widens, `viewportResize()` must scan newly exposed columns (`oldCol + 1` … `metrics.cols - 1`) for existing cell content before expanding image tiles to the right. The emptiness check used `rightCol > metrics.cols`, which is never true when widening, so the loop never ran, `hasData` stayed false, and tiles could be written over cells that already held text.

**Fix:** Use `rightCol < metrics.cols`.

**Repro:**
1. Load addon-image and display a wide image that does not fill the last column of the viewport.
2. Place text in the column(s) immediately to the right of the image’s last tile (e.g. type in those cells).
3. Widen the terminal (increase `cols`).
4. **Before:** Image tiles expand into columns that already contain text.
5. **After:** Expansion is skipped when those columns have content.

## 2. Render: abort on missing line (`render`)

**Bug:** `render()` walked viewport rows and used `if (!line) return`, aborting the entire pass when any single line was missing. Other rows in range were not drawn.

**Fix:** `return` → `continue` so missing buffer lines are skipped and remaining rows still render.

**Repro:**
1. Display images in the viewport.
2. Trigger buffer conditions where `buffer.lines.get(row + ydisp)` can be undefined for some rows in the dirty range (e.g. trim/scrollback edge cases while images remain referenced).
3. **Before:** One missing line stops all image drawing for the viewport range.
4. **After:** Other rows in the range still draw.

## 3. Viewport resize: missing scrollback lines (`viewportResize`)

**Bug:** On widen, `viewportResize()` walks the full scrollback (`buffer.lines.length`) and called `line.getBg(oldCol)` without checking that `lines.get(row)` returned a line. Gaps during resize/trim could throw and abort tile expansion for remaining rows.

**Fix:** Skip missing lines with `continue` (consistent with `render()`).

**Repro:**
1. Have image tiles in scrollback near the end of a partially trimmed buffer.
2. Widen the terminal.
3. **Before:** Possible exception or aborted expansion when a row index has no line object.
4. **After:** Missing rows are skipped; expansion continues for valid lines.

## Related

- Upstream commit `0ff7ec39269c443e05532b6d133e17bab84590a7` also contained `SelectionModel` trim fixes; those are **not** in this PR (see PR 4).

## Testing

- `npm run build && npm run esbuild`
- `npm run test-unit -- addons/addon-image/out-esbuild/*.test.js` — 16 passing
- `npm run test-integration -- --suite=addon-image` — passed (4 skipped)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1afef9e0-6693-4245-a3c6-c652241350b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1afef9e0-6693-4245-a3c6-c652241350b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

