### PR TITLE
Fix composition sent twice when a keydown finalizes it before compositionend

### DIFF
--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -234,6 +234,25 @@ describe('CompositionHelper', () => {
       }, 0);
     });
 
+    it('Should not duplicate the composition when a keydown ends it before compositionend fires', (done) => {
+      // Compose 'こんにちは'
+      compositionHelper.compositionstart();
+      compositionHelper.compositionupdate({ data: 'こんにちは' });
+      textarea.value = 'こんにちは';
+      setTimeout(() => { // wait for any textarea updates
+        // A keydown that is not consumed by the IME ends the composition and sends it immediately,
+        // eg. the macOS eisuu (英数) input source switch key (issue #5778)
+        compositionHelper.keydown({ keyCode: 102 } as KeyboardEvent);
+        assert.equal(handledText, 'こんにちは');
+        // The browser fires compositionend afterwards, which must not send the text again
+        compositionHelper.compositionend();
+        setTimeout(() => { // wait for any textarea updates
+          assert.equal(handledText, 'こんにちは');
+          done();
+        }, 0);
+      }, 0);
+    });
+
     it('Should insert middle composition and subsequent input without appending existing trailing text', (done) => {
       textarea.value = '一二';
       // screenReaderMode keeps textarea content/selection for assistive technologies (eg. screen

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -154,6 +154,9 @@ export class CompositionHelper {
       // Cancel any delayed composition send requests and send the input immediately.
       this._isSendingComposition = false;
       const input = this._textarea.value.substring(this._compositionPosition.start, this._compositionPosition.end);
+      // Record the data sent so the deferred send scheduled by the upcoming compositionend event
+      // doesn't send the same text again (issue #5778).
+      this._dataAlreadySent = input;
       this._coreService.triggerDataEvent(input, true);
     } else {
       // Make a deep copy of the composition position here as a new compositionstart event may


### PR DESCRIPTION
Fixes #5778

## Problem

When a keydown that the IME does not consume arrives during composition — eg. the macOS eisuu (英数) input source switch key, commonly bound to the left Command key via Karabiner-Elements — the composed text is sent twice:

1. `CompositionHelper.keydown()` falls through the keyCode exclusion list and calls `_finalizeComposition(false)`, which sends the composition immediately.
2. The browser then fires `compositionend`, and the deferred send scheduled by `_finalizeComposition(true)` reads the textarea (which is not cleared on this path) and emits the same text again.

The deferred path already has a dedup mechanism — `currentCompositionPosition.start += this._dataAlreadySent.length`, added for #3191 — but only `_handleAnyTextareaChanges()` (the keyCode 229 path) ever writes `_dataAlreadySent`. The immediate-finalize path does not record what it sent.

## Fix

Record the immediately sent text in `_dataAlreadySent` in the `!waitForPropagation` branch of `_finalizeComposition()`. The deferred send's existing offset logic then skips the already-sent text; if the IME commits additional text between the keydown and `compositionend`, only the delta is emitted, matching the existing semantics.

No key codes are special-cased (unlike the earlier CapsLock fix that added keyCode 20 to the exclusion list), so this also covers other input source switch keys across platforms and layouts (kana, Korean 한/영, remapped keys, etc.).

## Testing

- Added a unit test reproducing the issue: composition ended by a non-excluded keydown followed by `compositionend`. Without the fix it fails with `こんにちはこんにちは`; with the fix it passes.
- Full unit suite passes (2404 passing) and lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)