### PR TITLE
Fix module/exports fields in published @xterm/headless package

### DIFF
--- a/bin/package_headless.js
+++ b/bin/package_headless.js
@@ -17,7 +17,17 @@ const xtermHeadlessPackageJson = {
   name: '@xterm/headless',
   description: 'A headless terminal component that runs in Node.js',
   main: 'lib-headless/xterm-headless.js',
+  // Override every artifact-path field: the spread above copies the main
+  // package's values, whose module ("lib/xterm.mjs") does not exist in the
+  // published @xterm/headless package (see headless/package.json for the
+  // intended values).
+  module: 'lib-headless/xterm-headless.mjs',
   types: 'typings/xterm-headless.d.ts',
+  exports: {
+    types: './typings/xterm-headless.d.ts',
+    import: './lib-headless/xterm-headless.mjs',
+    require: './lib-headless/xterm-headless.js'
+  },
 };
 delete xtermHeadlessPackageJson['scripts'];
 delete xtermHeadlessPackageJson['devDependencies'];


### PR DESCRIPTION
Fixes #6052, fixes #5796

`bin/package_headless.js` regenerates `headless/package.json` at publish time by spreading the main package's package.json and only overriding `name`/`description`/`main`/`types`. The main package's `module` field (`lib/xterm.mjs` — a path that only exists in `@xterm/xterm`) leaks through into every published `@xterm/headless`, and the `exports` map from the committed `headless/package.json` is dropped. Verified broken on `6.0.0` and `6.1.0-beta.289` (`npm view @xterm/headless module` → `lib/xterm.mjs`; the tarball has no `lib/` directory).

This is also why #5442 (which fixed the same bug, reported in #5441) regressed: it corrected the committed `headless/package.json`, but the publish script clobbers that file on every release. Patching the script's overrides — `module` and `exports`, matching the committed manifest — fixes it at the source.

Verified by running `node bin/package_headless.js` and diffing the regenerated `headless/package.json` against the committed one: `main`/`module`/`types`/`exports` now all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)