### PR TITLE
Fix NaN coordinates in mouse wheel reports from touch fling inertia

### DIFF
--- a/src/browser/scrollable/touch.ts
+++ b/src/browser/scrollable/touch.ts
@@ -434,6 +434,15 @@ export class Gesture extends Disposable {
       const evt = this._newGestureEvent(EventType.CHANGE);
       evt.translationX = deltaPosX;
       evt.translationY = deltaPosY;
+      // Carry the extrapolated position on inertia frames. Real touchmove
+      // CHANGE events (_handleTouchMove) always stamp coordinates and
+      // consumers like the mouse-report wheel path read event.clientX/clientY.
+      // Without these, momentum frames yield NaN coordinates (undefined
+      // arithmetic), which ends up serialized into mouse reports.
+      evt.pageX = x + deltaPosX;
+      evt.pageY = y + deltaPosY;
+      evt.clientX = x + deltaPosX - targetWindow.scrollX;
+      evt.clientY = y + deltaPosY - targetWindow.scrollY;
       dispatchTo.forEach(d => d.dispatchEvent(evt));
 
       if (!stopped) {

--- a/src/browser/services/MouseService.ts
+++ b/src/browser/services/MouseService.ts
@@ -344,6 +344,15 @@ export class MouseService implements IMouseService {
       return;
     }
 
+    // Wheel reports carry the cell the "wheel" happened over, so a gesture
+    // event without usable coordinates must not be reported: NaN passes
+    // through getMouseReportCoords' clamping untouched and ends up serialized
+    // into the report sequence (e.g. `CSI < 64 ; NaN ; NaN M`), which the
+    // application then reads as garbage input.
+    if (!isFinite(e.clientX) || !isFinite(e.clientY)) {
+      return;
+    }
+
     this._touchScrollAccumulator -= e.translationY;
     const lines = Math.trunc(this._touchScrollAccumulator / cellHeight);
     if (lines === 0) {


### PR DESCRIPTION
Found this problem when using [6.1.0-beta.291](https://www.npmjs.com/package/@xterm/xterm/v/6.1.0-beta.291) on iPhone running `claude code` inside. Scrolling (touch fling) was causing garbage chars like `NaN;NaNM` being inputed into the prompt. This fixes it.


The rest is generated by Claude Fable.


## Problem

Inertia (fling momentum) CHANGE events dispatched by `Gesture._inertia` (`src/browser/scrollable/touch.ts`) carried only `translationX/Y`, while real touchmove CHANGE events also carry page/client coordinates. The mouse-report wheel path (`MouseService._handleTouchScrollAsWheel`) reads `event.clientX/clientY` to compute the reported cell position, which produced NaN coordinates that passed through `getMouseReportCoords`' clamping untouched and were serialized into wheel reports (e.g. `CSI < 64 ; NaN ; NaN M`) — applications with mouse tracking enabled (vim with `mouse=a`, tmux, agent TUIs) received them as garbage input on every fling release.

## Fix

Two additive changes (+18 lines):

- **`src/browser/scrollable/touch.ts`** — fix at the source by stamping the position the inertia animation already tracks onto the momentum events (page coordinates; client derived via the window's scroll offsets), matching what `_handleTouchMove` stamps on real frames.
- **`src/browser/services/MouseService.ts`** — defensively skip wheel reports for coordinate-less gesture events (`!isFinite(e.clientX) || !isFinite(e.clientY)`) so malformed sequences can't reach the PTY from this path again.

## To reproduce

On a touch device (or DevTools touch emulation), run any app that enables mouse tracking (e.g. vim with `set mouse=a`) in the demo, flick-scroll and lift — the app receives `ESC[<64;NaN;NaNM` per momentum tick, visible as literal `NaN;NaNM` input. Discovered embedding xterm.js in a web dashboard terminal running an agent TUI with mouse reporting.

## Validation

- `npm run build` (tsgo) clean
- `npm run esbuild` clean
- `npm run test-unit` — 2403 passing, 0 failing

No new test added — the touch handlers are private/DOM-wired and the unit harness has no gesture mocks; happy to add coverage wherever you'd prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)