### PR TITLE
Read the unicode trie header at the view's byteOffset

### DIFF
--- a/addons/addon-unicode-graphemes/src/third-party/unicode-trie.test.ts
+++ b/addons/addon-unicode-graphemes/src/third-party/unicode-trie.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import UnicodeTrie from './unicode-trie';
+
+const HEADER_LENGTH = 12;
+
+/**
+ * Wraps `data` in a single final DEFLATE "stored" block (BFINAL=1, BTYPE=00).
+ * tiny-inflate accepts these, which lets this test build a valid trie image
+ * without pulling in a compressor.
+ */
+function storedDeflate(data: Uint8Array): Uint8Array {
+  const result = new Uint8Array(5 + data.length);
+  result[0] = 0x01;                            // BFINAL=1, BTYPE=00 (stored)
+  result[1] = data.length & 0xff;              // LEN, little endian
+  result[2] = (data.length >> 8) & 0xff;
+  result[3] = ~data.length & 0xff;             // NLEN, one's complement of LEN
+  result[4] = (~data.length >> 8) & 0xff;
+  result.set(data, 5);
+  return result;
+}
+
+/**
+ * Builds a trie image in the serialized format the constructor expects: a 12
+ * byte little endian header (highStart, errorValue, uncompressedLength)
+ * followed by the doubly deflated trie body.
+ *
+ * `uncompressedLength` sizes the scratch buffer used for *both* inflate
+ * passes, so it must also fit the intermediate result. Stored blocks add 5
+ * bytes per pass rather than shrinking, hence the padding.
+ */
+function buildTrieImage(highStart: number, errorValue: number, body: Uint32Array): Uint8Array {
+  const bodyBytes = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  const payload = storedDeflate(storedDeflate(bodyBytes));
+  const image = new Uint8Array(HEADER_LENGTH + payload.length);
+  const header = new DataView(image.buffer, 0, HEADER_LENGTH);
+  header.setUint32(0, highStart, true);
+  header.setUint32(4, errorValue, true);
+  header.setUint32(8, bodyBytes.length + 8, true);
+  image.set(payload, HEADER_LENGTH);
+  return image;
+}
+
+/** Places `image` at `byteOffset` within a larger buffer and returns a view of it. */
+function viewAtOffset(image: Uint8Array, byteOffset: number): Uint8Array {
+  const backing = new Uint8Array(image.length + byteOffset);
+  backing.set(image, byteOffset);
+  return backing.subarray(byteOffset);
+}
+
+describe('UnicodeTrie', () => {
+  const HIGH_START = 0x110000;
+  const ERROR_VALUE = 0xdeadbeef;
+
+  // Deterministic body, kept small valued so every computed index stays in range.
+  const body = new Uint32Array(0x1000);
+  for (let i = 0; i < body.length; i++) {
+    body[i] = i & 0xff;
+  }
+  const image = buildTrieImage(HIGH_START, ERROR_VALUE, body);
+
+  it('reads a trie whose data starts at byte 0 of its buffer', () => {
+    const trie = new UnicodeTrie(image);
+    assert.strictEqual(trie.get(-1) >>> 0, ERROR_VALUE);
+    assert.strictEqual(trie.get(0x110000) >>> 0, ERROR_VALUE);
+  });
+
+  // A Uint8Array need not start at byte 0 of its ArrayBuffer. In node,
+  // `Buffer.from(str, 'base64')` returns a view into a shared 8 KiB pool
+  // whenever the result is smaller than half of `Buffer.poolSize`, so any
+  // earlier small allocation pushes the trie to a non-zero byteOffset. The
+  // header must be read relative to that offset.
+  describe('reading a trie whose data does not start at byte 0 of its buffer', () => {
+    for (const byteOffset of [1, 2, 3, 4, 8, 16, 33, 64]) {
+      it(`honours byteOffset ${byteOffset}`, () => {
+        const trie = new UnicodeTrie(viewAtOffset(image, byteOffset));
+        assert.strictEqual(trie.get(-1) >>> 0, ERROR_VALUE);
+        assert.strictEqual(trie.get(0x110000) >>> 0, ERROR_VALUE);
+      });
+    }
+
+    it('resolves code points identically regardless of byteOffset', () => {
+      const expected = new UnicodeTrie(image);
+      const shifted = new UnicodeTrie(viewAtOffset(image, 3));
+      for (const codePoint of [0x0, 0x41, 0x7f, 0x300, 0xd7ff, 0xd800, 0xdbff, 0xdc00, 0xffff, 0x10000, 0x1f469, 0x10ffff]) {
+        assert.strictEqual(shifted.get(codePoint), expected.get(codePoint), `code point 0x${codePoint.toString(16)}`);
+      }
+    });
+  });
+});

--- a/addons/addon-unicode-graphemes/src/third-party/unicode-trie.ts
+++ b/addons/addon-unicode-graphemes/src/third-party/unicode-trie.ts
@@ -71,7 +71,7 @@ class UnicodeTrie {
   constructor(data: Uint8Array) {
       // read binary format
       
-        const view = new DataView(data.buffer);
+        const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
         this.highStart = view.getUint32(0, true);
         this.errorValue = view.getUint32(4, true);
         let uncompressedLength = view.getUint32(8, true);


### PR DESCRIPTION
Fixes #6079.

## The defect

`UnicodeTrie`'s constructor reads its 12 byte header with

```ts
const view = new DataView(data.buffer);
```

`new DataView(buffer)` starts at byte 0 of the underlying `ArrayBuffer` and ignores the view's `byteOffset`. A `Uint8Array` need not own its whole buffer.

In node, `Buffer.from(str, 'base64')` returns a view into a shared 8 KiB pool whenever the result is smaller than half of `Buffer.poolSize`. `UnicodeProperties.ts` decodes the trie exactly that way (`_dec`), so any earlier small allocation in the process leaves the trie at a non-zero `byteOffset`, and `highStart` / `errorValue` / `uncompressedLength` are then read from unrelated bytes.

## Reproduction

```console
$ node -e "const{Terminal}=require('@xterm/headless');const{UnicodeGraphemesAddon}=require('@xterm/addon-unicode-graphemes');const t=new Terminal({allowProposedApi:true});t.loadAddon(new UnicodeGraphemesAddon());t.unicode.activeVersion='15-graphemes';console.log(t._core.unicodeService.getStringCellWidth('\u{1F468}‍\u{1F469}‍\u{1F467}'))"
2

$ node -e "Buffer.from('x');const{Terminal}=require('@xterm/headless');const{UnicodeGraphemesAddon}=require('@xterm/addon-unicode-graphemes');const t=new Terminal({allowProposedApi:true});t.loadAddon(new UnicodeGraphemesAddon());t.unicode.activeVersion='15-graphemes';console.log(t._core.unicodeService.getStringCellWidth('\u{1F468}‍\u{1F469}‍\u{1F467}'))"
3
```

The only difference is one small allocation before the addon is loaded. Nothing is thrown. Verified on node v24.15.0 with `@xterm/headless` 6.0.0 and both `@xterm/addon-unicode-graphemes` 0.4.0 (`latest`) and 0.5.0-beta.292 (`beta`).

## Symptoms, worst first

1. **Silently wrong widths, no error at all** — the case above. Running this addon's own width vectors in node with a single preceding allocation fails 3 of 13.
2. `Error: Data error` thrown out of tiny-inflate while the module is evaluating, so the import fails.
3. A multi-gigabyte allocation and an apparent hang, when the garbage `uncompressedLength` happens to be large.

Which one you get depends on where in the pool the trie lands.

## Why a regression test, not just the one line

The decoded trie is currently **3023 bytes**, against node's 4096 byte pooling threshold (`Buffer.poolSize >>> 1`) — only **1073 bytes of headroom**. If a future Unicode regeneration pushes the trie past 4096 bytes, node stops pooling it, `byteOffset` becomes 0, and the bug silently disappears, then reappears if the trie later shrinks. The test pins the behaviour independently of the trie's size, so this can't quietly come back.

## Why the current tests can't catch it

This addon's tests are Playwright integration tests, and browsers take the `atob` branch of `_dec`, which allocates a fresh `Uint8Array` at `byteOffset` 0. **Browsers are unaffected, and the Playwright tier structurally cannot observe this.** The regression test has to run in node.

## The test

`unicode-trie.test.ts` builds a trie image in the serialized format (12 byte header + doubly deflated body), places it at a range of `byteOffset`s, and asserts the header still reads correctly. It uses DEFLATE "stored" blocks, so it needs no compressor and no node builtins — which also means `src/tsconfig.json` doesn't need `@types/node` added.

Without the fix 9 of its 10 cases fail; with it all 10 pass. Both failure classes above are covered — wrong values at small offsets, `Data error` at larger ones.

**A question on placement:** I put it beside the file it tests, in `src/third-party/`. There's plenty of precedent for node unit tests under `addons/*/src/` (addon-image, addon-ligatures, addon-search, addon-serialize, addon-webgl), but none inside a `third-party/` directory — you may prefer to keep vendored directories test-free. Happy to move it, just say where.

## Scope

- Line 95, `this.data = new Uint32Array(data.buffer)`, looks like the same defect but isn't reachable: tiny-inflate returns either its freshly allocated `dest` or `dest.slice(0, destLen)`, and both have `byteOffset` 0 and own their whole buffer. I instrumented the real addon to confirm (`byteOffset=0 byteLength=51056 buffer.byteLength=51056`). Changing it would be a no-op today, so I left it out to keep this to a single fix. Glad to harden it separately if you'd like it defensive.
- The same defect is in the patch that *generates* this vendored file, so the next regeneration would revert this fix. Companion PR: [PerBothner/unicode-properties#1](https://github.com/PerBothner/unicode-properties/pull/1). I verified that patch chain reproduces this file byte for byte, before and after.

## Verification

- `npm run test-unit` — 2413 passing
- `npm run lint` — clean
- `npm run build` — clean

---

By contributing this code I agree to license it under xterm.js' [MIT license](https://github.com/xtermjs/xterm.js/blob/master/LICENSE), and I confirm that I have the right to contribute and license it.
