### PR TITLE
Restrict release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     # without running tests to save time to publish
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #6028.

The existing fork head could not be updated because the GitHub App credential was rejected when modifying a workflow file on that fork. This adds the missing least-privilege permission to the release workflow only:

```yaml
permissions:
  contents: read
```

The npm publish step uses `NPM_TOKEN`, so the workflow does not need write access through `GITHUB_TOKEN`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-030f3bb8-f270-4397-ac4a-f86be493aae3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-030f3bb8-f270-4397-ac4a-f86be493aae3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

