### PR TITLE
Render a synchronized-output frame on close, not on the next debounce

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -174,7 +174,15 @@ export class RenderService extends Disposable implements IRenderService {
       this._isNextRenderRedrawOnly = false;
     }
 
-    if (sync) {
+    // A just-closed synchronized-output frame must render now, not on the next
+    // debounced tick. Under a continuous animation the following frame opens a
+    // new sync block before the debounce fires, and `_renderRows` skips while
+    // sync is on — so a debounced render would be dropped and the frame would
+    // only appear on the 1s sync timeout, capping the display at ~1fps. Sync is
+    // false at this point (this runs from the mode-reset that just flushed the
+    // buffer), so rendering synchronously paints the completed frame before the
+    // next one can reopen sync.
+    if (sync || buffered) {
       this._renderRows(start, end);
     } else {
       this._renderDebouncer.refresh(start, end, this._rowCount);


### PR DESCRIPTION
Fixes #6071.

### Problem

Under a continuous full-screen animation that wraps every frame in a DEC
private mode 2026 (synchronized output) block, the display is capped at ~1 fps
however fast frames arrive and however idle the renderer is — completed frames
only paint when the 1000 ms synchronized-output timeout expires.

When a 2026 block closes, the input handler requests a refresh.
`RenderService.refreshRows` flushes the buffered rows but schedules the paint
through the render debouncer (`requestAnimationFrame`). Under a continuous
animation the next frame opens a new 2026 block before that rAF fires, and
`_renderRows` skips while synchronized output is on — so the debounced paint is
dropped and the frame only appears on the sync timeout.

### Fix

Render synchronously when a synchronized-output buffer was **just flushed**
(`buffered` is truthy). At that point `sync` is already `false` — the flush
runs from the mode-reset that turned sync off — so the completed frame paints
before the next frame can reopen the mode. No partial-frame tearing, since the
frame is complete by construction.

### Testing

Measured against a 30 fps animated-background TUI (TryIt.jl): renders went from
~1/s to the frame-arrival rate, with no tearing.

Assisted-by: AI
