### PR TITLE
Fix dropped and duplicated IME composition commits

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -1008,7 +1008,9 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
 
     this._onKey.fire({ key, domEvent: ev });
     this._showCursor();
-    this.coreService.triggerDataEvent(key, true);
+    if (!this._compositionHelper!.keypress(key)) {
+      this.coreService.triggerDataEvent(key, true);
+    }
 
     this._keyPressHandled = true;
 
@@ -1029,7 +1031,14 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     // Only support emoji IMEs when screen reader mode is disabled as the event must bubble up to
     // support reading out character input which can doubling up input characters
     // Based on these event traces: https://github.com/xtermjs/xterm.js/issues/3679
-    if (ev.data && ev.inputType === 'insertText' && (!ev.composed || !this._keyDownSeen) && !this.optionsService.rawOptions.screenReaderMode) {
+    if (ev.data && ev.inputType === 'insertText' && !this.optionsService.rawOptions.screenReaderMode) {
+      if (this._compositionHelper!.input(ev.data)) {
+        this._unprocessedDeadKey = false;
+        return true;
+      }
+      if (ev.composed && this._keyDownSeen) {
+        return false;
+      }
       if (this._keyPressHandled) {
         return false;
       }

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -106,6 +106,38 @@ describe('Terminal', () => {
       } as KeyboardEvent;
       term.keyDown(evKeyDown);
     });
+    it('should offer keypress text to a pending composition before emitting data', () => {
+      let compositionText = '';
+      const compositionHelper = new MockCompositionHelper();
+      compositionHelper.keypress = text => {
+        compositionText = text;
+        return true;
+      };
+      (term as any)._compositionHelper = compositionHelper;
+      let emittedText = '';
+      term.onData(data => emittedText += data);
+
+      term.keyPress({ charCode: 97, type: 'keypress' } as KeyboardEvent);
+
+      assert.equal(compositionText, 'a');
+      assert.equal(emittedText, '');
+    });
+    it('should offer insertText data to a pending composition before emitting data', () => {
+      let compositionText = '';
+      const compositionHelper = new MockCompositionHelper();
+      compositionHelper.input = text => {
+        compositionText = text;
+        return true;
+      };
+      (term as any)._compositionHelper = compositionHelper;
+      let emittedText = '';
+      term.onData(data => emittedText += data);
+
+      assert.isTrue(term.inputEvent({ data: '한', inputType: 'insertText', composed: true } as InputEvent));
+
+      assert.equal(compositionText, '한');
+      assert.equal(emittedText, '');
+    });
     it('should fire the onResize event', (done) => {
       term.onResize(e => {
         assert.equal(typeof e.cols, 'number');

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -25,6 +25,7 @@ export class TestTerminal extends CoreBrowserTerminal {
   public get curAttrData(): IAttributeData { return (this as any)._inputHandler._curAttrData; }
   public keyDown(ev: any): boolean | undefined { return this._keyDown(ev); }
   public keyPress(ev: any): boolean { return this._keyPress(ev); }
+  public inputEvent(ev: InputEvent): boolean { return this._inputEvent(ev); }
   public writeP(data: string | Uint8Array): Promise<void> {
     return new Promise(r => this.write(data, r));
   }
@@ -359,6 +360,12 @@ export class MockCompositionHelper implements ICompositionHelper {
   }
   public keydown(ev: KeyboardEvent): boolean {
     return true;
+  }
+  public keypress(text: string): boolean {
+    return false;
+  }
+  public input(text: string): boolean {
+    return false;
   }
 }
 

--- a/src/browser/Types.ts
+++ b/src/browser/Types.ts
@@ -44,6 +44,8 @@ export interface ICompositionHelper {
   compositionend(): void;
   updateCompositionElements(dontRecurse?: boolean): void;
   keydown(ev: KeyboardEvent): boolean;
+  keypress(text: string): boolean;
+  input(text: string): boolean;
 }
 
 export interface IBrowser {

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -14,6 +14,21 @@ describe('CompositionHelper', () => {
   let textarea: HTMLTextAreaElement;
   let handledText: string;
 
+  function nextEventLoop(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  async function beginComposition(data: string, value: string = textarea.value + data): Promise<void> {
+    textarea.selectionStart = textarea.value.length;
+    textarea.selectionEnd = textarea.value.length;
+    compositionHelper.compositionstart();
+    compositionHelper.compositionupdate({ data });
+    textarea.value = value;
+    textarea.selectionStart = value.length;
+    textarea.selectionEnd = value.length;
+    await nextEventLoop();
+  }
+
   beforeEach(() => {
     compositionView = {
       classList: {
@@ -258,6 +273,160 @@ describe('CompositionHelper', () => {
           done();
         }, 0);
       }, 0);
+    });
+
+    it('should send a propagated composition commit exactly once', async () => {
+      await beginComposition('한');
+
+      compositionHelper.compositionend();
+      assert.isTrue(compositionHelper.input('한'));
+      await nextEventLoop();
+
+      assert.equal(handledText, '한');
+    });
+
+    it('should send an unpropagated composition commit exactly once', async () => {
+      await beginComposition('한');
+
+      compositionHelper.compositionend();
+      await nextEventLoop();
+
+      assert.equal(handledText, '한');
+    });
+
+    it('should send a pending commit before a following key', async () => {
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+      textarea.value = '';
+
+      assert.isTrue(compositionHelper.keydown({ keyCode: 65 } as KeyboardEvent));
+      assert.equal(handledText, '한');
+      await nextEventLoop();
+      assert.equal(handledText, '한');
+    });
+
+    it('should preserve Hangul, ASCII, Hangul input order', async () => {
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+      compositionHelper.keypress('a');
+      compositionHelper.input('a');
+      textarea.value = '한a';
+
+      await beginComposition('글');
+      compositionHelper.compositionend();
+      compositionHelper.input('글');
+      await nextEventLoop();
+
+      assert.equal(handledText, '한a글');
+    });
+
+    it('should preserve following input when the composition has no insertText event', async () => {
+      await beginComposition('日');
+      compositionHelper.compositionend();
+      compositionHelper.keypress('a');
+      compositionHelper.input('a');
+      textarea.value = '日a';
+      await nextEventLoop();
+
+      assert.equal(handledText, '日a');
+    });
+
+    it('should preserve fast consecutive Hangul syllables', async () => {
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+
+      await beginComposition('글');
+      compositionHelper.compositionend();
+      compositionHelper.input('글');
+      await nextEventLoop();
+
+      assert.equal(handledText, '한글');
+    });
+
+    it('should leave a transferred final consonant for the next Hangul composition', async () => {
+      await beginComposition('텟');
+      compositionHelper.compositionend();
+      compositionHelper.input('테');
+      compositionHelper.keypress('t');
+      textarea.value = '테';
+
+      await beginComposition('스');
+      compositionHelper.compositionend();
+      compositionHelper.input('스');
+      await nextEventLoop();
+
+      assert.equal(handledText, '테스');
+    });
+
+    it('should send a composition once when Enter finalizes it before compositionend', async () => {
+      await beginComposition('한');
+
+      assert.isTrue(compositionHelper.keydown({ keyCode: 13 } as KeyboardEvent));
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+      await nextEventLoop();
+
+      assert.equal(handledText, '한');
+    });
+
+    it('should send a cleared pending commit before Enter', async () => {
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+      textarea.value = '';
+
+      assert.isTrue(compositionHelper.keydown({ keyCode: 13 } as KeyboardEvent));
+      await nextEventLoop();
+
+      assert.equal(handledText, '한');
+    });
+
+    it('should not repeat a keydown-finalized Japanese commit', async () => {
+      await beginComposition('日本');
+
+      assert.isTrue(compositionHelper.keydown({ keyCode: 65 } as KeyboardEvent));
+      compositionHelper.compositionend();
+      compositionHelper.input('日本');
+      await nextEventLoop();
+
+      assert.equal(handledText, '日本');
+    });
+
+    it('should reconcile duplicate keypress and input observations', async () => {
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.keypress('한');
+      compositionHelper.input('한');
+      await nextEventLoop();
+
+      assert.equal(handledText, '한');
+    });
+
+    it('should preserve repeated identical commits from separate compositions', async () => {
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+      await nextEventLoop();
+
+      await beginComposition('한');
+      compositionHelper.compositionend();
+      compositionHelper.input('한');
+      await nextEventLoop();
+
+      assert.equal(handledText, '한한');
+    });
+
+    it('should reconcile generic multi-character IME commits', async () => {
+      await beginComposition('日本');
+      compositionHelper.compositionend();
+      compositionHelper.keypress('日本');
+      compositionHelper.input('日本');
+      await nextEventLoop();
+
+      assert.equal(handledText, '日本');
     });
   });
 });

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -12,6 +12,15 @@ interface IPosition {
   end: number;
 }
 
+interface IPendingComposition {
+  position: IPosition;
+  suffix: string;
+  dataAlreadySent: string;
+  inputData: string;
+  keypressData: string;
+  nextCompositionStart?: number;
+}
+
 /**
  * Encapsulates the logic for handling compositionstart, compositionupdate and compositionend
  * events, displaying the in-progress composition to the UI and forwarding the final composition
@@ -36,11 +45,9 @@ export class CompositionHelper {
    */
   private _compositionSuffix: string;
 
-  /**
-   * Whether a composition is in the process of being sent, setting this to false will cancel any
-   * in-progress composition.
-   */
-  private _isSendingComposition: boolean;
+  private _pendingComposition: IPendingComposition | undefined;
+
+  private _isAwaitingCompositionEnd: boolean;
 
   /**
    * Data already sent due to keydown event.
@@ -61,7 +68,7 @@ export class CompositionHelper {
     @IRenderService private readonly _renderService: IRenderService
   ) {
     this._isComposing = false;
-    this._isSendingComposition = false;
+    this._isAwaitingCompositionEnd = false;
     this._compositionPosition = { start: 0, end: 0 };
     this._compositionSuffix = '';
     this._dataAlreadySent = '';
@@ -71,13 +78,20 @@ export class CompositionHelper {
    * Handles the compositionstart event, activating the composition view.
    */
   public compositionstart(): void {
-    this._isComposing = true;
     // It's important to use the selection here instead of textarea length to avoid conflicts with
     // screen reader mode
     const start = this._textarea.selectionStart ?? this._textarea.value.length;
     const end = this._textarea.selectionEnd ?? start;
-    this._compositionPosition.start = Math.min(start, end);
-    this._compositionPosition.end = Math.max(start, end);
+    const compositionStart = Math.min(start, end);
+    if (this._pendingComposition) {
+      this._pendingComposition.nextCompositionStart = compositionStart;
+    }
+    this._isComposing = true;
+    this._isAwaitingCompositionEnd = true;
+    this._compositionPosition = {
+      start: compositionStart,
+      end: Math.max(start, end)
+    };
     this._compositionSuffix = this._textarea.value.substring(this._compositionPosition.end);
     this._compositionView.textContent = '';
     this._dataAlreadySent = '';
@@ -93,9 +107,10 @@ export class CompositionHelper {
     // compositions
     this._compositionView.textContent = `\u200E${ev.data}\u200E`;
     this.updateCompositionElements();
+    const compositionPosition = this._compositionPosition;
     setTimeout(() => {
       const end = this._textarea.selectionEnd ?? this._textarea.value.length;
-      this._compositionPosition.end = Math.max( this._compositionPosition.start, end);
+      compositionPosition.end = Math.max(compositionPosition.start, end);
     }, 0);
   }
 
@@ -104,6 +119,10 @@ export class CompositionHelper {
    * the handler.
    */
   public compositionend(): void {
+    if (!this._isAwaitingCompositionEnd) {
+      return;
+    }
+    this._isAwaitingCompositionEnd = false;
     this._finalizeComposition(true);
   }
 
@@ -113,7 +132,7 @@ export class CompositionHelper {
    * @returns Whether the Terminal should continue processing the keydown event.
    */
   public keydown(ev: KeyboardEvent): boolean {
-    if (this._isComposing || this._isSendingComposition) {
+    if (this._isComposing || this._pendingComposition) {
       if (ev.keyCode === 20 || ev.keyCode === 229) {
         // 20 is CapsLock, 229 is Enter
         // Continue composing if the keyCode is the "composition character"
@@ -139,6 +158,28 @@ export class CompositionHelper {
   }
 
   /**
+   * Defers keypress text until the preceding composition commit is resolved.
+   */
+  public keypress(text: string): boolean {
+    if (!this._pendingComposition) {
+      return false;
+    }
+    this._pendingComposition.keypressData += text;
+    return true;
+  }
+
+  /**
+   * Defers insertText data until the preceding composition commit is resolved.
+   */
+  public input(text: string): boolean {
+    if (!this._pendingComposition) {
+      return false;
+    }
+    this._pendingComposition.inputData += text;
+    return true;
+  }
+
+  /**
    * Finalizes the composition, resuming regular input actions. This is called when a composition
    * is ending.
    * @param waitForPropagation Whether to wait for events to propagate before sending
@@ -147,22 +188,34 @@ export class CompositionHelper {
    *   the command is executed.
    */
   private _finalizeComposition(waitForPropagation: boolean): void {
+    const wasComposing = this._isComposing;
     this._compositionView.classList.remove('active');
     this._isComposing = false;
 
     if (!waitForPropagation) {
-      // Cancel any delayed composition send requests and send the input immediately.
-      this._isSendingComposition = false;
+      if (this._pendingComposition) {
+        this._sendPendingComposition(this._pendingComposition);
+        if (!wasComposing) {
+          return;
+        }
+      }
       const input = this._textarea.value.substring(this._compositionPosition.start, this._compositionPosition.end);
-      this._coreService.triggerDataEvent(input, true);
+      this._dataAlreadySent = input;
+      this._sendCompositionInput(input, '');
     } else {
-      // Make a deep copy of the composition position here as a new compositionstart event may
-      // fire before the setTimeout executes.
-      const currentCompositionPosition = {
-        start: this._compositionPosition.start,
-        end: this._compositionPosition.end
+      if (this._pendingComposition) {
+        this._sendPendingComposition(this._pendingComposition);
+      }
+      const pendingComposition: IPendingComposition = {
+        position: {
+          start: this._compositionPosition.start,
+          end: this._compositionPosition.end
+        },
+        suffix: this._compositionSuffix,
+        dataAlreadySent: this._dataAlreadySent,
+        inputData: '',
+        keypressData: ''
       };
-      const currentCompositionSuffix = this._compositionSuffix;
 
       // Since composition* events happen before the changes take place in the textarea on most
       // browsers, use a setTimeout with 0ms time to allow the native compositionend event to
@@ -172,35 +225,69 @@ export class CompositionHelper {
       // - The last compositionupdate event's data property does not always accurately describe
       //   the character, a counter example being Korean where an ending consonsant can move to
       //   the following character if the following input is a vowel.
-      this._isSendingComposition = true;
+      this._pendingComposition = pendingComposition;
       setTimeout(() => {
-        // Ensure that the input has not already been sent
-        if (this._isSendingComposition) {
-          this._isSendingComposition = false;
-          let input;
-          // Add length of data already sent due to keydown event,
-          // otherwise input characters can be duplicated. (Issue #3191)
-          currentCompositionPosition.start += this._dataAlreadySent.length;
-          if (this._isComposing) {
-            // Use the start position of the new composition to get the string
-            // if a new composition has started.
-            input = this._textarea.value.substring(currentCompositionPosition.start, this._compositionPosition.start);
-          } else {
-            // Keep support for non-composition characters typed immediately after composition end
-            // while avoiding re-sending the trailing text that was already present
-            // before composition started.
-            const value = this._textarea.value;
-            const valueEnd = currentCompositionSuffix.length > 0 && value.endsWith(currentCompositionSuffix)
-              ? value.length - currentCompositionSuffix.length
-              : value.length;
-            input = value.substring(currentCompositionPosition.start, Math.max(currentCompositionPosition.start, valueEnd));
-          }
-          if (input.length > 0) {
-            this._coreService.triggerDataEvent(input, true);
-          }
+        if (this._pendingComposition === pendingComposition) {
+          this._sendPendingComposition(pendingComposition);
         }
       }, 0);
     }
+  }
+
+  private _sendPendingComposition(pendingComposition: IPendingComposition): void {
+    if (this._pendingComposition === pendingComposition) {
+      this._pendingComposition = undefined;
+    }
+    const textareaInput = this._getTextareaInput(pendingComposition);
+    let input = textareaInput;
+    if (pendingComposition.inputData.length > 0) {
+      const inputData = this._removeAlreadySentData(pendingComposition.inputData, pendingComposition.dataAlreadySent);
+      // A matching keypress identifies insertText as following input, not a replacement commit.
+      input = inputData === pendingComposition.keypressData
+        ? this._mergeObservedData(textareaInput, inputData)
+        : inputData;
+    }
+    this._sendCompositionInput(input, pendingComposition.keypressData, pendingComposition.nextCompositionStart !== undefined);
+  }
+
+  private _getTextareaInput(pendingComposition: IPendingComposition): string {
+    const value = this._textarea.value;
+    const start = pendingComposition.position.start + pendingComposition.dataAlreadySent.length;
+    if (pendingComposition.nextCompositionStart !== undefined) {
+      return value.substring(start, Math.max(start, pendingComposition.nextCompositionStart));
+    }
+    const valueEnd = pendingComposition.suffix.length > 0 && value.endsWith(pendingComposition.suffix)
+      ? value.length - pendingComposition.suffix.length
+      : value.length;
+    return value.substring(start, Math.max(start, valueEnd));
+  }
+
+  private _removeAlreadySentData(input: string, dataAlreadySent: string): string {
+    if (dataAlreadySent.length === 0) {
+      return input;
+    }
+    if (input.startsWith(dataAlreadySent)) {
+      return input.substring(dataAlreadySent.length);
+    }
+    return dataAlreadySent.includes(input) ? '' : input;
+  }
+
+  private _sendCompositionInput(input: string, keypressData: string, hasNextComposition: boolean = false): void {
+    // A new preedit consumes unmatched keypress data during Hangul final-consonant transfer.
+    if (keypressData.length > 0 && !input.includes(keypressData) && !hasNextComposition) {
+      input = this._mergeObservedData(input, keypressData);
+    }
+    if (input.length > 0) {
+      this._coreService.triggerDataEvent(input, true);
+    }
+  }
+
+  private _mergeObservedData(first: string, second: string): string {
+    let overlap = Math.min(first.length, second.length);
+    while (overlap > 0 && !first.endsWith(second.substring(0, overlap))) {
+      overlap--;
+    }
+    return first + second.substring(overlap);
   }
 
   /**


### PR DESCRIPTION
## Summary

- reconcile the deferred textarea value, `insertText`, and legacy `keypress` observations for a pending IME commit
- flush a pending commit before the next key while retaining its copied textarea range and commit data
- keep an unmatched keypress out of the previous commit when a new preedit consumes it, as happens during Hangul final-consonant transfer

## Root cause

`compositionend` currently defers reading the helper textarea until the browser propagates the committed value. During that window, IBus/Chromium can also expose the logical commit through `beforeinput`/`input` and `keypress`, and a following key or Enter can force finalization after the textarea has already been cleared. The existing boolean pending state can therefore be cancelled before the correct value is read, or the same commit can be emitted once from the input route and again from the deferred finalizer.

Fast two-set Hangul adds one boundary case: a composition can end, the Latin key for a transferred final consonant can arrive, and the next preedit can begin without a separate `insertText` commit for that key. The pending state now records that next-composition boundary so the key remains owned by the new preedit.

The reconciliation is limited to the existing pending-composition window. It adds no platform-wide suppression and no new timing delay.

## Tests

- clean `npm ci` and `npm run setup`
- `npm run test-unit -- --forbid-only` (2422 passing)
- focused terminal/composition unit suite (175 passing)
- `NODE_OPTIONS=--max-old-space-size=8192 npm run lint`
- `npm run lint-api`

Regression coverage includes propagated and unpropagated exactly-once commits, a cleared commit before a following key or Enter, Hangul/ASCII/Hangul ordering, consecutive Hangul syllables, final-consonant transfer (`텟` to `테` plus `스`), duplicate input routes, repeated identical legitimate commits, and generic multi-character IME commits.

The Linux X11 IBus investigation that located the corruption at xterm.js `onData` is documented in https://github.com/stablyai/orca/issues/9862. Native Japanese and Chinese IME validation was not performed.
