### PR TITLE
Fix fcitx5 candidate selection commits

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -121,6 +121,15 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
    */
   private _unprocessedDeadKey: boolean = false;
 
+  /**
+   * Raw candidate selection keys can be followed by a text insertion from Linux IMEs when inline
+   * preedit is disabled. Defer those keys long enough for the input event to take precedence.
+   */
+  private _deferredCandidateCommitKey: { key: string, domEvent: KeyboardEvent } | undefined;
+  private _skipNextKeyPress: string[] | undefined;
+  private _skipNextInput: string | undefined;
+  private _lastKeyDownWasProcess: boolean = false;
+
   private _compositionHelper: ICompositionHelper | undefined;
   private _accessibilityManager: MutableDisposable<AccessibilityManager> = this._register(new MutableDisposable());
 
@@ -845,6 +854,10 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   protected _keyDown(event: KeyboardEvent): boolean | undefined {
     this._keyDownHandled = false;
     this._keyDownSeen = true;
+    this._clearDeferredCandidateCommitKey();
+    this._skipNextKeyPress = undefined;
+    this._skipNextInput = undefined;
+    this._lastKeyDownWasProcess = event.key === 'Process' || event.keyCode === 229;
 
     if (this._customKeyEventHandler && this._customKeyEventHandler(event) === false) {
       return false;
@@ -852,6 +865,11 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
     // Ignore composing with Alt key on Mac when macOptionIsMeta is enabled
     const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey;
+
+    if (!shouldIgnoreComposition && this._compositionHelper!.isComposing && this._deferCandidateCommitKey(event, undefined)) {
+      event.stopPropagation();
+      return false;
+    }
 
     if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
       if (this.options.scrollOnUserInput && this.buffer.ybase !== this.buffer.ydisp) {
@@ -890,10 +908,6 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       event.stopPropagation();
     }
 
-    if (!result.key) {
-      return true;
-    }
-
     // HACK: Process A-Z in the keypress event to fix an issue with macOS IMEs where lower case
     // letters cannot be input while caps lock is on. Skip this hack when using kitty protocol
     // or Win32 input mode as they need to send proper sequences for all key events.
@@ -905,6 +919,15 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
     if (this._unprocessedDeadKey) {
       this._unprocessedDeadKey = false;
+      return true;
+    }
+
+    if (this._deferCandidateCommitKey(event, result.key)) {
+      event.stopPropagation();
+      return false;
+    }
+
+    if (!result.key) {
       return true;
     }
 
@@ -966,6 +989,10 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     }
 
     this.updateCursorStyle(ev);
+    if (this._deferredCandidateCommitKey && this._getCandidateCommitKey(ev, undefined) === this._deferredCandidateCommitKey.key) {
+      this._sendDeferredCandidateCommitKey(true);
+    }
+    this._lastKeyDownWasProcess = false;
     this._keyPressHandled = false;
   }
 
@@ -1006,6 +1033,32 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
     key = String.fromCharCode(key);
 
+    if (this._consumeSkipNextKeyPress(key)) {
+      this._keyPressHandled = true;
+      return true;
+    }
+
+    if (this._deferredCandidateCommitKey?.key === key) {
+      // A raw candidate selection key can still be followed by IME committed text in an input
+      // event. Keep deferring until input or keyup decides whether to send the raw key.
+      this._keyPressHandled = true;
+      this._unprocessedDeadKey = false;
+      return true;
+    }
+
+    const deferredCandidateCommitKey = this._deferredCandidateCommitKey;
+    if (deferredCandidateCommitKey) {
+      this._skipNextInput = key;
+      this._clearDeferredCandidateCommitKey();
+      this._onKey.fire({ key, domEvent: ev });
+      this._showCursor();
+      this.coreService.triggerDataEvent(key, true);
+      this._compositionHelper!.recordDataAlreadySent(key);
+      this._keyPressHandled = true;
+      this._unprocessedDeadKey = false;
+      return true;
+    }
+
     this._onKey.fire({ key, domEvent: ev });
     this._showCursor();
     this.coreService.triggerDataEvent(key, true);
@@ -1029,21 +1082,137 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     // Only support emoji IMEs when screen reader mode is disabled as the event must bubble up to
     // support reading out character input which can doubling up input characters
     // Based on these event traces: https://github.com/xtermjs/xterm.js/issues/3679
-    if (ev.data && ev.inputType === 'insertText' && (!ev.composed || !this._keyDownSeen) && !this.optionsService.rawOptions.screenReaderMode) {
-      if (this._keyPressHandled) {
+    if (ev.data && ev.inputType === 'insertText' && !this.optionsService.rawOptions.screenReaderMode) {
+      if (this._skipNextInput) {
+        const skipInput = this._skipNextInput;
+        this._skipNextInput = undefined;
+        if (skipInput === ev.data) {
+          return false;
+        }
+      }
+
+      if (this._keyPressHandled && !this._deferredCandidateCommitKey && !this._lastKeyDownWasProcess) {
+        return false;
+      }
+
+      if (!this._deferredCandidateCommitKey && !this._lastKeyDownWasProcess && (ev.composed && this._keyDownSeen)) {
         return false;
       }
 
       // The key was handled so clear the dead key state, otherwise certain keystrokes like arrow
       // keys could be ignored
       this._unprocessedDeadKey = false;
+      const deferredCandidateCommitKey = this._deferredCandidateCommitKey;
+      if (deferredCandidateCommitKey) {
+        this._addSkipNextKeyPress(deferredCandidateCommitKey.key);
+        if (ev.data !== deferredCandidateCommitKey.key) {
+          this._addSkipNextKeyPress(ev.data);
+        }
+        if (ev.data === deferredCandidateCommitKey.key) {
+          this._sendDeferredCandidateCommitKey();
+        } else {
+          this._clearDeferredCandidateCommitKey();
+          const text = ev.data;
+          this.coreService.triggerDataEvent(text, true);
+          this._compositionHelper!.recordDataAlreadySent(text);
+        }
+        this._lastKeyDownWasProcess = false;
+        this._keyPressHandled = false;
+        return true;
+      }
+      this._clearDeferredCandidateCommitKey();
 
       const text = ev.data;
       this.coreService.triggerDataEvent(text, true);
+      if (this._lastKeyDownWasProcess) {
+        this._compositionHelper!.recordDataAlreadySent(text);
+      }
+      this._lastKeyDownWasProcess = false;
       return true;
     }
 
     return false;
+  }
+
+  private _deferCandidateCommitKey(event: KeyboardEvent, key: string | undefined): boolean {
+    if (this.optionsService.rawOptions.screenReaderMode ||
+      this._keyboardService.useKitty || this._keyboardService.useWin32InputMode ||
+      !this.browser.isLinux || event.ctrlKey || event.altKey || event.metaKey) {
+      return false;
+    }
+
+    const candidateCommitKey = this._getCandidateCommitKey(event, key);
+    if (!candidateCommitKey) {
+      return false;
+    }
+
+    this._deferredCandidateCommitKey = { key: candidateCommitKey, domEvent: event };
+    this._keyPressHandled = true;
+    // The key was handled so clear the dead key state, otherwise certain keystrokes like arrow
+    // keys could be ignored
+    this._unprocessedDeadKey = false;
+
+    return true;
+  }
+
+  private _getCandidateCommitKey(event: KeyboardEvent, key: string | undefined): string | undefined {
+    if (key === ' ' || event.key === ' ' || event.code === 'Space' || event.keyCode === 32) {
+      return ' ';
+    }
+
+    for (let i = 1; i <= 9; i++) {
+      const digit = `${i}`;
+      if (key === digit || event.key === digit || event.code === `Digit${digit}` ||
+        event.code === `Numpad${digit}` || event.keyCode === 48 + i || event.keyCode === 96 + i) {
+        return digit;
+      }
+    }
+
+    return undefined;
+  }
+
+  private _sendDeferredCandidateCommitKey(skipNextInput: boolean = false): boolean {
+    const deferred = this._deferredCandidateCommitKey;
+    if (!deferred) {
+      return false;
+    }
+    this._clearDeferredCandidateCommitKey();
+    if (skipNextInput) {
+      this._skipNextInput = deferred.key;
+    }
+    this._onKey.fire({ key: deferred.key, domEvent: deferred.domEvent });
+    this._showCursor();
+    this.coreService.triggerDataEvent(deferred.key, true);
+    this._unprocessedDeadKey = false;
+    return true;
+  }
+
+  private _clearDeferredCandidateCommitKey(): void {
+    this._deferredCandidateCommitKey = undefined;
+  }
+
+  private _addSkipNextKeyPress(key: string): void {
+    this._skipNextKeyPress ??= [];
+    if (!this._skipNextKeyPress.includes(key)) {
+      this._skipNextKeyPress.push(key);
+    }
+  }
+
+  private _consumeSkipNextKeyPress(key: string): boolean {
+    if (!this._skipNextKeyPress) {
+      return false;
+    }
+
+    const index = this._skipNextKeyPress.indexOf(key);
+    if (index === -1) {
+      return false;
+    }
+
+    this._skipNextKeyPress.splice(index, 1);
+    if (this._skipNextKeyPress.length === 0) {
+      this._skipNextKeyPress = undefined;
+    }
+    return true;
   }
 
   /**

--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -126,6 +126,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
    * preedit is disabled. Defer those keys long enough for the input event to take precedence.
    */
   private _deferredCandidateCommitKey: { key: string, domEvent: KeyboardEvent } | undefined;
+  private _deferredCandidateCommitKeyTimeout: number | undefined;
   private _skipNextKeyPress: string[] | undefined;
   private _skipNextInput: string | undefined;
   private _lastKeyDownWasProcess: boolean = false;
@@ -854,6 +855,9 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   protected _keyDown(event: KeyboardEvent): boolean | undefined {
     this._keyDownHandled = false;
     this._keyDownSeen = true;
+    if (this._deferredCandidateCommitKeyTimeout !== undefined) {
+      this._sendDeferredCandidateCommitKey(true);
+    }
     this._clearDeferredCandidateCommitKey();
     this._skipNextKeyPress = undefined;
     this._skipNextInput = undefined;
@@ -990,7 +994,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
     this.updateCursorStyle(ev);
     if (this._deferredCandidateCommitKey && this._getCandidateCommitKey(ev, undefined) === this._deferredCandidateCommitKey.key) {
-      this._sendDeferredCandidateCommitKey(true);
+      this._scheduleDeferredCandidateCommitKey();
     }
     this._lastKeyDownWasProcess = false;
     this._keyPressHandled = false;
@@ -1136,7 +1140,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
   private _deferCandidateCommitKey(event: KeyboardEvent, key: string | undefined): boolean {
     if (this.optionsService.rawOptions.screenReaderMode ||
-      this._keyboardService.useKitty || this._keyboardService.useWin32InputMode ||
+      this._keyboardService.useWin32InputMode ||
       !this.browser.isLinux || event.ctrlKey || event.altKey || event.metaKey) {
       return false;
     }
@@ -1153,6 +1157,16 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     this._unprocessedDeadKey = false;
 
     return true;
+  }
+
+  private _scheduleDeferredCandidateCommitKey(): void {
+    if (this._deferredCandidateCommitKeyTimeout !== undefined) {
+      return;
+    }
+    this._deferredCandidateCommitKeyTimeout = window.setTimeout(() => {
+      this._deferredCandidateCommitKeyTimeout = undefined;
+      this._sendDeferredCandidateCommitKey(true);
+    }, 50);
   }
 
   private _getCandidateCommitKey(event: KeyboardEvent, key: string | undefined): string | undefined {
@@ -1188,6 +1202,10 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   }
 
   private _clearDeferredCandidateCommitKey(): void {
+    if (this._deferredCandidateCommitKeyTimeout !== undefined) {
+      window.clearTimeout(this._deferredCandidateCommitKeyTimeout);
+      this._deferredCandidateCommitKeyTimeout = undefined;
+    }
     this._deferredCandidateCommitKey = undefined;
   }
 

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -354,6 +354,8 @@ export class MockCompositionHelper implements ICompositionHelper {
   public compositionend(): void {
     throw new Error('Method not implemented.');
   }
+  public recordDataAlreadySent(data: string): void {
+  }
   public updateCompositionElements(dontRecurse?: boolean): void {
     throw new Error('Method not implemented.');
   }

--- a/src/browser/Types.ts
+++ b/src/browser/Types.ts
@@ -42,6 +42,7 @@ export interface ICompositionHelper {
   compositionstart(): void;
   compositionupdate(ev: CompositionEvent): void;
   compositionend(): void;
+  recordDataAlreadySent(data: string): void;
   updateCompositionElements(dontRecurse?: boolean): void;
   keydown(ev: KeyboardEvent): boolean;
 }
@@ -55,6 +56,7 @@ export interface IBrowser {
   isIpad: boolean;
   isIphone: boolean;
   isWindows: boolean;
+  isLinux: boolean;
 }
 
 export interface IColorSet {

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -43,7 +43,7 @@ export class CompositionHelper {
   private _isSendingComposition: boolean;
 
   /**
-   * Data already sent due to keydown event.
+   * Data already sent before delayed composition or textarea-change finalization.
    */
   private _dataAlreadySent: string;
 
@@ -105,6 +105,17 @@ export class CompositionHelper {
    */
   public compositionend(): void {
     this._finalizeComposition(true);
+  }
+
+  /**
+   * Records text that has already been forwarded while delayed composition or textarea-change
+   * handling is still pending. This prevents the final textarea diff from sending it again.
+   */
+  public recordDataAlreadySent(data: string): void {
+    if (!this._isComposing && !this._isSendingComposition && !this._textareaChangeTimer) {
+      return;
+    }
+    this._dataAlreadySent += data;
   }
 
   /**
@@ -178,7 +189,7 @@ export class CompositionHelper {
         if (this._isSendingComposition) {
           this._isSendingComposition = false;
           let input;
-          // Add length of data already sent due to keydown event,
+          // Add length of data already sent due to keydown/input events,
           // otherwise input characters can be duplicated. (Issue #3191)
           currentCompositionPosition.start += this._dataAlreadySent.length;
           if (this._isComposing) {
@@ -214,24 +225,36 @@ export class CompositionHelper {
       return;
     }
     const oldValue = this._textarea.value;
+    const dataAlreadySentLength = this._dataAlreadySent.length;
     this._textareaChangeTimer = window.setTimeout(() => {
       this._textareaChangeTimer = undefined;
       // Ignore if a composition has started since the timeout
       if (!this._isComposing) {
         const newValue = this._textarea.value;
 
-        const diff = newValue.replace(oldValue, '');
-
-        this._dataAlreadySent = diff;
+        let diff = newValue.replace(oldValue, '');
+        if (diff.length > 0) {
+          const alreadySent = this._dataAlreadySent.substring(dataAlreadySentLength);
+          if (diff.startsWith(alreadySent)) {
+            diff = diff.substring(alreadySent.length);
+          } else if (alreadySent.startsWith(diff)) {
+            diff = '';
+          }
+        }
 
         if (newValue.length > oldValue.length) {
-          this._coreService.triggerDataEvent(diff, true);
+          if (diff.length > 0) {
+            this._dataAlreadySent += diff;
+            this._coreService.triggerDataEvent(diff, true);
+          }
         } else if (newValue.length < oldValue.length) {
           this._coreService.triggerDataEvent(`${C0.DEL}`, true);
         } else if ((newValue.length === oldValue.length) && (newValue !== oldValue)) {
+          this._dataAlreadySent += newValue;
           this._coreService.triggerDataEvent(newValue, true);
         }
 
+        this._dataAlreadySent = '';
       }
     }, 0);
   }


### PR DESCRIPTION
## Summary

- defer Linux IME candidate selection keys so committed text can take precedence
- prevent deferred candidate keys and delayed composition handling from duplicating input
- track data already forwarded by input events in `CompositionHelper`

Fixes #6036

## Validation

- `git diff --cached --check` passed before commit
- `npm run lint-changes` failed before linting changed files because the current oxlint configuration uses reserved JS plugin name `eslint`
- `npm run build` failed due to missing existing addon dependencies/types: `xterm-wasm-parts`, `sixel`, `opentype.js`
