### PR TITLE
Respect erase attributes (back-color-erase) for scrollDown blank lines

### DIFF
--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -1527,6 +1527,11 @@ describe('InputHandler', () => {
       await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[2;4r\x1b[2Tm');
       assert.deepEqual(getLines(bufferService), ['m', '', '', '1', '4', '5', '6', '7', '8', '9']);
     });
+    it('scrollDown blank lines respect erase attributes', async () => {
+      await inputHandler.parseP('\x1b[41m\x1b[2;4r\x1b[2H\x1b[T');
+      // The blank line inserted at the top of the scroll region should use the current background.
+      assert.equal(bufferService.buffer.lines.get(1)!.loadCell(0, new CellData()).getBgColor(), 1);
+    });
     it('insertLines - out of margins', async () => {
       await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
       assert.equal(bufferService.buffer.scrollTop, 2);

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -1481,7 +1481,7 @@ export class InputHandler extends Disposable implements IInputHandler {
 
     while (param--) {
       this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollBottom, 1);
-      this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollTop, 0, this._activeBuffer.getBlankLine(DEFAULT_ATTR_DATA));
+      this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollTop, 0, this._activeBuffer.getBlankLine(this._eraseAttrData()));
     }
     this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom);
     return true;


### PR DESCRIPTION
`scrollDown` (SD, `CSI Ps T`) does not honor back-color-erase: the blank line it inserts at the top of the scroll region is filled with `DEFAULT_ATTR_DATA` instead of the current SGR background.

Every other place that introduces blank cells (ED, EL, ECH, alt-buffer clear, `insertLines`, `deleteLines`, and notably its sibling `scrollUp`) uses `this._eraseAttrData()`, which folds the active background into the erase attributes. Only `scrollDown` uses the default, so after an application sets a background (for example `CSI 41m`) and scrolls the region down, the new line shows the terminal default background instead of the active one, leaving a wrong cell-attribute state that is visible in TUIs and shells.

## Fix

Use `this._eraseAttrData()` for the inserted line, matching `scrollUp` (`InputHandler.ts`) and the other blank-cell paths. `DEFAULT_ATTR_DATA` is still used elsewhere, so there is no orphaned import.

## Testing

Added a test to the `scroll margins` block of `InputHandler.test.ts`: set a red background, define a scroll region, scroll down, and assert the inserted blank line carries that background. It fails on the current code (background color comes back as the default) and passes with the fix. The full `InputHandler` suite stays green (193 passing).
