### PR TITLE
Fix mouse coordinates under CSS scale transforms

### DIFF
--- a/src/browser/input/Mouse.test.ts
+++ b/src/browser/input/Mouse.test.ts
@@ -5,7 +5,7 @@
 
 import jsdom = require('jsdom');
 import { assert } from 'chai';
-import { getCoords } from './Mouse';
+import { getCoords, getCoordsRelativeToElement } from './Mouse';
 
 const CHAR_WIDTH = 10;
 const CHAR_HEIGHT = 20;
@@ -24,6 +24,26 @@ describe('Mouse getCoords', () => {
     };
     document = new jsdom.JSDOM('').window.document;
   });
+
+  function createElement(left: number, top: number, width: number, height: number, scaleX = 1, scaleY = scaleX): HTMLElement {
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      offsetWidth: { value: width },
+      offsetHeight: { value: height }
+    });
+    element.getBoundingClientRect = () => ({
+      x: left,
+      y: top,
+      left,
+      top,
+      right: left + width * scaleX,
+      bottom: top + height * scaleY,
+      width: width * scaleX,
+      height: height * scaleY,
+      toJSON: () => undefined
+    });
+    return element;
+  }
 
   it('should return the cell that was clicked', () => {
     let coords: [number, number] | undefined;
@@ -44,5 +64,36 @@ describe('Mouse getCoords', () => {
     // Event are double the cols/rows
     coords = getCoords(windowOverride, { clientX: CHAR_WIDTH * 20, clientY: CHAR_HEIGHT * 20 }, document.createElement('div'), 10, 10, true, CHAR_WIDTH, CHAR_HEIGHT);
     assert.deepEqual(coords, [10, 10], 'coordinates should never come back as larger than the terminal');
+  });
+
+  it('should account for an element scaled down by a CSS transform', () => {
+    const element = createElement(50, 80, 100, 200, 0.6);
+    const coords = getCoords(windowOverride, { clientX: 65, clientY: 98 }, element, 10, 10, true, CHAR_WIDTH, CHAR_HEIGHT);
+    assert.deepEqual(coords, [3, 2]);
+  });
+
+  it('should account for an element scaled up by a CSS transform', () => {
+    const element = createElement(50, 80, 100, 200, 1.6);
+    const coords = getCoords(windowOverride, { clientX: 90, clientY: 128 }, element, 10, 10, true, CHAR_WIDTH, CHAR_HEIGHT);
+    assert.deepEqual(coords, [3, 2]);
+  });
+
+  it('should subtract padding after accounting for CSS transform scale', () => {
+    windowOverride = {
+      getComputedStyle(): any {
+        return {
+          getPropertyValue: (property: string) => property === 'padding-left' ? '10px' : '5px'
+        } as Pick<CSSStyleDeclaration, 'getPropertyValue'>;
+      }
+    };
+    const element = createElement(50, 80, 200, 400, 0.5, 0.25);
+    const coords = getCoordsRelativeToElement(windowOverride, { clientX: 100, clientY: 105 }, element);
+    assert.deepEqual(coords, [90, 95]);
+  });
+
+  it('should preserve unscaled coordinates when element dimensions cannot be measured', () => {
+    const element = createElement(50, 80, 0, 0);
+    const coords = getCoordsRelativeToElement(windowOverride, { clientX: 75, clientY: 110 }, element);
+    assert.deepEqual(coords, [25, 30]);
   });
 });

--- a/src/browser/input/Mouse.ts
+++ b/src/browser/input/Mouse.ts
@@ -8,9 +8,11 @@ export function getCoordsRelativeToElement(window: Pick<Window, 'getComputedStyl
   const elementStyle = window.getComputedStyle(element);
   const leftPadding = parseInt(elementStyle.getPropertyValue('padding-left'), 10);
   const topPadding = parseInt(elementStyle.getPropertyValue('padding-top'), 10);
+  const scaleX = element.offsetWidth > 0 && rect.width > 0 ? rect.width / element.offsetWidth : 1;
+  const scaleY = element.offsetHeight > 0 && rect.height > 0 ? rect.height / element.offsetHeight : 1;
   return [
-    event.clientX - rect.left - leftPadding,
-    event.clientY - rect.top - topPadding
+    (event.clientX - rect.left) / scaleX - leftPadding,
+    (event.clientY - rect.top) / scaleY - topPadding
   ];
 }
 

--- a/test/playwright/MouseTracking.test.ts
+++ b/test/playwright/MouseTracking.test.ts
@@ -181,6 +181,45 @@ test.describe('Mouse Tracking Tests', () => {
     await ctx.proxy.resize(cols, rows);
   });
 
+  test('should report the correct cell under an ancestor CSS scale transform', async () => {
+    const encoding = 'SGR';
+    await resetMouseModes();
+    await ctx.page.evaluate(`
+      const container = document.querySelector('#terminal-container');
+      container.style.transformOrigin = 'top left';
+      container.style.transform = 'scale(0.6)';
+    `);
+
+    try {
+      await ctx.proxy.write('\x1b[?9h\x1b[?1006h');
+      const [x, y]: number[] = await ctx.page.evaluate(`
+        (function() {
+          const rect = window.term.element.getBoundingClientRect();
+          const dimensions = window.term.dimensions.css.cell;
+          const scaleX = rect.width / window.term.element.offsetWidth;
+          const scaleY = rect.height / window.term.element.offsetHeight;
+          return [
+            rect.left + (50 * dimensions.width + 2) * scaleX,
+            rect.top + (10 * dimensions.height + 2) * scaleY
+          ];
+        })();
+      `);
+      await ctx.page.mouse.move(x, y);
+      await mouseDown('left');
+      await mouseUp('left');
+      await pollFor(ctx.page, () => getReports(encoding), [
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
+      ]);
+    } finally {
+      await resetMouseModes();
+      await ctx.page.evaluate(`
+        const container = document.querySelector('#terminal-container');
+        container.style.transformOrigin = '';
+        container.style.transform = '';
+      `);
+    }
+  });
+
   test.describe('DECSET 9 (X10)', async () => {
     /**
      * X10 protocol:


### PR DESCRIPTION
Fixes #6023

## Summary

- derive CSS scale factors from the transformed and layout dimensions
- invert positive axis-aligned scaling before applying terminal padding
- add unit coverage for scale down, scale up, non-uniform scale, padding, and zero-size fallback
- add a browser regression test for mouse tracking under an ancestor scale transform

## Tests

- npm run build && npm run esbuild
- npm run test-unit -- out-esbuild/browser/input/Mouse.test.js
- npm run esbuild-demo-client && npm run esbuild-demo-server
- npm run test-integration -- --suite=core --project=Chromium test/playwright/MouseTracking.test.ts
- npm run lint-changes