### PR TITLE
Add Cate to real-world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Xterm.js is used in many world-class applications to provide great terminal expe
 - [**WooTTY**](https://github.com/icoretech/wootty): Flawless browser terminal for real operators.
 - [**Orca**](https://github.com/stablyai/orca): Agentic development environment for 100x builders.
 - [**4bit**](https://ciembor.github.io/4bit): Terminal Color Scheme Designer.
+- [**Cate**](https://github.com/0-AI-UG/cate): Open source desktop IDE on an infinite zoomable canvas. Editor, browser, and terminal panels float in spatial space; the terminals are xterm.js with the WebGL addon, backed by node-pty.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Please add any new contributions to the end of the list.


### PR DESCRIPTION
Adds Cate to the real-world uses list, following the note at the end of the section. Cate is an open source Electron IDE where panels are arranged on an infinite canvas, and its terminal panels are built on @xterm/xterm with the WebGL addon. Added at the end of the list as requested.
