### PR TITLE
Fix Option+punctuation sending composed codepoints in the Kitty keyboard protocol

### DIFF
--- a/src/common/input/KittyKeyboard.test.ts
+++ b/src/common/input/KittyKeyboard.test.ts
@@ -929,9 +929,65 @@ describe('KittyKeyboard', () => {
         assert.strictEqual(result.key, 'ƒ');
       });
 
-      it('falls through when ev.code is not Key*/Digit* (Opt+;)', () => {
+      it('Opt+; (key=…) → CSI 59;3 u', () => {
         const result = kitty.evaluate(createEvent({ key: '…', code: 'Semicolon', altKey: true }), flags, press, true);
-        assert.strictEqual(result.key, '\x1b[8230;3u');
+        assert.strictEqual(result.key, '\x1b[59;3u');
+      });
+
+      it('Opt+] → CSI 93;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '’', code: 'BracketRight', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[93;3u');
+      });
+
+      it('Opt+[ → CSI 91;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '“', code: 'BracketLeft', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[91;3u');
+      });
+
+      it('Opt+/ → CSI 47;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '÷', code: 'Slash', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[47;3u');
+      });
+
+      it('Opt+- → CSI 45;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '–', code: 'Minus', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[45;3u');
+      });
+
+      it('Opt+= → CSI 61;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '≠', code: 'Equal', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[61;3u');
+      });
+
+      it('Opt+, → CSI 44;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '≤', code: 'Comma', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[44;3u');
+      });
+
+      it('Opt+. → CSI 46;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '≥', code: 'Period', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[46;3u');
+      });
+
+      it('Opt+quote → CSI 39;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'æ', code: 'Quote', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[39;3u');
+      });
+
+      it('Opt+backslash → CSI 92;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: '«', code: 'Backslash', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[92;3u');
+      });
+
+      it('Opt+backtick dead key → CSI 96;3 u', () => {
+        const result = kitty.evaluate(createEvent({ key: 'Dead', code: 'Backquote', altKey: true }), flags, press, true);
+        assert.strictEqual(result.key, '\x1b[96;3u');
+      });
+
+      it('Shift+] with REPORT_ALL_KEYS unwinds to base → CSI 93;2 u', () => {
+        const allKeys = KittyKeyboardFlags.REPORT_ALL_KEYS_AS_ESCAPE_CODES;
+        const result = kitty.evaluate(createEvent({ key: '}', code: 'BracketRight', shiftKey: true }), allKeys, press, false);
+        assert.strictEqual(result.key, '\x1b[93;2u');
       });
 
       it('Opt+f release with REPORT_EVENT_TYPES → CSI 102;3:3 u', () => {

--- a/src/common/input/KittyKeyboard.ts
+++ b/src/common/input/KittyKeyboard.ts
@@ -162,6 +162,26 @@ export class KittyKeyboard {
   };
 
   /**
+   * Punctuation keys mapped from their physical `code` to the base US-layout
+   * codepoint. Used to recover the unmodified key when macOS Option composition
+   * (or Shift) has replaced ev.key with a different character.
+   */
+  private readonly _punctuationKeyCodes: { [key: string]: number } = {
+    'Backquote': 96,
+    'Minus': 45,
+    'Equal': 61,
+    'BracketLeft': 91,
+    'BracketRight': 93,
+    'Backslash': 92,
+    'Semicolon': 59,
+    'Quote': 39,
+    'Comma': 44,
+    'Period': 46,
+    'Slash': 47,
+    'Space': 32
+  };
+
+  /**
    * Map browser key codes to Kitty numpad codes.
    */
   private _getNumpadKeyCode(ev: IKeyboardEvent): number | undefined {
@@ -244,6 +264,10 @@ export class KittyKeyboard {
       if (ev.code.startsWith('Key') && ev.code.length === 4) {
         const letter = ev.code.charAt(3).toLowerCase();
         return letter.charCodeAt(0);
+      }
+      const punctuationCode = this._punctuationKeyCodes[ev.code];
+      if (punctuationCode !== undefined) {
+        return punctuationCode;
       }
     }
 


### PR DESCRIPTION
Fixes #5819.

On macOS with Option-as-Alt, `KittyKeyboard._getKeyCode` fell through to the Option-composed `ev.key` for punctuation keys, so Option+punctuation emitted the composed Unicode codepoint (e.g. Option+] → CSI 8217;3u for `'`) instead of the base key with the Alt modifier (CSI 93;3u for `]`).

The mac Option (and Shift) unwind gate already recovered the base codepoint from `ev.code` for `Digit*` and `Key*` codes but not for punctuation. This adds the remaining standard punctuation codes (Backquote, Minus, Equal, Bracket[Left|Right], Backslash, Semicolon, Quote, Comma, Period, Slash, Space) to that same gate so the base key is recovered.

Recovery is based on the US-QWERTY layout, consistent with the existing letter/digit handling.
