### PR TITLE
Fix stale rendering after a shared texture atlas is cleared

### DIFF
--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -145,6 +145,11 @@ export class TextureAtlas implements ITextureAtlas {
     this._cacheMap.clear();
     this._cacheMapCombined.clear();
     this._didWarmUp = false;
+
+    // Invalidate renderer models so all texture pages are refreshed. The atlas may be shared, in
+    // which case the clearing renderer has cleared only its own model and every other owner still
+    // holds texture coords into the rows just wiped.
+    this._pageLayoutVersion++;
   }
 
   private _createNewPage(): AtlasPage {

--- a/addons/addon-webgl/test/WebglSharedAtlasGarble.test.ts
+++ b/addons/addon-webgl/test/WebglSharedAtlasGarble.test.ts
@@ -240,4 +240,43 @@ test.describe('shared-atlas garble across terminals (#6038)', () => {
       await ctx.page.close();
     }
   });
+
+  test('keeps a second terminal rendering correctly after terminal A clears the shared atlas', async ({ browser }) => {
+    const ctx = await createTestContext(browser);
+    try {
+      await openTerminal(ctx, { cols: 80, rows: 24 });
+      await loadWebglStrict(ctx);
+      await createTerminalB(ctx);
+
+      const atlasShared = await ctx.page.evaluate(() => {
+        return window.term._core?._renderService?._renderer?.value?._charAtlas === window.termB?._core?._renderService?._renderer?.value?._charAtlas;
+      });
+      expect(atlasShared, 'terminals with equal configs should share one texture atlas').toBe(true);
+
+      await writeToBAndWaitForRender(ctx, HEADER);
+      const reference = await captureRowSignatures(ctx, 1, HEADER_COLS);
+
+      // Terminal A alone clears the shared atlas, as embedders do to force a redraw (VS Code calls
+      // this for every terminal on OS resume). This wipes the pages that terminal B's model still
+      // holds texture coords into.
+      await ctx.proxy.clearTextureAtlas();
+
+      // Terminal A repopulates the cleared pages with a different glyph set, so B's stale coords now
+      // resolve to whatever A rasterized into those slots.
+      await writeAndWaitForRender(ctx, '\x1b[2;1H' + generateColoredAsciiFlood(23 * 78));
+
+      // Nudge B into a render that does not touch row 1, mirroring a terminal that is idle but
+      // visible. Row 1 must still be drawn from a model B rebuilt against the current atlas.
+      await writeToBAndWaitForRender(ctx, '\x1b[24;1Hx');
+      const termBHeader = await ctx.page.evaluate(() => window.termB?.buffer.active.getLine(0)?.translateToString(true));
+      expect(termBHeader, 'terminal B buffer must still contain the header').toBe(HEADER);
+
+      const after = await captureRowSignatures(ctx, 1, HEADER_COLS);
+      for (let i = 0; i < HEADER_COLS.length; i++) {
+        expectSignatureMatches(after[i], reference[i], `terminal B header col ${HEADER_COLS[i]} garbled by terminal A's atlas clear`);
+      }
+    } finally {
+      await ctx.page.close();
+    }
+  });
 });


### PR DESCRIPTION
Fixes #6014. Supersedes #6018.

## Problem

`TextureAtlas.clearTexture()` wipes every page and both cache maps but never bumps `_pageLayoutVersion`, so it silently breaks the invalidation contract #6042 introduced for shared atlases.

The atlas is shared by every terminal with an equal config (`CharAtlasCache`), but `WebglRenderer.clearTextureAtlas()` only clears the *calling* renderer's model:

```ts
public clearTextureAtlas(): void {
  this._charAtlas?.clearTexture();
  this._clearModel(true);   // caller only
  this._requestRedrawViewport();
}
```

Every other owner keeps vertex data pointing into the rows that were just wiped, and `GlyphRenderer.beginFrame()` has no way to notice. Once the clearing terminal rasterizes new glyphs into the freed rows, the siblings render whatever landed there instead of their own text.

Page merges (`_createNewPage`) and evictions already bump `_pageLayoutVersion`; `clearTexture()` was the one mutation that missed it.

## Impact

Embedders hit this whenever they force a redraw on one terminal while others are alive. VS Code calls `Terminal.clearTextureAtlas()` on OS resume (`terminalNativeContribution.ts`) and on other redraw paths, which matches the downstream reports of a terminal that stays garbled even after opening a **new** terminal — the new one re-acquires the same cached atlas via `configEquals` — and only recovers once the whole panel is closed and the last owner drops the atlas.

## Fix

Bump `_pageLayoutVersion` on clear so sibling renderers rebuild their models on their next frame, matching what merges and evictions already do. The early return when the atlas is already empty is left intact — no mutation, no version bump.

## Test

Extends `WebglSharedAtlasGarble.test.ts` (the #6042 harness) with a second-terminal clear case. On master it fails — terminal B's header row renders terminal A's colored flood glyphs, max channel diff ~128 against a limit of 14 — and passes with the fix.

Verified locally on Chromium: full `addon-webgl` integration suite (60 passed, 9 skipped) and unit tests (2403 passing) stay green, lint clean.

## Note on #6018

#6018 sets `this._requestClearModel = true`. That field was removed when #6042 landed on 2026-07-13 and replaced by `pageLayoutVersion`, so that patch no longer builds against master.