### PR TITLE
Scope GitHub Actions permissions to least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read 
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '41 17 * * 0'
 
+permissions:
+  actions: read          
+  contents: read          
+  security-events: write 
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicitly downscoping github token privileges increases the GitHub Actions security posture of repositories

closes #6027 