### PR TITLE
Preserve fractional scroll offset for pixel-smooth trackpad scrolling

### DIFF
--- a/addons/addon-webgl/src/GlyphRenderer.ts
+++ b/addons/addon-webgl/src/GlyphRenderer.ts
@@ -100,6 +100,7 @@ export class GlyphRenderer extends Disposable {
   private readonly _attributesBuffer: WebGLBuffer;
 
   private _atlas: ITextureAtlas | undefined;
+  private _lastSeenClearModelGeneration: number = 0;
   private _activeBuffer: number = 0;
   private readonly _vertices: IVertices = {
     count: 0,
@@ -214,7 +215,15 @@ export class GlyphRenderer extends Disposable {
   }
 
   public beginFrame(): boolean {
-    return this._atlas ? this._atlas.beginFrame() : true;
+    if (!this._atlas) {
+      return true;
+    }
+    // Shared atlases need per-renderer clear tracking.
+    if (this._atlas.clearModelGeneration === this._lastSeenClearModelGeneration) {
+      return false;
+    }
+    this._lastSeenClearModelGeneration = this._atlas.clearModelGeneration;
+    return true;
   }
 
   public updateCell(x: number, y: number, code: number, bg: number, fg: number, ext: number, chars: string, width: number, lastBg: number): void {
@@ -374,7 +383,11 @@ export class GlyphRenderer extends Disposable {
   }
 
   public setAtlas(atlas: ITextureAtlas): void {
-    this._atlas = atlas;
+    if (this._atlas !== atlas) {
+      this._atlas = atlas;
+      // Texture invalidation below already handles the atlas swap.
+      this._lastSeenClearModelGeneration = atlas.clearModelGeneration;
+    }
     this.invalidateAtlasTextures();
   }
 

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -132,12 +132,8 @@ export class TextureAtlas implements ITextureAtlas {
     }
   }
 
-  private _requestClearModel = false;
-  public beginFrame(): boolean {
-    const result = this._requestClearModel;
-    this._requestClearModel = false;
-    return result;
-  }
+  private _clearModelGeneration = 0;
+  public get clearModelGeneration(): number { return this._clearModelGeneration; }
 
   public clearTexture(): void {
     if (this._pages[0].currentRow.x === 0 && this._pages[0].currentRow.y === 0) {
@@ -207,7 +203,7 @@ export class TextureAtlas implements ITextureAtlas {
       this.pages.push(mergedPage);
 
       // Request the model to be cleared to refresh all texture pages.
-      this._requestClearModel = true;
+      this._clearModelGeneration++;
       this._onAddTextureAtlasCanvas.fire(mergedPage.canvas);
     }
 
@@ -819,7 +815,7 @@ export class TextureAtlas implements ITextureAtlas {
           this.pages.push(this._overflowSizePage);
 
           // Request the model to be cleared to refresh all texture pages.
-          this._requestClearModel = true;
+          this._clearModelGeneration++;
           this._onAddTextureAtlasCanvas.fire(this._overflowSizePage.canvas);
         }
         activePage = this._overflowSizePage;

--- a/addons/addon-webgl/src/Types.ts
+++ b/addons/addon-webgl/src/Types.ts
@@ -68,10 +68,10 @@ export interface ITextureAtlas extends IDisposable {
   warmUp(): void;
 
   /**
-   * Call when a frame is being drawn, this will return true if the atlas was cleared to make room
-   * for a new set of glyphs.
+   * Bumped when atlas page layout changes require renderer models to clear.
+   * Renderers compare this against their last handled generation.
    */
-  beginFrame(): boolean;
+  readonly clearModelGeneration: number;
 
   /**
    * Clear all glyphs from the texture atlas.

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -29,6 +29,9 @@ export class Viewport extends Disposable {
   private _suppressOnScrollHandler: boolean = false;
   private _needsSyncOnRender: boolean = false;
 
+  private _screenElement: HTMLElement;
+  private _pixelOffset: number = 0;
+
   constructor(
     element: HTMLElement,
     screenElement: HTMLElement,
@@ -80,6 +83,8 @@ export class Viewport extends Disposable {
     element.appendChild(this._scrollableElement.getDomNode());
     this._register(toDisposable(() => this._scrollableElement.getDomNode().remove()));
 
+    this._screenElement = screenElement;
+    screenElement.style.willChange = 'transform';
     this._styleElement = coreBrowserService.mainDocument.createElement('style');
     screenElement.appendChild(this._styleElement);
     this._register(toDisposable(() => this._styleElement.remove()));
@@ -102,6 +107,8 @@ export class Viewport extends Disposable {
       // Reset _latestYDisp when switching buffers to prevent stale scroll position
       // from alt buffer contaminating normal buffer scroll position
       this._latestYDisp = undefined;
+      this._pixelOffset = 0;
+      this._applyPixelOffset();
       this.queueSync();
     }));
     this._register(this._bufferService.onScroll(() => this._sync()));
@@ -209,13 +216,30 @@ export class Viewport extends Disposable {
       return;
     }
     this._isHandlingScroll = true;
-    const newRow = Math.round(e.scrollTop / this._renderService.dimensions.css.cell.height);
+    const cellHeight = this._renderService.dimensions.css.cell.height;
+    const newRow = Math.round(e.scrollTop / cellHeight);
     const diff = newRow - this._bufferService.buffer.ydisp;
     if (diff !== 0) {
       this._latestYDisp = newRow;
       this._onRequestScrollLines.fire(diff);
     }
+    // Preserve sub-row motion between row-aligned scroll positions.
+    this._pixelOffset = newRow * cellHeight - e.scrollTop;
+    this._applyPixelOffset();
     this._isHandlingScroll = false;
+  }
+
+  // Round to device pixels to avoid canvas blur.
+  private _applyPixelOffset(): void {
+    const el = this._screenElement;
+    if (!el) {
+      return;
+    }
+    let offset = this._pixelOffset || 0;
+    const win = el.ownerDocument && el.ownerDocument.defaultView;
+    const dpr = (win && win.devicePixelRatio) || 1;
+    offset = Math.round(offset * dpr) / dpr;
+    el.style.transform = offset ? `translateY(${offset}px)` : '';
   }
 
   public handleTouchScroll(translationY: number): void {


### PR DESCRIPTION
This preserves the fractional viewport offset so trackpad scrolling can move at pixel granularity while rows remain the unit of layout and rendering.

Changes:
- Keep the row calculation intact, then store the leftover pixel offset as `_pixelOffset = newRow * cellHeight - scrollTop`.
- Apply that offset as a `devicePixelRatio`-rounded `translateY()` on the screen element.
- Add `will-change: transform` so the in-between motion stays on the compositor.
- Reset the offset when switching between the normal and alt buffers.
- Replace the WebGL addon's one-shot `beginFrame()` boolean with a monotonic `clearModelGeneration` counter. With a shared atlas, the boolean can be consumed by the first renderer that sees it; the counter lets each renderer observe and handle model clears independently.

Unaffected behavior:
- Selection still uses the same row model.
- Alt-buffer apps still reset to an aligned viewport.
- `smoothScrollDuration` is unchanged; this only affects the fractional offset inside each row step.

Demo recording:
BEFORE:

https://github.com/user-attachments/assets/14dacd11-770b-4642-9b23-62ea91a50e1f


AFTER:

https://github.com/user-attachments/assets/ab45efca-38f9-4db3-a7fa-84c85a6371e3





