### PR TITLE
fix: return cached dimensions after renderer dispose

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -6,6 +6,7 @@
 import { RenderDebouncer } from '../RenderDebouncer';
 import { IRenderDebouncerWithCallback } from '../Types';
 import { IRenderDimensions, IRenderer } from '../renderer/shared/Types';
+import { createRenderDimensions } from '../renderer/shared/RendererUtils';
 import { ICharSizeService, ICoreBrowserService, IRenderService, IThemeService } from './Services';
 import { Disposable, MutableDisposable, toDisposable } from '../../common/Lifecycle';
 import { DebouncedIdleTask } from '../../common/TaskQueue';
@@ -53,7 +54,15 @@ export class RenderService extends Disposable implements IRenderService {
   private readonly _onRefreshRequest = this._register(new Emitter<{ start: number, end: number }>());
   public readonly onRefreshRequest = this._onRefreshRequest.event;
 
-  public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }
+  private _cachedDimensions: IRenderDimensions = createRenderDimensions();
+
+  public get dimensions(): IRenderDimensions {
+    const renderer = this._renderer.value;
+    if (renderer) {
+      this._cachedDimensions = renderer.dimensions;
+    }
+    return this._cachedDimensions;
+  }
 
   constructor(
     private _rowCount: number,


### PR DESCRIPTION
Both #5586 (mouse event path) and #5826 (decoration refresh path) crash on the same line:

```ts
public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }
```

After `dispose()`, the `MutableDisposable` clears its value, so `_renderer.value` is `undefined` and the non-null assertion throws `TypeError: Cannot read properties of undefined (reading 'dimensions')`.

#5591 and #5827 fixed the two known crash paths with per-callsite guards (`isDisposed` / `hasRenderer()` checks). That works, but there are 20+ remaining unguarded `.dimensions` accesses across:

- `CoreBrowserTerminal.ts` — cursor positioning, overview ruler sizing (10+)
- `AccessibilityManager.ts` — live region sizing (4)
- `BufferDecorationRenderer.ts` — decoration element sizing (6+)
- `MouseCoordsService.ts` — mouse coordinate math (4)

Any async callback (rAF, setTimeout, intersection observer) that races `dispose()` on one of those paths will hit the same crash. Adding a guard at every callsite is whack-a-mole.

This PR fixes the getter itself — cache the last known `IRenderDimensions` on every read and return it after dispose. Stale values are harmless since the terminal is mid-teardown.

```diff
- public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }
+ private _cachedDimensions: IRenderDimensions = createRenderDimensions();
+ public get dimensions(): IRenderDimensions {
+   const renderer = this._renderer.value;
+   if (renderer) {
+     this._cachedDimensions = renderer.dimensions;
+   }
+   return this._cachedDimensions;
+ }
```

The per-callsite guards from #5591/#5827 can stay (they prevent unnecessary work on a disposed terminal) but are no longer load-bearing for crash safety.

Builds clean with `tsgo -b ./tsconfig.all.json`.
