### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: 22.x
         cache: 'npm'
@@ -69,7 +69,7 @@ jobs:
           ./addons/addon-webgl/out/* \
           ./addons/addon-webgl/out-*st/*
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-artifacts
         path: compressed-build.zip
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: 22.x
         cache: 'npm'
@@ -100,16 +100,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: 22.x
         cache: 'npm'
     - name: Install dependencies
       run: |
         npm ci
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: build-artifacts
     - name: Unzip artifacts
@@ -129,6 +129,7 @@ jobs:
         exit $EXIT_CODE
 
   test-unit:
+    needs: build
     timeout-minutes: 20
     strategy:
       matrix:
@@ -136,21 +137,16 @@ jobs:
         runs-on: [ubuntu, macos, windows]
     runs-on: ${{ matrix.runs-on }}-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}.x
         cache: 'npm'
     - name: Install dependencies
       run: |
         npm ci
-    - name: Wait for build job
-      uses: NathanFirmo/wait-for-other-job@v1.1.1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        job: build
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: build-artifacts
     - name: Unzip artifacts
@@ -166,6 +162,7 @@ jobs:
       run: npm run test-unit --forbid-only
 
   test-integration:
+    needs: build
     timeout-minutes: 20
     strategy:
       matrix:
@@ -174,9 +171,9 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}.x
         cache: 'npm'
@@ -185,12 +182,7 @@ jobs:
         npm ci
     - name: Install playwright
       run: npx playwright install --with-deps ${{ matrix.browser }}
-    - name: Wait for build job
-      uses: NathanFirmo/wait-for-other-job@v1.1.1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        job: build
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: build-artifacts
     - name: Unzip artifacts
@@ -240,9 +232,9 @@ jobs:
       matrix:
         node-version: [22]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}.x
         cache: 'npm'
@@ -251,7 +243,7 @@ jobs:
         npm ci
     - name: Install playwright
       run: npx playwright install
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: build-artifacts
     - name: Unzip artifacts

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: 22.x
         cache: 'npm'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #6006

GitHub is deprecating Node 20 for Actions runners (removal planned for fall 2026). Several workflow actions were still pinned to versions that run on Node 20 internally.

This PR upgrades all workflow actions to their latest major versions that run on Node 24:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v3 / v4 | v5 |
| `actions/setup-node` | v3 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `github/codeql-action/*` | v2 | v4 |

Also replaces `NathanFirmo/wait-for-other-job@v1.1.1` (Node 16) with native `needs: build` on the `test-unit` and `test-integration` jobs, consistent with `test-unit-coverage` and `release-dry-run`.

## Files changed

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/copilot-setup-steps.yml`

## Testing

- Validated YAML syntax for all four workflow files locally
- CI will verify the updated workflows on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac4b8aac-4c88-4007-a883-02d6e93ec2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac4b8aac-4c88-4007-a883-02d6e93ec2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

