### PR TITLE
fix(addon-webgl): request model clear when clearing shared atlas texture

### DIFF
--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -149,6 +149,7 @@ export class TextureAtlas implements ITextureAtlas {
     this._cacheMap.clear();
     this._cacheMapCombined.clear();
     this._didWarmUp = false;
+    this._requestClearModel = true;
   }
 
   private _createNewPage(): AtlasPage {


### PR DESCRIPTION
**Problem**

When multiple terminals share the same WebGL texture atlas, calling clearTextureAtlas on one terminal clears the shared atlas pages and glyph caches, but sibling terminals are not notified to rebuild their model.

This leaves stale vertex texture coordinates in unchanged rows on sibling terminals and can render text garbled or blank until a full refresh happens.

Closes #6014

**Solution**

Set _requestClearModel = true in TextureAtlas.clearTexture after clearing pages/caches.

This aligns clearTexture with other atlas-wide mutation paths that already request a shared model rebuild, so every renderer sharing the atlas performs a full model update on the next frame.