### PR TITLE
Handle IME-transformed printable input

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -115,6 +115,17 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   private _keyPressHandled: boolean = false;
 
   /**
+   * A printable keydown that is being held briefly so beforeinput/input can override it. Some IMEs
+   * (eg. SKK) commit certain characters without composition events, which means keydown reports the
+   * raw key (eg. "a") while beforeinput/input reports the composed text (eg. "あ").
+   */
+  private _deferredPrintableKeyDown: {
+    key: string;
+    event: KeyboardEvent;
+    timer: ReturnType<typeof setTimeout>;
+  } | undefined;
+
+  /**
    * Records whether there has been a keydown event for a dead key without a corresponding keydown
    * event for the composed/alternative character. If we cancel the keydown event for the dead key,
    * no events will be emitted for the final character.
@@ -426,6 +437,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     }));
     this._register(addDisposableListener(this.textarea!, 'compositionupdate', (e: CompositionEvent) => this._compositionHelper!.compositionupdate(e)));
     this._register(addDisposableListener(this.textarea!, 'compositionend', () => this._compositionHelper!.compositionend()));
+    this._register(addDisposableListener(this.textarea!, 'beforeinput', (ev: InputEvent) => this._beforeInputEvent(ev), true));
     this._register(addDisposableListener(this.textarea!, 'input', (ev: InputEvent) => this._inputEvent(ev), true));
     this._register(this.onRender(() => this._compositionHelper!.updateCompositionElements()));
   }
@@ -915,6 +927,14 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       this.textarea!.value = '';
     }
 
+    if (this._shouldDeferPrintableKeyDown(event, result.key)) {
+      this._deferPrintableKeyDown(result.key, event);
+      // Don't preventDefault here; doing so would suppress the beforeinput/input event containing
+      // the IME-transformed text. Do stop propagation like the synchronous path below.
+      event.stopPropagation();
+      return false;
+    }
+
     const wasModifierOnly = this._keyboardService.useWin32InputMode && wasModifierKeyOnlyEvent(event);
     this._onKey.fire({ key: result.key, domEvent: event });
     this._showCursor();
@@ -931,6 +951,73 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     }
 
     this._keyDownHandled = true;
+  }
+
+  private _shouldDeferPrintableKeyDown(event: KeyboardEvent, key: string): boolean {
+    if (
+      this._keyboardService.useKitty ||
+      this._keyboardService.useWin32InputMode ||
+      this.optionsService.rawOptions.screenReaderMode ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.metaKey
+    ) {
+      return false;
+    }
+
+    // Defer only printable keydown events that map directly to a single character. Control
+    // sequences, modified keys and special keyboard modes must stay synchronous.
+    return key.length === 1 && event.key === key;
+  }
+
+  private _deferPrintableKeyDown(key: string, event: KeyboardEvent): void {
+    this._flushDeferredPrintableKeyDown();
+    this._deferredPrintableKeyDown = {
+      key,
+      event,
+      timer: setTimeout(() => this._flushDeferredPrintableKeyDown(), 0)
+    };
+  }
+
+  private _flushDeferredPrintableKeyDown(): void {
+    if (!this._deferredPrintableKeyDown) {
+      return;
+    }
+    const deferred = this._deferredPrintableKeyDown;
+    this._deferredPrintableKeyDown = undefined;
+    clearTimeout(deferred.timer);
+    this._onKey.fire({ key: deferred.key, domEvent: deferred.event });
+    this._showCursor();
+    this.coreService.triggerDataEvent(deferred.key, true);
+  }
+
+  private _clearDeferredPrintableKeyDown(): { key: string, event: KeyboardEvent } | undefined {
+    if (!this._deferredPrintableKeyDown) {
+      return undefined;
+    }
+    const deferred = this._deferredPrintableKeyDown;
+    this._deferredPrintableKeyDown = undefined;
+    clearTimeout(deferred.timer);
+    return deferred;
+  }
+
+  private _handleDeferredPrintableInput(ev: InputEvent): boolean {
+    if (!ev.data || ev.inputType !== 'insertText' || this.optionsService.rawOptions.screenReaderMode) {
+      return false;
+    }
+    const deferred = this._clearDeferredPrintableKeyDown();
+    if (!deferred) {
+      return false;
+    }
+
+    // The key was handled so clear the dead key state, otherwise certain keystrokes like arrow
+    // keys could be ignored.
+    this._unprocessedDeadKey = false;
+
+    this._onKey.fire({ key: ev.data, domEvent: deferred.event });
+    this._showCursor();
+    this.coreService.triggerDataEvent(ev.data, true);
+    return true;
   }
 
   private _isThirdLevelShift(browser: IBrowser, ev: KeyboardEvent): boolean {
@@ -984,6 +1071,12 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       return false;
     }
 
+    // A printable keydown is pending so the browser's beforeinput/input event can provide the
+    // authoritative text. Suppress keypress to avoid sending the raw key first.
+    if (this._deferredPrintableKeyDown) {
+      return false;
+    }
+
     if (this._customKeyEventHandler && this._customKeyEventHandler(ev) === false) {
       return false;
     }
@@ -1020,12 +1113,31 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   }
 
   /**
+   * Handle a beforeinput event.
+   * Key Resources:
+   *   - https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
+   * @param ev The beforeinput event to be handled.
+   */
+  protected _beforeInputEvent(ev: InputEvent): boolean {
+    if (this._handleDeferredPrintableInput(ev)) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Handle an input event.
    * Key Resources:
    *   - https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
    * @param ev The input event to be handled.
    */
   protected _inputEvent(ev: InputEvent): boolean {
+    if (this._handleDeferredPrintableInput(ev)) {
+      return true;
+    }
+
     // Only support emoji IMEs when screen reader mode is disabled as the event must bubble up to
     // support reading out character input which can doubling up input characters
     // Based on these event traces: https://github.com/xtermjs/xterm.js/issues/3679

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -402,6 +402,93 @@ describe('Terminal', () => {
     });
 
     describe('keyDown', () => {
+      function createKeyDownEvent(key: string, keyCode: number): KeyboardEvent {
+        return {
+          type: 'keydown',
+          key,
+          keyCode,
+          preventDefault: () => { },
+          stopPropagation: () => { }
+        } as KeyboardEvent;
+      }
+
+      function createKeyPressEvent(keyCode: number): KeyboardEvent {
+        return {
+          type: 'keypress',
+          charCode: keyCode,
+          keyCode,
+          preventDefault: () => { },
+          stopPropagation: () => { }
+        } as KeyboardEvent;
+      }
+
+      function createInputEvent(data: string): InputEvent & { defaultPreventedForTest: boolean, propagationStoppedForTest: boolean } {
+        const ev = {
+          data,
+          inputType: 'insertText',
+          defaultPreventedForTest: false,
+          propagationStoppedForTest: false,
+          preventDefault(): void { this.defaultPreventedForTest = true; },
+          stopPropagation(): void { this.propagationStoppedForTest = true; }
+        };
+        return ev as InputEvent & { defaultPreventedForTest: boolean, propagationStoppedForTest: boolean };
+      }
+
+      it('should prefer beforeinput data over printable keydown data', async () => {
+        const data: string[] = [];
+        term.onData(e => data.push(e));
+        (term as any).textarea = { value: '' };
+
+        term.keyDown(createKeyDownEvent('a', 65));
+        term.keyPress(createKeyPressEvent(97));
+        assert.deepEqual(data, []);
+
+        const ev = createInputEvent('あ');
+        assert.equal(term.beforeInput(ev), true);
+        assert.equal(ev.defaultPreventedForTest, true);
+        assert.equal(ev.propagationStoppedForTest, true);
+        await new Promise(r => setTimeout(r, 0));
+
+        assert.deepEqual(data, ['あ']);
+      });
+
+      it('should send printable keydown data via beforeinput for regular text', async () => {
+        const data: string[] = [];
+        term.onData(e => data.push(e));
+        (term as any).textarea = { value: '' };
+
+        term.keyDown(createKeyDownEvent('a', 65));
+        const ev = createInputEvent('a');
+        assert.equal(term.beforeInput(ev), true);
+        await new Promise(r => setTimeout(r, 0));
+
+        assert.deepEqual(data, ['a']);
+      });
+
+      it('should fall back to keydown data when beforeinput/input does not arrive', async () => {
+        const data: string[] = [];
+        term.onData(e => data.push(e));
+        (term as any).textarea = { value: '' };
+
+        term.keyDown(createKeyDownEvent('a', 65));
+        assert.deepEqual(data, []);
+        await new Promise(r => setTimeout(r, 0));
+
+        assert.deepEqual(data, ['a']);
+      });
+
+      it('should not defer printable keydown data in special keyboard modes', () => {
+        const data: string[] = [];
+        term.onData(e => data.push(e));
+        term.options.vtExtensions = { win32InputMode: true };
+        term.coreService.decPrivateModes.win32InputMode = true;
+        (term as any).textarea = { value: '' };
+
+        term.keyDown(createKeyDownEvent('a', 65));
+
+        assert.lengthOf(data, 1);
+      });
+
       it('should not scroll down on modifier-only input in win32 input mode', async () => {
         term.options.vtExtensions = { win32InputMode: true };
         term.coreService.decPrivateModes.win32InputMode = true;

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -25,6 +25,8 @@ export class TestTerminal extends CoreBrowserTerminal {
   public get curAttrData(): IAttributeData { return (this as any)._inputHandler._curAttrData; }
   public keyDown(ev: any): boolean | undefined { return this._keyDown(ev); }
   public keyPress(ev: any): boolean { return this._keyPress(ev); }
+  public beforeInput(ev: any): boolean { return this._beforeInputEvent(ev); }
+  public input(ev: any): boolean { return this._inputEvent(ev); }
   public writeP(data: string | Uint8Array): Promise<void> {
     return new Promise(r => this.write(data, r));
   }


### PR DESCRIPTION
Fixes #5348

This changes printable key handling to give `beforeinput`/`input` a chance to provide the authoritative text before xterm.js sends the raw `keydown` character.

Some IMEs such as SKK commit certain characters without a `compositionstart`/`compositionend` sequence. In Chromium-based runtimes, a key like `a` can arrive as:

- `keydown`: raw key `a`
- `beforeinput`/`input`: committed IME text `あ`

Before this change, xterm.js sent the raw keydown text immediately, so terminal apps received `a` instead of `あ`. Multi-key SKK input such as `ka` can still work because the first key enters IME state and the committed text arrives later.

The fix:

- defers unmodified, single-character printable keydown data for one tick
- handles `beforeinput` first, preventing the DOM mutation when possible
- falls back to `input` if `beforeinput` is unavailable
- flushes the original keydown text if no text input event arrives
- leaves Kitty keyboard protocol, Win32 input mode, modified keys, control sequences, and screen reader mode on the existing synchronous path

Added unit coverage for:

- IME-transformed `beforeinput` data replacing raw printable keydown data (`a` -> `あ`)
- regular printable text still being sent (`a` -> `a`)
- fallback when no `beforeinput`/`input` arrives
- special keyboard modes not being deferred

Validation run locally:

- `npm run build`
- `npm run esbuild`
- `node ./bin/test_unit.js out-esbuild/browser/Terminal.test.js`
- `npm run test-unit`
- `npm run lint-changes`
