### PR TITLE
Report cursor position relative to scroll margin under origin mode

### DIFF
--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -1259,6 +1259,29 @@ describe('InputHandler', () => {
       await inputHandler.parseP('\x1b[2;1H');
       assert.deepEqual(getCursor(bufferService), [0, 1]);
     });
+    it('cursor position report (CPR) is relative to scroll margin under DECOM', async () => {
+      const cpr: number[][] = [];
+      coreService.onData(data => {
+        const m = data.match(/\x1b\[\??(\d+);(\d+)R/);
+        if (m) { cpr.push([parseInt(m[1]), parseInt(m[2])]); }
+      });
+      // origin mode on, scroll region rows 3..8 (1-based) -> scrollTop = 2
+      await inputHandler.parseP('\x1b[?6h\x1b[3;8r');
+      // CUP to origin-relative row 2, col 5 -> absolute buffer cursor [x=4, y=3]
+      await inputHandler.parseP('\x1b[2;5H');
+      assert.deepEqual(getCursor(bufferService), [4, 3]);
+      // CPR (DSR 6) and DECXCPR (private DSR ?6) both report the
+      // origin-relative row 2, not the absolute row 4
+      await inputHandler.parseP('\x1b[6n');
+      await inputHandler.parseP('\x1b[?6n');
+      assert.deepEqual(cpr, [[2, 5], [2, 5]]);
+      // with origin mode off, CPR reports the absolute row
+      await inputHandler.parseP('\x1b[?6l\x1b[4;5H');
+      assert.deepEqual(getCursor(bufferService), [4, 3]);
+      cpr.length = 0;
+      await inputHandler.parseP('\x1b[6n');
+      assert.deepEqual(cpr, [[4, 5]]);
+    });
     it('horizontal position absolute (HPA)', async () => {
       await inputHandler.parseP('\x1b[`');
       assert.deepEqual(getCursor(bufferService), [0, 0]);

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -2743,7 +2743,9 @@ export class InputHandler extends Disposable implements IInputHandler {
         break;
       case 6:
         // cursor position
-        const y = this._activeBuffer.y + 1;
+        // In origin mode (DECOM) the report is relative to the top scroll
+        // margin, mirroring how CUP positions the cursor.
+        const y = this._activeBuffer.y + 1 - (this._coreService.decPrivateModes.origin ? this._activeBuffer.scrollTop : 0);
         const x = this._activeBuffer.x + 1;
         this._coreService.triggerDataEvent(`${C0.ESC}[${y};${x}R`);
         break;
@@ -2758,7 +2760,9 @@ export class InputHandler extends Disposable implements IInputHandler {
     switch (params.params[0]) {
       case 6:
         // cursor position
-        const y = this._activeBuffer.y + 1;
+        // In origin mode (DECOM) the report is relative to the top scroll
+        // margin, mirroring how CUP positions the cursor.
+        const y = this._activeBuffer.y + 1 - (this._coreService.decPrivateModes.origin ? this._activeBuffer.scrollTop : 0);
         const x = this._activeBuffer.x + 1;
         this._coreService.triggerDataEvent(`${C0.ESC}[?${y};${x}R`);
         break;


### PR DESCRIPTION
### Problem

The Cursor Position Report handlers — CPR (`CSI 6 n`) and DECXCPR
(`CSI ? 6 n`) in `deviceStatus`/`deviceStatusPrivate` — always report the
**absolute** row:

```ts
const y = this._activeBuffer.y + 1;
```

But cursor *addressing* (CUP) already honors DEC origin mode (DECOM):
`_setCursor` adds `scrollTop` when origin mode is set. The report never applied
the reverse conversion, so the read path did not mirror the write path.

A full-screen app that sets a scroll region and origin mode (`CSI ? 6 h`) and
relies on the CPR round-trip — read the position, later restore it with CUP —
gets the cursor placed `scrollTop` rows too low:

```
CSI 3;8 r      set scroll region rows 3..8   (scrollTop = 2)
CSI ? 6 h      origin mode on
CSI 2;5 H      CUP to region row 2            (cursor lands at absolute row 4)
CSI 6 n        request CPR
  → reports ESC[4;5R   (absolute)   — should be ESC[2;5R (region-relative)
```

An app that then restores with `CSI 4;5 H` (still in origin mode) lands the
cursor at absolute row 5 instead of the original row 4.

### Fix

Subtract `scrollTop` when origin mode is active, in both handlers, so the report
is relative to the top margin — matching how CUP positions the cursor, and
matching xterm's own `report_cursor_position`
(`cur_row + 1 - (flags & ORIGIN ? top_marg : 0)`). With origin mode off the
report is unchanged (absolute). The column needs no adjustment, as xterm.js does
not implement horizontal margins.

### Test

Added a `cursor positioning` case asserting that under DECOM + scroll margins
both CPR and DECXCPR report the origin-relative row, and that with origin mode
off the report is absolute. Fails on `master`; all 193 `InputHandler` unit tests
pass with the fix.

### Spec

DEC STD 070 / VT510 DECOM: origin mode makes cursor addressing *and* cursor
position reports relative to the top margin of the scroll region.
