### PR TITLE
Don't set _keyDownSeen for pure modifier keydowns

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -844,7 +844,14 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
    */
   protected _keyDown(event: KeyboardEvent): boolean | undefined {
     this._keyDownHandled = false;
-    this._keyDownSeen = true;
+    // A pure modifier keydown (Shift, Ctrl, Alt, Meta) never produces text and its keyup may not
+    // arrive before the next character, so recording it here would leave _keyDownSeen stuck true
+    // and cause _inputEvent() to drop an IME-committed character (e.g. holding Shift while typing
+    // full-width punctuation in a WKWebView). Modifiers are irrelevant to that heuristic, so skip
+    // them. See https://github.com/xtermjs/xterm.js/issues/5887
+    if (!wasModifierKeyOnlyEvent(event)) {
+      this._keyDownSeen = true;
+    }
 
     if (this._customKeyEventHandler && this._customKeyEventHandler(event) === false) {
       return false;


### PR DESCRIPTION
## Summary

Fixes a variant of #5887: `_inputEvent()` only delivers an IME-committed character when `!this._keyDownSeen` (for `composed` input). `_keyDown()` sets `_keyDownSeen = true` on *every* keydown and `_keyUp()` clears it — but if a modifier is being held, its keyup doesn't arrive before the next character's keydown/input pair, so the flag stays poisoned and the character is silently dropped.

## Reproduction

macOS WKWebView (a Tauri app embedding xterm.js 6.0.0), Traditional Chinese (Zhuyin) IME, holding <kbd>Shift</kbd> and pressing <kbd>[</kbd> repeatedly to type full-width `「「「`.

**Symptom:** the first character is dropped; every subsequent one arrives (`「「` typed → only `「` reaches the PTY).

**Event trace** on `.xterm-helper-textarea` — note `input` fires *before* the matching `keydown 229` on WKWebView, and there are no composition events at all:

```
keydown key=Shift keyCode=16                     ← sets _keyDownSeen = true
input   data="「" isComposing=false value="「"    ← dropped: ev.composed && _keyDownSeen
keydown key={ keyCode=229 value="「"              ← CompositionHelper diff is empty (input already applied)
keyup   key={ keyCode=219                        ← resets _keyDownSeen
input   data="「" value="「「"                     ← now !_keyDownSeen → delivered via _inputEvent fallback
keydown key={ keyCode=229
```

Because `input` precedes `keydown 229` here, `CompositionHelper._handleAnyTextareaChanges()` never has a useful diff to send — the `_inputEvent` fallback gated on `_keyDownSeen` is the only delivery path for these characters on this platform, which is why the held modifier's side effect on that flag matters.

This is the same root cause as the rapid-typing case in #5887 (there, the *previous character's own* keydown poisons the flag before its keyup fires; here it's a held modifier) — different trigger, same broken assumption that a keydown's keyup always arrives before the next relevant character.

## Fix

Skip setting `_keyDownSeen` for pure modifier keydowns, reusing the existing `wasModifierKeyOnlyEvent()` helper already in this file. Modifiers never produce text themselves, so they're irrelevant to this "was there an intervening real keydown" heuristic and shouldn't arm it.

## Testing

Verified against the real-world repro above (patched into a Tauri/WKWebView app's `@xterm/xterm` dist via `pnpm patch`, confirmed the dropped-first-character symptom is gone with no regressions in normal typing/IME use). I wasn't able to run this repo's own unit/lint/integration suite in my current sandbox (no network access for `npm ci`'s postinstall scripts), so I'm relying on CI here — happy to address any lint/type findings it turns up.

Refs #5887