### PR TITLE
feat: add support and tests for mouse auxiliary buttons (AUX1 to AUX8)

### DIFF
--- a/src/browser/services/MouseService.test.ts
+++ b/src/browser/services/MouseService.test.ts
@@ -203,8 +203,57 @@ describe('MouseService _triggerMouseEvent', () => {
     });
   });
 
+  it('AUX buttons encoding', () => {
+    mouseStateService.activeProtocol = 'ANY';
+
+    // 1. DEFAULT encoding
+    mouseStateService.activeEncoding = 'DEFAULT';
+    // Down actions
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX1, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX2, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX3, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX4, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX5, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX6, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX7, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX8, action: CoreMouseAction.DOWN }), true);
+    assert.deepEqual(reports, [
+      '\x1b[M\u00a0!!', '\x1b[M\u00a1!!', '\x1b[M\u00a2!!', '\x1b[M\u00a3!!',
+      '\x1b[M\u00e0!!', '\x1b[M\u00e1!!', '\x1b[M\u00e2!!', '\x1b[M\u00e3!!'
+    ]);
+    reports = [];
+
+    // Up actions (always reports release code 3 in DEFAULT encoding)
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX1, action: CoreMouseAction.UP }), true);
+    assert.deepEqual(reports, ['\x1b[M\u00a3!!']);
+    reports = [];
+
+    // 2. SGR encoding
+    mouseStateService.activeEncoding = 'SGR';
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX1, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX1, action: CoreMouseAction.UP }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX5, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 0, y: 0, button: CoreMouseButton.AUX5, action: CoreMouseAction.UP }), true);
+    assert.deepEqual(reports, [
+      '\x1b[<128;1;1M',
+      '\x1b[<128;1;1m',
+      '\x1b[<192;1;1M',
+      '\x1b[<192;1;1m'
+    ]);
+    reports = [];
+
+    // 3. SGR_PIXELS encoding
+    mouseStateService.activeEncoding = 'SGR_PIXELS';
+    assert.equal(trigger({ col: 0, row: 0, x: 10, y: 20, button: CoreMouseButton.AUX1, action: CoreMouseAction.DOWN }), true);
+    assert.equal(trigger({ col: 0, row: 0, x: 10, y: 20, button: CoreMouseButton.AUX1, action: CoreMouseAction.UP }), true);
+    assert.deepEqual(reports, [
+      '\x1b[<128;10;20M',
+      '\x1b[<128;10;20m'
+    ]);
+    reports = [];
+  });
+
   it('eventCodes with modifiers (DEFAULT encoding)', () => {
-    // TODO: implement AUX button tests
     mouseStateService.activeProtocol = 'ANY';
     mouseStateService.activeEncoding = 'DEFAULT';
     // all buttons + down + no modifer

--- a/src/browser/services/MouseService.ts
+++ b/src/browser/services/MouseService.ts
@@ -117,23 +117,31 @@ export class MouseService implements IMouseService {
           // buttons is not supported on macOS, try to get a value from button instead
           but = CoreMouseButton.NONE;
           if (ev.button !== undefined) {
-            but = ev.button < 3 ? ev.button : CoreMouseButton.NONE;
+            but = ev.button < 3 ? ev.button :
+              ev.button >= 3 && ev.button <= 10 ? (ev.button + 5) as CoreMouseButton :
+                CoreMouseButton.NONE;
           }
         } else {
           // according to MDN buttons only reports up to button 5 (AUX2)
           but = ev.buttons & 1 ? CoreMouseButton.LEFT :
             ev.buttons & 4 ? CoreMouseButton.MIDDLE :
               ev.buttons & 2 ? CoreMouseButton.RIGHT :
-                CoreMouseButton.NONE; // fallback to NONE
+                ev.buttons & 8 ? CoreMouseButton.AUX1 :
+                  ev.buttons & 16 ? CoreMouseButton.AUX2 :
+                    CoreMouseButton.NONE; // fallback to NONE
         }
         break;
       case 'mouseup':
         action = CoreMouseAction.UP;
-        but = ev.button < 3 ? ev.button : CoreMouseButton.NONE;
+        but = ev.button < 3 ? ev.button :
+          ev.button >= 3 && ev.button <= 10 ? (ev.button + 5) as CoreMouseButton :
+            CoreMouseButton.NONE;
         break;
       case 'mousedown':
         action = CoreMouseAction.DOWN;
-        but = ev.button < 3 ? ev.button : CoreMouseButton.NONE;
+        but = ev.button < 3 ? ev.button :
+          ev.button >= 3 && ev.button <= 10 ? (ev.button + 5) as CoreMouseButton :
+            CoreMouseButton.NONE;
         break;
       case 'wheel':
         if (!this._mouseStateService.allowCustomWheelEvent(ev as WheelEvent)) {
@@ -160,8 +168,8 @@ export class MouseService implements IMouseService {
     }
 
     // exit if we cannot determine valid button/action values
-    // do nothing for higher buttons than wheel
-    if (action === undefined || but === undefined || but > CoreMouseButton.WHEEL) {
+    // do nothing for higher buttons than wheel, except auxiliary buttons
+    if (action === undefined || but === undefined || (but > CoreMouseButton.WHEEL && (but < CoreMouseButton.AUX1 || but > CoreMouseButton.AUX8))) {
       return false;
     }
 


### PR DESCRIPTION
Adds support for auxiliary mouse buttons (buttons 8–15, such as browser back/forward buttons) and implements the corresponding unit tests to resolve the existing TODO in MouseService.test.ts.

Changes:

MouseService.ts: Mapped ev.button values 3-10 to CoreMouseButton.AUX1-AUX8, and added ev.buttons bitmask checking for drag/move events.
MouseService.test.ts: Added test assertions to cover AUX buttons under DEFAULT, SGR, and SGR_PIXELS protocols.
All unit tests pass and code style is clean. Let me know if you need any adjustments!