### PR TITLE
Fix WebGL texture atlas background cache churn on per-cell background colors

### DIFF
--- a/addons/addon-webgl/src/CharAtlasUtils.test.ts
+++ b/addons/addon-webgl/src/CharAtlasUtils.test.ts
@@ -4,8 +4,9 @@
  */
 
 import { assert } from 'chai';
-import { configEquals } from './CharAtlasUtils';
+import { cacheKeyBg, configEquals } from './CharAtlasUtils';
 import { ICharAtlasConfig } from './Types';
+import { Attributes, BgFlags, FgFlags } from 'common/buffer/Constants';
 import { NULL_COLOR } from 'common/Color';
 import { IColor } from 'common/Types';
 
@@ -83,5 +84,90 @@ describe('CharAtlasUtils', () => {
       const b = createTestConfig({ deviceCellHeight: 21 });
       assert.ok(!configEquals(a, b));
     });
+  });
+});
+
+describe('cacheKeyBg', () => {
+  const RGB_RED = Attributes.CM_RGB | 0xFF0000;
+  const RGB_BLUE = Attributes.CM_RGB | 0x0000FF;
+  const TRANSPARENT = { allowTransparency: true };
+
+  it('should keep the background colour in the key by default', () => {
+    // With an opaque atlas the tile is filled with the background and the
+    // antialiased fringe is blended against it, so two backgrounds cannot
+    // share a glyph.
+    const config = createTestConfig();
+    assert.notStrictEqual(
+      cacheKeyBg(RGB_RED, 0, config),
+      cacheKeyBg(RGB_BLUE, 0, config)
+    );
+    assert.strictEqual(cacheKeyBg(RGB_RED, 0, config), RGB_RED);
+  });
+
+  it('should collapse background colours when the tile cannot depend on them', () => {
+    const config = createTestConfig(TRANSPARENT);
+    assert.strictEqual(
+      cacheKeyBg(RGB_RED, 0, config),
+      cacheKeyBg(RGB_BLUE, 0, config)
+    );
+  });
+
+  it('should collapse every colour mode onto the same key', () => {
+    const config = createTestConfig(TRANSPARENT);
+    const expected = cacheKeyBg(Attributes.CM_DEFAULT, 0, config);
+    assert.strictEqual(cacheKeyBg(Attributes.CM_P16 | 3, 0, config), expected);
+    assert.strictEqual(cacheKeyBg(Attributes.CM_P256 | 200, 0, config), expected);
+    assert.strictEqual(cacheKeyBg(RGB_RED, 0, config), expected);
+  });
+
+  it('should keep the background flags that change what is rasterised', () => {
+    // ITALIC, DIM and OVERLINE live in bg and each alters the tile, so they
+    // must survive even when the colour is dropped.
+    const config = createTestConfig(TRANSPARENT);
+    for (const flag of [BgFlags.ITALIC, BgFlags.DIM, BgFlags.OVERLINE]) {
+      assert.notStrictEqual(
+        cacheKeyBg(RGB_RED | flag, 0, config),
+        cacheKeyBg(RGB_RED, 0, config),
+        `flag ${flag.toString(16)} was dropped from the key`
+      );
+      // The flag survives; only the colour is masked away.
+      assert.strictEqual(cacheKeyBg(RGB_RED | flag, 0, config) & flag, flag);
+      // ...and it still collapses across colours.
+      assert.strictEqual(
+        cacheKeyBg(RGB_RED | flag, 0, config),
+        cacheKeyBg(RGB_BLUE | flag, 0, config)
+      );
+    }
+  });
+
+  it('should keep the background colour for inverse cells', () => {
+    // Inverse promotes the background colour to the foreground, so the tile
+    // depends on it after all. The flag is read from fg.
+    const config = createTestConfig(TRANSPARENT);
+    assert.notStrictEqual(
+      cacheKeyBg(RGB_RED, FgFlags.INVERSE, config),
+      cacheKeyBg(RGB_BLUE, FgFlags.INVERSE, config)
+    );
+    assert.strictEqual(cacheKeyBg(RGB_RED, FgFlags.INVERSE, config), RGB_RED);
+  });
+
+  it('should keep the background colour when a minimum contrast ratio is set', () => {
+    // The foreground is then adjusted against the background.
+    const config = createTestConfig({ ...TRANSPARENT, minimumContrastRatio: 4.5 });
+    assert.notStrictEqual(
+      cacheKeyBg(RGB_RED, 0, config),
+      cacheKeyBg(RGB_BLUE, 0, config)
+    );
+  });
+
+  it('should bound the number of keys over a background that changes per cell', () => {
+    // The workload this exists for: an animated background walks the truecolor
+    // space, and every glyph over it used to take its own atlas entry.
+    const config = createTestConfig(TRANSPARENT);
+    const keys = new Set<number>();
+    for (let i = 0; i < 4096; i++) {
+      keys.add(cacheKeyBg(Attributes.CM_RGB | i, 0, config));
+    }
+    assert.strictEqual(keys.size, 1);
   });
 });

--- a/addons/addon-webgl/src/CharAtlasUtils.ts
+++ b/addons/addon-webgl/src/CharAtlasUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ICharAtlasConfig } from './Types';
-import { Attributes } from 'common/buffer/Constants';
+import { Attributes, FgFlags } from 'common/buffer/Constants';
 import { ITerminalOptions } from '@xterm/xterm';
 import { IColorSet, ReadonlyColorSet } from 'browser/Types';
 import { NULL_COLOR } from 'common/Color';
@@ -80,4 +80,42 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
 
 export function is256Color(colorCode: number): boolean {
   return (colorCode & Attributes.CM_MASK) === Attributes.CM_P16 || (colorCode & Attributes.CM_MASK) === Attributes.CM_P256;
+}
+
+/**
+ * The `bg` component of a glyph's atlas cache key.
+ *
+ * `TextureAtlas._drawToCache` reads the *colour* held in `bg` in exactly three
+ * places:
+ *
+ * - `_getBackgroundColor`, which fills the tile. It returns `NULL_COLOR` for
+ *   every background when `allowTransparency` is set, because a translucent
+ *   background must not be baked into the glyph.
+ * - `_getMinimumContrastColor`, which adjusts the foreground against the
+ *   background. It returns early when `minimumContrastRatio` is 1.
+ * - the inverse swap, which promotes the background colour to the foreground.
+ *
+ * When none of the three apply, every background produces a pixel-identical
+ * tile, and keying the cache on the background colour only multiplies the
+ * atlas: one entry per glyph per colour it has ever been drawn over. Content
+ * that varies the background per cell — an animated background, a heatmap, a
+ * diff with highlighted regions, ANSI art — then misses on every cell of every
+ * frame and grows the atlas without bound, since glyphs are never evicted.
+ *
+ * Only the colour bits are dropped. `bg` also carries `BgFlags`, and `ITALIC`,
+ * `DIM` and `OVERLINE` each change what is rasterised, so they must stay part
+ * of the key.
+ *
+ * `INVERSE` is read from `fg`: the flag lives there even though the swap it
+ * describes is what makes the background colour matter.
+ */
+export function cacheKeyBg(bg: number, fg: number, config: ICharAtlasConfig): number {
+  if (
+    !config.allowTransparency ||
+    config.minimumContrastRatio !== 1 ||
+    (fg & FgFlags.INVERSE) !== 0
+  ) {
+    return bg;
+  }
+  return bg & ~(Attributes.CM_MASK | Attributes.RGB_MASK);
 }

--- a/addons/addon-webgl/src/TextureAtlas.ts
+++ b/addons/addon-webgl/src/TextureAtlas.ts
@@ -4,6 +4,7 @@
  */
 
 import { IColorContrastCache } from 'browser/Types';
+import { cacheKeyBg } from './CharAtlasUtils';
 import { DIM_OPACITY, TEXT_BASELINE } from './Constants';
 import { tryDrawCustomGlyph } from './customGlyphs/CustomGlyphRasterizer';
 import { computeNextVariantOffset, treatGlyphAsBackgroundColor, isPowerlineGlyph, isRestrictedPowerlineGlyph, throwIfFalsy } from 'browser/renderer/shared/RendererUtils';
@@ -293,10 +294,17 @@ export class TextureAtlas implements ITextureAtlas {
     restrictToCellHeight: boolean,
     domContainer: HTMLElement | undefined
   ): IRasterizedGlyph {
-    $glyph = cacheMap.get(key, bg, fg, ext);
+    // Glyphs that cannot depend on the background colour share a single entry
+    // across every background they are drawn over — see `cacheKeyBg`. The real
+    // `bg` is still handed to `_drawToCache`: by that same invariant every
+    // background rasterises an identical tile, so whichever arrives first is
+    // as good as any, and passing the caller's own value keeps this purely a
+    // change to how entries are keyed.
+    const keyBg = cacheKeyBg(bg, fg, this._config);
+    $glyph = cacheMap.get(key, keyBg, fg, ext);
     if (!$glyph) {
       $glyph = this._drawToCache(key, bg, fg, ext, restrictToCellHeight, domContainer);
-      cacheMap.set(key, bg, fg, ext, $glyph);
+      cacheMap.set(key, keyBg, fg, ext, $glyph);
     }
     return $glyph;
   }

--- a/addons/addon-webgl/test/WebglAtlasBackgroundChurn.test.ts
+++ b/addons/addon-webgl/test/WebglAtlasBackgroundChurn.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import test, { expect } from '@playwright/test';
+import type { Terminal, ITerminalInitOnlyOptions, ITerminalOptions } from '@xterm/xterm';
+import type { IWebglAddonOptions, WebglAddon } from '@xterm/addon-webgl';
+import { ITestContext, createTestContext, openTerminal } from '../../../test/playwright/TestUtils';
+
+/**
+ * A deterministic repro for glyph-cache churn driven by the *background*.
+ *
+ * #6038 fixed what happens once churn overruns the page cap — pages are
+ * evicted and the renderer no longer garbles or throws. It deliberately left
+ * glyph-level eviction alone ("avoid global eviction unless it has its own
+ * deterministic test"), so `TextureAtlas._cacheMap` still only ever grows.
+ *
+ * This file supplies the missing determinism from the other side: rather than
+ * flooding unique *glyphs*, it repaints a handful of glyphs over a background
+ * that changes every cell of every frame — an animated TUI background, a
+ * heatmap, a diff with highlighted regions, ANSI art. The glyph set is tiny
+ * and fixed, so a cache keyed on what is actually rasterised has a small fixed
+ * size, and any growth is churn by definition. Frame count and cell count are
+ * fixed, so the churn rate is exact rather than probabilistic.
+ *
+ * That makes it both a regression test for the cache key and a ready-made
+ * workload for eviction work: with the key fixed the cache is bounded, and
+ * removing the `allowTransparency` precondition puts the unbounded case back
+ * whenever a bound needs exercising.
+ */
+
+interface ITwoKeyMapInternal {
+  _data: { [first: string]: { [second: string]: unknown } | undefined };
+}
+
+interface IFourKeyMapInternal {
+  _data: ITwoKeyMapInternal & {
+    _data: { [first: string]: { [second: string]: ITwoKeyMapInternal | undefined } | undefined };
+  };
+}
+
+interface ITestTextureAtlas {
+  pages: unknown[];
+  _cacheMap: IFourKeyMapInternal;
+}
+
+interface ITestRenderer {
+  _charAtlas?: ITestTextureAtlas;
+}
+
+interface ITestTerminal extends Terminal {
+  _core?: {
+    _renderService?: {
+      _renderer?: { value?: ITestRenderer };
+    };
+  };
+}
+
+interface ITestWebglAddon extends WebglAddon {
+  _renderer?: ITestRenderer;
+}
+
+interface ITestWindow extends Window {
+  Terminal: new (options?: ITerminalOptions & ITerminalInitOnlyOptions) => ITestTerminal;
+  WebglAddon: new (options?: IWebglAddonOptions) => ITestWebglAddon;
+  term: ITestTerminal;
+  addon?: ITestWebglAddon;
+}
+
+const COLS = 80;
+const ROWS = 24;
+const FRAMES = 16;
+
+/** Deliberately small: the cache should settle at roughly this many entries. */
+const GLYPHS = '─│┌┐└┘abcXYZ';
+
+async function loadWebglStrict(ctx: ITestContext): Promise<void> {
+  await ctx.page.evaluate(() => {
+    const w = window as unknown as ITestWindow;
+    w.addon = new w.WebglAddon({ preserveDrawingBuffer: true });
+    w.term.loadAddon(w.addon);
+  });
+  const isWebglRenderer = await ctx.page.evaluate(() => {
+    const w = window as unknown as ITestWindow;
+    return !!w.addon && w.term._core?._renderService?._renderer?.value === w.addon._renderer;
+  });
+  expect(isWebglRenderer, 'WebGL renderer must be active').toBe(true);
+}
+
+async function writeAndWaitForRender(ctx: ITestContext, data: string): Promise<void> {
+  const renderPromise = new Promise<void>(resolve => {
+    const disposable = ctx.proxy.onRender(() => {
+      disposable.dispose();
+      resolve();
+    });
+  });
+  await ctx.proxy.write(data);
+  await renderPromise;
+}
+
+/**
+ * Wait for the atlas to stop growing on its own.
+ *
+ * `_doWarmUp` pre-rasterises ASCII 33-125 from an `IdleTaskQueue`, so the
+ * cache keeps filling for a while after the first render for reasons that have
+ * nothing to do with the workload under test. Settling first lets the
+ * assertion below be an exact equality rather than a tolerance.
+ */
+async function waitForCacheToSettle(ctx: ITestContext): Promise<number> {
+  let previous = -1;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const current = await getCachedGlyphCount(ctx);
+    if (current === previous) {
+      return current;
+    }
+    previous = current;
+    await ctx.page.waitForTimeout(50);
+  }
+  throw new Error(`glyph cache never settled, last count ${previous}`);
+}
+
+/** Number of rasterised tiles held in the atlas' glyph cache. */
+async function getCachedGlyphCount(ctx: ITestContext): Promise<number> {
+  const count = await ctx.page.evaluate(() => {
+    const w = window as unknown as ITestWindow;
+    const atlas = w.term._core?._renderService?._renderer?.value?._charAtlas;
+    if (!atlas?._cacheMap) {
+      return undefined;
+    }
+    let total = 0;
+    const byKey = atlas._cacheMap._data._data;
+    for (const key of Object.keys(byKey)) {
+      const byBg = byKey[key];
+      if (!byBg) {
+        continue;
+      }
+      for (const bg of Object.keys(byBg)) {
+        const byFg = byBg[bg]?._data;
+        if (!byFg) {
+          continue;
+        }
+        for (const fg of Object.keys(byFg)) {
+          total += Object.keys(byFg[fg] ?? {}).length;
+        }
+      }
+    }
+    return total;
+  });
+  expect(count, 'glyph cache must be reachable').toBeDefined();
+  return count!;
+}
+
+/**
+ * One frame of a full-screen animated background: every cell gets its own
+ * truecolor background, and the glyph on it comes from a fixed small set.
+ */
+function backgroundFrame(frame: number): string {
+  let out = '\x1b[H';
+  for (let row = 0; row < ROWS; row++) {
+    for (let col = 0; col < COLS; col++) {
+      // A cheap deterministic walk through the truecolor space. Distinct per
+      // cell and per frame, which is exactly what an animation produces.
+      const seed = frame * 7919 + row * 131 + col * 17;
+      const r = seed % 256;
+      const g = (seed >> 3) % 256;
+      const b = (seed >> 6) % 256;
+      out += `\x1b[38;2;220;220;220m\x1b[48;2;${r};${g};${b}m`;
+      out += GLYPHS[(row * COLS + col) % GLYPHS.length];
+    }
+    if (row < ROWS - 1) {
+      out += '\r\n';
+    }
+  }
+  return out;
+}
+
+test.describe('glyph cache churn from per-cell backgrounds', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium');
+  test.describe.configure({ timeout: 90000 });
+
+  test('a background that changes every cell must not grow the glyph cache without bound', async ({ browser }) => {
+    const ctx = await createTestContext(browser);
+    const errors: string[] = [];
+    const onError = (error: Error): void => { errors.push(error.message); };
+    ctx.page.on('pageerror', onError);
+    try {
+      // allowTransparency is what makes the tile independent of the
+      // background: the atlas is filled with NULL_COLOR instead of the
+      // background colour, so nothing about the background is baked in.
+      // minimumContrastRatio must stay at 1, or the foreground is adjusted
+      // against the background and the tile depends on it after all.
+      await openTerminal(ctx, {
+        cols: COLS,
+        rows: ROWS,
+        allowTransparency: true,
+        minimumContrastRatio: 1
+      });
+      await loadWebglStrict(ctx);
+
+      await writeAndWaitForRender(ctx, backgroundFrame(0));
+      const settled = await waitForCacheToSettle(ctx);
+      expect(settled, 'the first frame must populate the cache').toBeGreaterThan(0);
+
+      for (let frame = 1; frame < FRAMES; frame++) {
+        await writeAndWaitForRender(ctx, backgroundFrame(frame));
+      }
+      const afterAllFrames = await getCachedGlyphCount(ctx);
+
+      // The glyph set never changes, so nothing new is rasterised however many
+      // backgrounds go past. Before the cache key dropped the background
+      // colour this grew by one entry per cell per frame — 30k odd over these
+      // 16 frames — and never came back down.
+      expect(
+        afterAllFrames,
+        `glyph cache grew from ${settled} to ${afterAllFrames} over ${FRAMES} frames of a changing background`
+      ).toBe(settled);
+
+      expect(errors, `renderer must not throw: ${errors[0] ?? ''}`).toEqual([]);
+    } finally {
+      ctx.page.off('pageerror', onError);
+      await ctx.page.close();
+    }
+  });
+
+  test('an opaque atlas still keys glyphs on the background colour', async ({ browser }) => {
+    const ctx = await createTestContext(browser);
+    try {
+      // The complement of the case above, kept so the precondition is not
+      // silently widened later. With an opaque atlas the tile is filled with
+      // the background and the antialiased fringe is blended against it, so
+      // sharing one tile across backgrounds would halo the glyph edges.
+      await openTerminal(ctx, {
+        cols: COLS,
+        rows: ROWS,
+        allowTransparency: false,
+        minimumContrastRatio: 1
+      });
+      await loadWebglStrict(ctx);
+
+      await writeAndWaitForRender(ctx, backgroundFrame(0));
+      const afterFirstFrame = await getCachedGlyphCount(ctx);
+      await writeAndWaitForRender(ctx, backgroundFrame(1));
+      const afterSecondFrame = await getCachedGlyphCount(ctx);
+
+      expect(
+        afterSecondFrame,
+        'an opaque atlas must still rasterise per background colour'
+      ).toBeGreaterThan(afterFirstFrame);
+    } finally {
+      await ctx.page.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6074.

### Problem

The WebGL glyph atlas is keyed on the full `bg` value, colour bits included
(`cacheMap.get(key, bg, fg, ext)`). But `_drawToCache` only reads the
background *colour* in three cases — `_getBackgroundColor` (unless
`allowTransparency`), `_getMinimumContrastColor` (unless `minimumContrastRatio`
is 1), and the inverse swap. When none apply, every background colour rasterizes
a pixel-identical tile, yet each gets its own atlas entry. Content that varies
the background per cell (animated backgrounds, heatmaps, diffs, ANSI art) then
misses on every cell of every frame and grows the never-evicted atlas without
bound.

### Fix

Introduce a `cacheKeyBg` that drops the background colour bits when they cannot
change the tile, keeping the `BgFlags` that do (`ITALIC`, `DIM`, `OVERLINE`).
`INVERSE` (read from `fg`) stays in the key, since the inverse swap depends on
the colour. Same glyph over different background colours now reuses one atlas
entry.

### Testing

- `CharAtlasUtils.test.ts` — unit coverage for `cacheKeyBg` (colour dropped;
  rasterizing flags and the transparency / contrast / inverse exceptions kept).
- `WebglAtlasBackgroundChurn.test.ts` — regression test that a per-cell
  background-colour sweep no longer multiplies atlas entries.

Assisted-by: AI
