### PR TITLE
fix(buffer): copyCellsFrom metadata scope and reflow isWrapped cleanup

### DIFF
--- a/src/common/buffer/BufferLine.test.ts
+++ b/src/common/buffer/BufferLine.test.ts
@@ -495,6 +495,21 @@ describe('BufferLine', function(): void {
       assert.deepEqual(columns, [0]);
     });
   });
+  describe('copyCellsFrom', () => {
+    it('should only move combined data within the copied range', () => {
+      const src = new TestBufferLine(10, NULL_CELL_DATA, false);
+      src.setCell(1, createCellData(1, 'a', 1));
+      src.addCodepointToCell(1, '\u0301'.charCodeAt(0), 0);
+      src.setCell(5, createCellData(1, 'z', 1));
+      src.addCodepointToCell(5, '\u0301'.charCodeAt(0), 0);
+
+      const dest = new TestBufferLine(10, NULL_CELL_DATA, false);
+      dest.copyCellsFrom(src, 0, 0, 2, false);
+
+      assert.property(dest.combined, '1');
+      assert.notProperty(dest.combined, '5');
+    });
+  });
   describe('addCharToCell', () => {
     it('should set width to 1 for empty cell', () => {
       const line = new TestBufferLine(3, NULL_CELL_DATA, false);

--- a/src/common/buffer/BufferLine.ts
+++ b/src/common/buffer/BufferLine.ts
@@ -609,9 +609,13 @@ export class BufferLine implements IBufferLine {
     const srcStart = srcCol * Constants.CELL_INDICIES;
     if (src._data[srcStart + Cell.CONTENT] & Content.IS_COMBINED_MASK) {
       this._combined[destCol] = src._combined[srcCol];
+    } else {
+      delete this._combined[destCol];
     }
     if (src._data[srcStart + Cell.BG] & BgFlags.HAS_EXTENDED) {
       this._extendedAttrs[destCol] = src._extendedAttrs[srcCol];
+    } else {
+      delete this._extendedAttrs[destCol];
     }
   }
 

--- a/src/common/buffer/BufferReflow.test.ts
+++ b/src/common/buffer/BufferReflow.test.ts
@@ -10,6 +10,7 @@ import { CellData } from './CellData';
 import { NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE } from './Constants';
 import { reflowLargerGetLinesToRemove, reflowSmallerGetNewLineLengths } from './BufferReflow';
 import { IBufferLine } from './Types';
+import { createCellData, NULL_CELL_DATA } from '../TestUtils.test';
 
 const TEST_STRING_CACHE = new BufferLineStringCache();
 
@@ -121,6 +122,28 @@ describe('BufferReflow', () => {
     it('should reflow wrapped blocks when the cursor is outside the block', () => {
       const lines = createWrappedLines('abcde');
       assert.notDeepEqual(reflowLargerGetLinesToRemove(lines, 1, 5, 10, nullCell, false), []);
+    });
+
+    it('should clear isWrapped on the last retained row after unwrap', () => {
+      const lines = new CircularList<BufferLine>(10);
+      const set2 = (line: BufferLine, s: string) => {
+        for (let i = 0; i < s.length; i++) {
+          line.setCell(i, createCellData(0, s[i], 1));
+        }
+      };
+      const l0 = new BufferLine(TEST_STRING_CACHE, 2);
+      set2(l0, 'ab');
+      const l1 = new BufferLine(TEST_STRING_CACHE, 2, undefined, true);
+      set2(l1, 'cd');
+      const l2 = new BufferLine(TEST_STRING_CACHE, 2, undefined, true);
+      set2(l2, 'ef');
+      lines.push(l0);
+      lines.push(l1);
+      lines.push(l2);
+
+      reflowLargerGetLinesToRemove(lines, 2, 6, 99, NULL_CELL_DATA, false);
+
+      assert.equal(l1.isWrapped, false);
     });
   });
 });

--- a/src/common/buffer/BufferReflow.ts
+++ b/src/common/buffer/BufferReflow.ts
@@ -99,6 +99,11 @@ export function reflowLargerGetLinesToRemove(lines: CircularList<IBufferLine>, o
     }
 
     if (countToRemove > 0) {
+      wrappedLines[destLineIndex].isWrapped = false;
+      const lineAfterGroup = lines.get(y + wrappedLines.length);
+      if (lineAfterGroup) {
+        lineAfterGroup.isWrapped = false;
+      }
       toRemove.push(y + wrappedLines.length - countToRemove); // index
       toRemove.push(countToRemove);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-picks from `Tyriar/explore-correctness` (commits `992cc5c`, `cd4da10d`), with a small merge adaptation on `master` for `_copyCellMapsFrom`.

## 1. `BufferLine.copyCellsFrom` — limit combined/extended metadata to copied range

`copyCellsFrom` copied Uint32 cell data only for the requested column range, but previously migrated every `_combined` entry with key `>= srcCol`. Partial line copies during reflow and wraparound could therefore attach grapheme metadata to unrelated destination columns.

**Fix:** Copy combined and extended attributes only per cell in the copied range, and delete stale entries on the destination when the source cell does not use them. On current `master`, this is implemented by extending `_copyCellMapsFrom` (used by `copyCellsFrom` and `copyFrom`) to clear stale `_combined` / `_extendedAttrs` keys when flags are absent.

**Risk:** Any path that partially copies cells between lines (reflow, wraparound, scroll regions).

**Tests:** `BufferLine.test.ts` — `copyCellsFrom` / `should only move combined data within the copied range`.

## 2. `reflowLargerGetLinesToRemove` — clear stale `isWrapped` after larger reflow

When widening the terminal unwraps a multi-row soft wrap and removes trailing buffer lines, the last retained row could still have `isWrapped` set, and the following line could still think it continued a removed row. That broke wrapped-range string translation.

**Fix:** When rows are removed during reflow, clear `isWrapped` on the last retained row in the group (`wrappedLines[destLineIndex]`) and on the first line after the group if present.

**Risk:** Resize/reflow and any feature that depends on correct wrap continuation across buffer lines (search, selection, translation).

**Tests:** `BufferReflow.test.ts` — `reflowLargerGetLinesToRemove` / `should clear isWrapped on the last retained row after unwrap`, plus existing cursor/reflow guard tests on `master`.

## Verification

```
npm run build && npm run esbuild
npm run test-unit -- **/BufferLine.test.js
npm run test-unit -- **/BufferReflow.test.js
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-073c9f27-6803-46ff-8059-897ed5ea40a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-073c9f27-6803-46ff-8059-897ed5ea40a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

