### PR TITLE
fix(DomRenderer): resilience when buffer lines are missing

### DIFF
--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -542,6 +542,7 @@ export class DomRenderer extends Disposable implements IRenderer {
       const lineData = buffer.lines.get(row);
       if (!lineData) {
         rowElement.replaceChildren();
+        this._setRowBlinkState(y, false);
         continue;
       }
       rowElement.replaceChildren(
@@ -620,6 +621,7 @@ export class DomRenderer extends Disposable implements IRenderer {
       const bufferline = buffer.lines.get(row);
       if (!bufferline) {
         rowElement.replaceChildren();
+        this._setRowBlinkState(i, false);
         continue;
       }
       rowElement.replaceChildren(

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -536,9 +536,13 @@ export class DomRenderer extends Disposable implements IRenderer {
     for (let y = start; y <= end; y++) {
       const row = y + buffer.ydisp;
       const rowElement = this._rowElements[y];
+      if (!rowElement) {
+        continue;
+      }
       const lineData = buffer.lines.get(row);
-      if (!rowElement || !lineData) {
-        break;
+      if (!lineData) {
+        rowElement.replaceChildren();
+        continue;
       }
       rowElement.replaceChildren(
         ...this._rowFactory.createRow(
@@ -610,9 +614,13 @@ export class DomRenderer extends Disposable implements IRenderer {
     for (let i = y; i <= y2; ++i) {
       const row = i + buffer.ydisp;
       const rowElement = this._rowElements[i];
+      if (!rowElement) {
+        continue;
+      }
       const bufferline = buffer.lines.get(row);
-      if (!rowElement || !bufferline) {
-        break;
+      if (!bufferline) {
+        rowElement.replaceChildren();
+        continue;
       }
       rowElement.replaceChildren(
         ...this._rowFactory.createRow(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a viewport row has no corresponding buffer line (e.g. during scroll/trim/resize races), `DomRenderer` previously hit `!lineData` and **`break`**, leaving stale DOM on rows below the gap.

**Now:**
- Clear the row with `replaceChildren()` and **`continue`** so remaining viewport rows still update (`renderRows` and link underline refresh).
- Reset **`_rowHasBlinkingCells`** for skipped rows so text blink state cannot stick after the row is emptied.

## Related work (same pattern, no hard dependency)

- addon-webgl renderer resilience (PR 7c)
- addon-image render path (PR 7b)

## Testing

- `npm run build && npm run esbuild`
- `npm run test-unit -- **/DomRendererRowFactory.test.js` (no `DomRenderer.test.js` in tree)
- `npm run test-integration -- test/playwright/Terminal.test.ts` (207 passed, core suite)
- `oxlint` on `DomRenderer.ts`
- Manual: demo at port 3000 — scrollback fill, scroll, resize, verify clean render

<a href="https://cursor.com/agents/bc-edcf8147-1dc4-4ca0-8029-547d212881db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdomrenderer_missing_lines_manual_test.mp4"><img src="https://cursor.com/artifacts/c/art-7206eb64-e2fa-4f16-9e29-6dada813a587" alt="domrenderer_missing_lines_manual_test.mp4" /></a>
Manual demo: scrollback, scroll, resize, then `echo after-scroll-resize` with no stale rows.

![Terminal after scroll and resize](https://cursor.com/artifacts/c/art-933c1d74-a64d-4d4e-ba37-862b7c7d1275)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edcf8147-1dc4-4ca0-8029-547d212881db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edcf8147-1dc4-4ca0-8029-547d212881db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

