### PR TITLE
Recover Ctrl+<letter> and Escape under a CJK IME (keyCode 229)

### DIFF
--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -260,4 +260,16 @@ describe('CompositionHelper', () => {
       }, 0);
     });
   });
+
+  describe('keydown under a CJK IME (keyCode 229)', () => {
+    // A CJK IME delivers control inputs with keyCode 229 and no composition.
+    // keydown() must let those continue to the normal key handler (return true)
+    // rather than swallowing them. https://github.com/xtermjs/xterm.js/issues/153
+    it('should pass ctrl chords through (return true)', () => {
+      assert.equal(compositionHelper.keydown({ keyCode: 229, code: 'KeyJ', ctrlKey: true } as any), true);
+    });
+    it('should pass a bare escape through (return true)', () => {
+      assert.equal(compositionHelper.keydown({ keyCode: 229, code: 'Escape' } as any), true);
+    });
+  });
 });

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -13,6 +13,16 @@ interface IPosition {
 }
 
 /**
+ * Whether a keyCode-229 keydown is a control input a CJK IME has masked (and
+ * that produces no composition), rather than composable text. These must reach
+ * the normal key handler instead of being swallowed as textarea changes. Kept
+ * in sync with `recoverImeControlKeyCode` in common/input/Keyboard.ts.
+ */
+function isImeControlPassthrough(ev: KeyboardEvent): boolean {
+  return ev.code === 'Escape' || (ev.ctrlKey && !ev.altKey && !ev.metaKey);
+}
+
+/**
  * Encapsulates the logic for handling compositionstart, compositionupdate and compositionend
  * events, displaying the in-progress composition to the UI and forwarding the final composition
  * to the handler.
@@ -129,6 +139,16 @@ export class CompositionHelper {
     }
 
     if (ev.keyCode === 229) {
+      // A CJK IME reports keyCode 229 ("Process") for every key it claims,
+      // including control inputs that never begin a composition and produce no
+      // input event: Ctrl+<letter>, Ctrl+Space and a bare Escape. Swallowing
+      // those (return false) loses them entirely, so let them continue to the
+      // normal key handler, which recovers the key from `code`. Everything else
+      // (numbers, punctuation typed with the IME active) still goes through the
+      // textarea diff below.
+      if (isImeControlPassthrough(ev)) {
+        return true;
+      }
       // If the "composition character" is used but gets to this point it means a non-composition
       // character (eg. numbers and punctuation) was pressed when the IME was active.
       this._handleAnyTextareaChanges();

--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -361,5 +361,31 @@ describe('Keyboard', () => {
       assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, shiftKey: true, keyCode: 189, code: 'Minus', key: '_' }).key, '\x1f');
     });
 
+    // Under a CJK IME (Korean/Japanese/Chinese on Windows) every claimed key is
+    // delivered with keyCode 229; recover control inputs from `code` so they are
+    // not silently dropped. https://github.com/xtermjs/xterm.js/issues/153
+    describe('CJK IME keyCode 229 recovery', () => {
+      it('should encode ctrl+j (LF) from code when keyCode is 229', () => {
+        assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, keyCode: 229, code: 'KeyJ', key: 'Process' }).key, '\n');
+      });
+      it('should encode ctrl+c (ETX) from code when keyCode is 229', () => {
+        assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, keyCode: 229, code: 'KeyC', key: 'Process' }).key, '\x03');
+      });
+      it('should encode ctrl+space (NUL) from code when keyCode is 229', () => {
+        assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, keyCode: 229, code: 'Space', key: 'Process' }).key, '\x00');
+      });
+      it('should encode escape from code when keyCode is 229', () => {
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 229, code: 'Escape', key: 'Process' }).key, '\x1b');
+      });
+      it('should not synthesize a key for a plain composable key at keyCode 229', () => {
+        // A composing letter with no control modifier must be left to the
+        // composition/input path, not encoded here.
+        assert.equal(testEvaluateKeyboardEvent({ keyCode: 229, code: 'KeyJ', key: 'Process' }).key, undefined);
+      });
+      it('should be unaffected when keyCode is the real value', () => {
+        assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, keyCode: 74, code: 'KeyJ', key: 'j' }).key, '\n');
+      });
+    });
+
   });
 });

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -35,6 +35,41 @@ const KEYCODE_KEY_MAPPINGS: { [key: number]: [string, string]} = {
   222: ['\'', '"']
 };
 
+/**
+ * Recover the legacy `keyCode` for a control input that a CJK IME has masked
+ * with keyCode 229 ("Process").
+ *
+ * On Windows/Chromium (Korean, Japanese, Chinese IMEs) every key the IME has
+ * claimed is delivered with `keyCode === 229`, even control inputs that never
+ * begin a composition — Ctrl+<letter>, Ctrl+Space and a bare Escape. Because
+ * the encoding below switches on the deprecated `keyCode`, those inputs match
+ * nothing and are silently dropped: no ESC reaches the PTY for Escape, no ^J
+ * for Ctrl+J, etc. The physical `code` is still correct, so use it to recover
+ * the keyCode for exactly these control inputs. Printable keys are left at 229
+ * so the composition/input path keeps handling them.
+ */
+function recoverImeControlKeyCode(ev: IKeyboardEvent): number {
+  // A bare Escape cancels the foreground app's UI; it has no printable meaning
+  // and never composes, so recover it regardless of modifiers.
+  if (ev.code === 'Escape') {
+    return 27;
+  }
+  // Ctrl+<key> is always a control chord under an IME, never a composition.
+  if (ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+    // 'KeyA'..'KeyZ' -> 65..90
+    if (ev.code.length === 4 && ev.code.startsWith('Key')) {
+      const c = ev.code.charCodeAt(3);
+      if (c >= 65 && c <= 90) {
+        return c;
+      }
+    }
+    if (ev.code === 'Space') {
+      return 32;
+    }
+  }
+  return ev.keyCode;
+}
+
 export function evaluateKeyboardEvent(
   ev: IKeyboardEvent,
   applicationCursorMode: boolean,
@@ -50,7 +85,10 @@ export function evaluateKeyboardEvent(
     key: undefined
   };
   const modifiers = (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0) | (ev.metaKey ? 8 : 0);
-  switch (ev.keyCode) {
+  // Under a CJK IME control inputs arrive with keyCode 229; recover the real
+  // keyCode from the physical `code` so the encoding below can match them.
+  const keyCode = ev.keyCode === 229 ? recoverImeControlKeyCode(ev) : ev.keyCode;
+  switch (keyCode) {
     case 0:
       if (ev.key === 'UIKeyInputUpArrow') {
         if (applicationCursorMode) {
@@ -312,9 +350,9 @@ export function evaluateKeyboardEvent(
     default:
       // a-z and space
       if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
-        if (ev.keyCode >= 65 && ev.keyCode <= 90) {
-          result.key = String.fromCharCode(ev.keyCode - 64);
-        } else if (ev.keyCode === 32) {
+        if (keyCode >= 65 && keyCode <= 90) {
+          result.key = String.fromCharCode(keyCode - 64);
+        } else if (keyCode === 32) {
           result.key = C0.NUL;
         } else if (ev.keyCode >= 51 && ev.keyCode <= 55) {
           // escape, file sep, group sep, record sep, unit sep


### PR DESCRIPTION
Fixes #6065


## What

While a CJK IME is active, Windows/Chromium delivers control inputs with `keyCode === 229` ("Process") even though they never begin a composition. `Ctrl+<letter>`, `Ctrl+Space`, and a bare `Escape` are then silently dropped — nothing reaches `onData`. Inside an in-pane TUI this shows up as `Ctrl+J` not inserting a newline, `Ctrl+C` not interrupting, and `Escape` not cancelling; the same keys work with the IME off.

Root cause and measurements are in #6065. In short, two keyCode-based paths combine:

1. `CompositionHelper.keydown` returns `false` for every `keyCode === 229` keydown, so `_keyDown` bails before the encoder runs. That assumes a later `input`/composition event will carry the key — true for printable characters, but control chords produce neither.
2. `evaluateKeyboardEvent` switches on `keyCode`, so `229` matches neither Escape (`case 27`) nor the `Ctrl+<letter>` derivation (`keyCode 65..90`).

The physical `ev.code` is correct throughout, so it's used to recover the intended key.

## Changes

- **`common/input/Keyboard.ts`** — add `recoverImeControlKeyCode(ev)`: when `keyCode === 229`, map `ev.code` back to a real keyCode for the masked control inputs (`Escape` → 27; with Ctrl held, `KeyA`..`KeyZ` → 65..90 and `Space` → 32). `evaluateKeyboardEvent` uses the recovered value for its `switch` and for the `Ctrl+<letter>`/`Ctrl+Space` cases in the `default` branch. Printable/composable keys keep `keyCode === 229` and are left to the composition path.
- **`browser/input/CompositionHelper.ts`** — in the non-composing `keyCode === 229` branch, let control inputs (`ev.code === 'Escape'`, or `ev.ctrlKey && !ev.altKey && !ev.metaKey`) continue to the normal key handler (`return true`) instead of being swallowed. A small `isImeControlPassthrough` predicate mirrors the recovery scope.

Both are gated on the control-key conditions, so genuine IME composition — which never involves Ctrl, and for a bare key produces an `input`/composition event — is unaffected.

## Testing

- `Keyboard.test.ts`: new cases asserting `Ctrl+J`→`\n`, `Ctrl+C`→`\x03`, `Ctrl+Space`→`\x00`, `Escape`→`\x1b` at `keyCode 229`; that a plain composable key at 229 still yields no key; and that real keyCodes are unaffected.
- `CompositionHelper.test.ts`: new cases asserting `keydown` returns `true` (passthrough) for a Ctrl chord and for Escape at `keyCode 229`.
- Full `Keyboard` + `CompositionHelper` suites pass (77 tests). `tsgo` build clean; `oxlint --type-aware` and the naming ESLint config clean on both changed files.
- End-to-end dynamic repro against the built `lib/xterm.mjs` in Chromium (dispatches keydowns with `keyCode` forced to 229): stock emits nothing for all four control inputs; with the fix they emit the correct bytes and a plain composing key still emits nothing.

| keydown (keyCode 229) | stock `onData` | fixed `onData` |
|---|---|---|
| Ctrl+J | *(nothing)* | `0a` |
| Ctrl+C | *(nothing)* | `03` |
| Ctrl+Space | *(nothing)* | `00` |
| Escape | *(nothing)* | `1b` |
| plain j (composing) | *(nothing)* | *(nothing)* |

## Notes

Scoped to `Ctrl+<letter>`, `Ctrl+Space`, and `Escape` — the inputs with confirmed field reports. `Alt`/`Meta` chords are derived from `keyCode` in the same branch and are plausibly affected; left out here to keep the change conservative, easy to add if wanted.
