### PR TITLE
Set autocomplete="off" on the helper textarea

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -492,6 +492,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       // https://issuetracker.google.com/issues/260170397
       this.textarea.setAttribute('aria-multiline', 'false');
     }
+    this.textarea.setAttribute('autocomplete', 'off');
     this.textarea.setAttribute('autocorrect', 'off');
     this.textarea.setAttribute('autocapitalize', 'off');
     this.textarea.setAttribute('spellcheck', 'false');


### PR DESCRIPTION
On iOS/iPadOS Safari, focusing a terminal brings up the keyboard AutoFill accessory offering passwords / credit cards / contact info, because the hidden helper textarea carries no `autocomplete` hint and Safari treats it as an autofillable form field.

The textarea already sets the sibling hints — `autocorrect`, `autocapitalize`, `spellcheck` — so this adds the missing `autocomplete="off"`. Verified on iPadOS Safari: the AutoFill suggestions no longer appear when the terminal gains focus. (Chrome for iOS draws its own autofill bar and ignores the hint by policy, so this helps Safari/WebKit-hinted browsers only.)

No behavior change on desktop browsers.