### PR TITLE
Add BitFun to real-world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Xterm.js is used in many world-class applications to provide great terminal expe
 - [**Orca**](https://github.com/stablyai/orca): Agentic development environment for 100x builders.
 - [**4bit**](https://ciembor.github.io/4bit): Terminal Color Scheme Designer.
 - [**Cate**](https://github.com/0-AI-UG/cate): Open source desktop IDE on an infinite zoomable canvas. Editor, browser, and terminal panels float in spatial space; the terminals are xterm.js with the WebGL addon, backed by node-pty.
+- [**BitFun**](https://github.com/GCWing/BitFun): Open-source desktop AI agent whose integrated terminals and read-only terminal output views use xterm.js with the Fit, Web Links, and WebGL addons.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Please add any new contributions to the end of the list.


### PR DESCRIPTION
I help maintain BitFun. We use xterm.js for both the interactive terminal and read-only terminal output, together with the Fit, Web Links, and WebGL addons.

This adds it to the end of the Real-world uses list as requested in the README.