### PR TITLE
fix: emit the compositionend committed string so whole-value-replacement IMEs don't truncate commits

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -425,7 +425,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       this._compositionHelper!.updateCompositionElements();
     }));
     this._register(addDisposableListener(this.textarea!, 'compositionupdate', (e: CompositionEvent) => this._compositionHelper!.compositionupdate(e)));
-    this._register(addDisposableListener(this.textarea!, 'compositionend', () => this._compositionHelper!.compositionend()));
+    this._register(addDisposableListener(this.textarea!, 'compositionend', (e: CompositionEvent) => this._compositionHelper!.compositionend(e)));
     this._register(addDisposableListener(this.textarea!, 'input', (ev: InputEvent) => this._inputEvent(ev), true));
     this._register(this.onRender(() => this._compositionHelper!.updateCompositionElements()));
   }

--- a/src/browser/Types.ts
+++ b/src/browser/Types.ts
@@ -41,7 +41,7 @@ export interface ICompositionHelper {
   readonly isComposing: boolean;
   compositionstart(): void;
   compositionupdate(ev: CompositionEvent): void;
-  compositionend(): void;
+  compositionend(ev?: CompositionEvent): void;
   updateCompositionElements(dontRecurse?: boolean): void;
   keydown(ev: KeyboardEvent): boolean;
 }

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -259,5 +259,50 @@ describe('CompositionHelper', () => {
         }, 0);
       }, 0);
     });
+
+    it('Should not drop leading pre-existing text when the IME replaces the whole textarea value', (done) => {
+      // 3 characters typed before composing (already sent to the terminal) remain in the textarea.
+      // Windows TSF IMEs (eg. Microsoft Pinyin) apply the composition as a whole-value replacement
+      // that absorbs this pre-existing text, so the start offset recorded at compositionstart is
+      // left stale and slicing the textarea drops the leading commit. The compositionend event's
+      // data carries the authoritative committed string, which is immune to the replacement
+      // geometry. (Issue #6049)
+      textarea.value = '   ';
+      textarea.selectionStart = 3;
+      textarea.selectionEnd = 3;
+      compositionHelper.compositionstart();
+      compositionHelper.compositionupdate({ data: 'n' });
+      textarea.value = '   n';
+      setTimeout(() => { // wait for any textarea updates
+        // The next TSF frame replaces the ENTIRE value (selection spanned 0..4 in the real trace).
+        compositionHelper.compositionupdate({ data: 'ni' });
+        textarea.value = 'ni';
+        setTimeout(() => { // wait for any textarea updates
+          compositionHelper.compositionend({ data: '你是' } as CompositionEvent);
+          textarea.value = '你是';
+          setTimeout(() => { // wait for any textarea updates
+            assert.equal(handledText, '你是');
+            done();
+          }, 0);
+        }, 0);
+      }, 0);
+    });
+
+    it('Should emit nothing when a composition is cancelled with empty compositionend data', (done) => {
+      // An empty compositionend data string is a legitimate "nothing was committed" result (eg. the
+      // composition was cancelled) and must be distinguished from the undefined passed when no
+      // compositionend event is available (which falls back to slicing).
+      compositionHelper.compositionstart();
+      compositionHelper.compositionupdate({ data: 'n' });
+      textarea.value = 'n';
+      setTimeout(() => { // wait for any textarea updates
+        compositionHelper.compositionend({ data: '' } as CompositionEvent);
+        textarea.value = '';
+        setTimeout(() => { // wait for any textarea updates
+          assert.equal(handledText, '');
+          done();
+        }, 0);
+      }, 0);
+    });
   });
 });

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -48,6 +48,14 @@ export class CompositionHelper {
   private _dataAlreadySent: string;
 
   /**
+   * The committed string reported by the last compositionend event, or undefined when no such event
+   * was provided (eg. the keydown-driven early finalize, or a direct API call). This is the DOM's
+   * authoritative result and is preferred over slicing the textarea, which breaks when a TSF IME
+   * replaces the whole textarea value. An empty string is a valid "nothing committed" result.
+   */
+  private _compositionEndData: string | undefined;
+
+  /**
    * The pending textarea change timer, if any.
    */
   private _textareaChangeTimer?: number;
@@ -65,6 +73,7 @@ export class CompositionHelper {
     this._compositionPosition = { start: 0, end: 0 };
     this._compositionSuffix = '';
     this._dataAlreadySent = '';
+    this._compositionEndData = undefined;
   }
 
   /**
@@ -81,6 +90,7 @@ export class CompositionHelper {
     this._compositionSuffix = this._textarea.value.substring(this._compositionPosition.end);
     this._compositionView.textContent = '';
     this._dataAlreadySent = '';
+    this._compositionEndData = undefined;
     this._compositionView.classList.add('active');
   }
 
@@ -102,8 +112,12 @@ export class CompositionHelper {
   /**
    * Handles the compositionend event, hiding the composition view and sending the composition to
    * the handler.
+   * @param ev The event. When provided, its `data` is the DOM's authoritative committed string and
+   *   is emitted verbatim; when omitted (eg. a direct API call) the committed string is instead
+   *   recovered by slicing the textarea.
    */
-  public compositionend(): void {
+  public compositionend(ev?: CompositionEvent): void {
+    this._compositionEndData = ev?.data;
     this._finalizeComposition(true);
   }
 
@@ -163,12 +177,17 @@ export class CompositionHelper {
         end: this._compositionPosition.end
       };
       const currentCompositionSuffix = this._compositionSuffix;
+      // Capture the compositionend data now too, as a new composition may reset it before the
+      // setTimeout executes.
+      const currentCompositionEndData = this._compositionEndData;
 
       // Since composition* events happen before the changes take place in the textarea on most
       // browsers, use a setTimeout with 0ms time to allow the native compositionend event to
       // complete. This ensures the correct character is retrieved.
-      // This solution was used because:
-      // - The compositionend event's data property is unreliable, at least on Chromium
+      // The captured compositionend data is preferred as the committed string; slicing the textarea
+      // is kept as a fallback for callers that do not supply the event. Slicing was originally the
+      // only path because:
+      // - The compositionend event's data property was unreliable, at least on Chromium
       // - The last compositionupdate event's data property does not always accurately describe
       //   the character, a counter example being Korean where an ending consonsant can move to
       //   the following character if the following input is a vowel.
@@ -178,22 +197,32 @@ export class CompositionHelper {
         if (this._isSendingComposition) {
           this._isSendingComposition = false;
           let input;
-          // Add length of data already sent due to keydown event,
-          // otherwise input characters can be duplicated. (Issue #3191)
-          currentCompositionPosition.start += this._dataAlreadySent.length;
-          if (this._isComposing) {
-            // Use the start position of the new composition to get the string
-            // if a new composition has started.
-            input = this._textarea.value.substring(currentCompositionPosition.start, this._compositionPosition.start);
+          if (currentCompositionEndData !== undefined) {
+            // Prefer the committed string reported by compositionend. Unlike slicing the textarea
+            // from the offset recorded at compositionstart, it is immune to the replaced range's
+            // geometry: TSF IMEs (eg. Microsoft Pinyin on Windows) apply the composition as a
+            // whole-value replacement that absorbs pre-existing text, leaving that offset stale and
+            // dropping the leading part of the commit. An empty string means nothing was committed.
+            // (Issue #6049)
+            input = currentCompositionEndData;
           } else {
-            // Keep support for non-composition characters typed immediately after composition end
-            // while avoiding re-sending the trailing text that was already present
-            // before composition started.
-            const value = this._textarea.value;
-            const valueEnd = currentCompositionSuffix.length > 0 && value.endsWith(currentCompositionSuffix)
-              ? value.length - currentCompositionSuffix.length
-              : value.length;
-            input = value.substring(currentCompositionPosition.start, Math.max(currentCompositionPosition.start, valueEnd));
+            // Add length of data already sent due to keydown event,
+            // otherwise input characters can be duplicated. (Issue #3191)
+            currentCompositionPosition.start += this._dataAlreadySent.length;
+            if (this._isComposing) {
+              // Use the start position of the new composition to get the string
+              // if a new composition has started.
+              input = this._textarea.value.substring(currentCompositionPosition.start, this._compositionPosition.start);
+            } else {
+              // Keep support for non-composition characters typed immediately after composition end
+              // while avoiding re-sending the trailing text that was already present
+              // before composition started.
+              const value = this._textarea.value;
+              const valueEnd = currentCompositionSuffix.length > 0 && value.endsWith(currentCompositionSuffix)
+                ? value.length - currentCompositionSuffix.length
+                : value.length;
+              input = value.substring(currentCompositionPosition.start, Math.max(currentCompositionPosition.start, valueEnd));
+            }
           }
           if (input.length > 0) {
             this._coreService.triggerDataEvent(input, true);


### PR DESCRIPTION
Fixes #6049

## Mechanism

When text is already present in the hidden helper textarea (eg. characters just typed, already sent to the terminal) and the user starts an IME composition, Windows TSF IMEs (verified with Microsoft Pinyin) apply composition updates as a **whole-value replacement** — from the second `insertCompositionText` frame on, the replaced range spans the *entire* textarea, absorbing the pre-existing text.

`CompositionHelper` records the composition start offset once at `compositionstart` (`_compositionPosition.start = selectionStart`) and never rebases it. After the whole-value replacement that offset is stale by exactly the length of the absorbed text, so `_finalizeComposition`'s `waitForPropagation` branch does `textarea.value.substring(staleStart, ...)` and silently drops the first N committed characters (N = pre-existing length; the entire commit when N ≥ commit length). Deterministic repro: type 3 spaces, then compose and commit `你是` → nothing is emitted. Full trace is in #6049.

## The fix

Record the `compositionend` event's `data` (the DOM's authoritative committed string) and emit **that** from the `waitForPropagation === true` branch instead of slicing the textarea. Because it is the committed string itself, it is immune to the replacement geometry — offsets no longer matter, and the trailing-suffix special case is sidestepped for the commit path.

The fallback is preserved: when no event data is available — `undefined`, eg. the keydown-driven early-finalize path (`waitForPropagation === false`, no `compositionend` has fired yet) or an embedder calling the API directly — the existing textarea-slice logic runs unchanged, so `_dataAlreadySent` (#3191), `_compositionSuffix` (#5698) and screen-reader-mode behavior are all retained. An empty string is treated as a legitimate "nothing committed" result (distinct from `undefined`) and emits nothing.

The public signature stays backward-compatible: `compositionend(ev?: CompositionEvent)`. `CoreBrowserTerminal` now passes the real event through.

## Tests

Adds two cases to `CompositionHelper.test.ts` mirroring the existing #5698 harness:
- the whole-value-replacement scenario from #6049 (fails on master — `''` instead of `你是`, verified before the fix; passes after);
- a cancelled composition (empty `compositionend` data → nothing emitted).

All existing tests call `compositionend()` with no argument and continue to exercise the slice fallback unchanged. Full unit suite green (2338 passing), lint clean, `tsc` clean.

Verified downstream with real Microsoft Pinyin on Windows 11 (Electron 42), where this fix ships as a patch on `6.1.0-beta.220`.
