### PR TITLE
Add horizontal wheel mouse reporting

### DIFF
--- a/src/browser/services/MouseService.test.ts
+++ b/src/browser/services/MouseService.test.ts
@@ -76,8 +76,27 @@ function createTestMouseTargetElement(): HTMLElement {
 describe('MouseService _triggerMouseEvent', () => {
   let mouseService: MouseService;
   let mouseStateService: MouseStateService;
+  let renderService: MockRenderService;
   let coreService: ICoreService;
   let reports: string[];
+  let originalWheelEvent: typeof WheelEvent | undefined;
+
+  before(() => {
+    originalWheelEvent = globalThis.WheelEvent;
+    (globalThis as any).WheelEvent ??= {
+      DOM_DELTA_PIXEL: 0,
+      DOM_DELTA_LINE: 1,
+      DOM_DELTA_PAGE: 2
+    };
+  });
+
+  after(() => {
+    if (originalWheelEvent) {
+      (globalThis as any).WheelEvent = originalWheelEvent;
+    } else {
+      delete (globalThis as any).WheelEvent;
+    }
+  });
 
   beforeEach(() => {
     reports = [];
@@ -87,9 +106,12 @@ describe('MouseService _triggerMouseEvent', () => {
       triggerBinaryEvent: (data: string) => reports.push(data),
       decPrivateModes: { applicationCursorKeys: false }
     } as any;
+    renderService = new MockRenderService();
+    renderService.dimensions.device.cell.width = 10;
+    renderService.dimensions.device.cell.height = 20;
 
     mouseService = new MouseService(
-      new MockRenderService(),
+      renderService,
       {
         getMouseReportCoords: (_ev: MouseEvent, _el: HTMLElement) => ({ col: 0, row: 0, x: 0, y: 0 })
       } as any,
@@ -105,6 +127,20 @@ describe('MouseService _triggerMouseEvent', () => {
 
   function trigger(e: Parameters<any>[0]): boolean {
     return (mouseService as any)._triggerMouseEvent(e);
+  }
+
+  function sendWheel(deltaX: number, deltaY: number, deltaMode: number = WheelEvent.DOM_DELTA_LINE): boolean {
+    return (mouseService as any)._sendEvent({
+      target: { screenElement: createTestMouseTargetElement() }
+    }, {
+      type: 'wheel',
+      deltaX,
+      deltaY,
+      deltaMode,
+      altKey: false,
+      ctrlKey: false,
+      shiftKey: false
+    } as WheelEvent);
   }
 
   it('NONE', () => {
@@ -168,6 +204,44 @@ describe('MouseService _triggerMouseEvent', () => {
     assert.equal(trigger({ col: 500, row: 0, x: 0, y: 0, button: CoreMouseButton.LEFT, action: CoreMouseAction.DOWN }), false);
     assert.equal(trigger({ col: 0, row: -1, x: 0, y: 0, button: CoreMouseButton.LEFT, action: CoreMouseAction.DOWN }), false);
     assert.equal(trigger({ col: 0, row: 500, x: 0, y: 0, button: CoreMouseButton.LEFT, action: CoreMouseAction.DOWN }), false);
+  });
+
+  it('should report wheel events on both axes using the dominant axis', () => {
+    mouseStateService.activeProtocol = 'ANY';
+    mouseStateService.activeEncoding = 'SGR';
+
+    assert.isTrue(sendWheel(-1, 0));
+    assert.isTrue(sendWheel(1, 0));
+    assert.isTrue(sendWheel(0, -1));
+    assert.isTrue(sendWheel(0, 1));
+    assert.isTrue(sendWheel(2, -1));
+    assert.isTrue(sendWheel(1, -2));
+
+    assert.deepEqual(reports, [
+      '\x1b[<66;1;1M',
+      '\x1b[<67;1;1M',
+      '\x1b[<64;1;1M',
+      '\x1b[<65;1;1M',
+      '\x1b[<67;1;1M',
+      '\x1b[<64;1;1M'
+    ]);
+  });
+
+  it('should accumulate pixel wheel events independently per axis', () => {
+    mouseStateService.activeProtocol = 'ANY';
+    mouseStateService.activeEncoding = 'SGR';
+
+    for (let i = 0; i < 3; i++) {
+      assert.isFalse(sendWheel(10, 0, WheelEvent.DOM_DELTA_PIXEL));
+      assert.isFalse(sendWheel(0, 20, WheelEvent.DOM_DELTA_PIXEL));
+    }
+    assert.isTrue(sendWheel(10, 0, WheelEvent.DOM_DELTA_PIXEL));
+    assert.isTrue(sendWheel(0, 20, WheelEvent.DOM_DELTA_PIXEL));
+
+    assert.deepEqual(reports, [
+      '\x1b[<67;1;1M',
+      '\x1b[<65;1;1M'
+    ]);
   });
 
   describe('coords', () => {

--- a/src/browser/services/MouseService.ts
+++ b/src/browser/services/MouseService.ts
@@ -29,7 +29,7 @@ export class MouseService implements IMouseService {
   public serviceBrand: undefined;
 
   private _lastEvent: ICoreMouseEvent | null = null;
-  private _wheelPartialScroll: number = 0;
+  private _wheelPartialScroll: Record<'x' | 'y', number> = { x: 0, y: 0 };
   private _touchScrollAccumulator: number = 0;
   private _altMouseCursor: AltMouseCursorController | undefined;
 
@@ -139,19 +139,26 @@ export class MouseService implements IMouseService {
         if (!this._mouseStateService.allowCustomWheelEvent(ev as WheelEvent)) {
           return false;
         }
-        const deltaY = (ev as WheelEvent).deltaY;
-        if (deltaY === 0) {
+        const wheelEvent = ev as WheelEvent;
+        const axis = Math.abs(wheelEvent.deltaX) > Math.abs(wheelEvent.deltaY) ? 'x' : 'y';
+        const delta = axis === 'x' ? wheelEvent.deltaX : wheelEvent.deltaY;
+        if (delta === 0) {
           return false;
         }
         const lines = this._consumeWheelEvent(
-          ev as WheelEvent,
-          this._renderService?.dimensions?.device?.cell?.height,
+          wheelEvent,
+          axis,
+          axis === 'x'
+            ? this._renderService?.dimensions?.device?.cell?.width
+            : this._renderService?.dimensions?.device?.cell?.height,
           this._coreBrowserService?.dpr
         );
         if (lines === 0) {
           return false;
         }
-        action = deltaY < 0 ? CoreMouseAction.UP : CoreMouseAction.DOWN;
+        action = axis === 'x'
+          ? delta < 0 ? CoreMouseAction.LEFT : CoreMouseAction.RIGHT
+          : delta < 0 ? CoreMouseAction.UP : CoreMouseAction.DOWN;
         but = CoreMouseButton.WHEEL;
         break;
       default:
@@ -275,6 +282,7 @@ export class MouseService implements IMouseService {
 
       const lines = this._consumeWheelEvent(
         ev,
+        'y',
         this._renderService?.dimensions?.device?.cell?.height,
         this._coreBrowserService?.dpr
       );
@@ -373,7 +381,8 @@ export class MouseService implements IMouseService {
 
   public reset(): void {
     this._lastEvent = null;
-    this._wheelPartialScroll = 0;
+    this._wheelPartialScroll.x = 0;
+    this._wheelPartialScroll.y = 0;
     this._touchScrollAccumulator = 0;
   }
 
@@ -454,32 +463,32 @@ export class MouseService implements IMouseService {
    * Processes a wheel event, accounting for partial scrolls for trackpad, mouse scrolls.
    * This prevents hyper-sensitive scrolling in alt buffer.
    */
-  private _consumeWheelEvent(ev: WheelEvent, cellHeight?: number, dpr?: number): number {
-    // Do nothing if it's not a vertical scroll event
-    if (ev.deltaY === 0 || ev.shiftKey) {
+  private _consumeWheelEvent(ev: WheelEvent, axis: 'x' | 'y', cellSize?: number, dpr?: number): number {
+    const delta = axis === 'x' ? ev.deltaX : ev.deltaY;
+    if (delta === 0 || ev.shiftKey) {
       return 0;
     }
 
-    if (cellHeight === undefined || dpr === undefined) {
+    if (cellSize === undefined || dpr === undefined) {
       return 0;
     }
 
-    const targetWheelEventPixels = cellHeight / dpr;
-    let amount = this._applyScrollModifier(ev.deltaY, ev);
+    const targetWheelEventPixels = cellSize / dpr;
+    let amount = this._applyScrollModifier(delta, ev);
 
     if (ev.deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
       amount /= (targetWheelEventPixels + 0.0); // Prevent integer division
 
-      const isLikelyTrackpad = Math.abs(ev.deltaY) < 50;
+      const isLikelyTrackpad = Math.abs(delta) < 50;
       if (isLikelyTrackpad) {
         amount *= 0.3;
       }
 
-      this._wheelPartialScroll += amount;
-      amount = Math.floor(Math.abs(this._wheelPartialScroll)) * (this._wheelPartialScroll > 0 ? 1 : -1);
-      this._wheelPartialScroll %= 1;
+      this._wheelPartialScroll[axis] += amount;
+      amount = Math.floor(Math.abs(this._wheelPartialScroll[axis])) * (this._wheelPartialScroll[axis] > 0 ? 1 : -1);
+      this._wheelPartialScroll[axis] %= 1;
     } else if (ev.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
-      amount *= this._bufferService.rows;
+      amount *= axis === 'x' ? this._bufferService.cols : this._bufferService.rows;
     }
     return amount;
   }

--- a/test/playwright/MouseTracking.test.ts
+++ b/test/playwright/MouseTracking.test.ts
@@ -1424,6 +1424,24 @@ test.describe('Mouse Tracking Tests', () => {
       ]);
     });
   });
+
+  test('should report horizontal wheel input', async () => {
+    const encoding = 'SGR';
+    await resetMouseModes();
+    await mouseMove(43, 24);
+    await ctx.proxy.write('\x1b[?1000h\x1b[?1006h');
+
+    await ctx.page.mouse.wheel(-100, 0);
+    await pollFor(ctx.page, () => getReports(encoding), [
+      { col: 44, row: 25, state: { action: 'left', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }
+    ]);
+
+    await ctx.page.mouse.wheel(100, 0);
+    await pollFor(ctx.page, () => getReports(encoding), [
+      { col: 44, row: 25, state: { action: 'right', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }
+    ]);
+  });
+
   /**
    * move tests with multiple buttons pressed:
    * currently not possible due to a limitation of the playwright mouse interface


### PR DESCRIPTION
## Summary

- Report horizontal `WheelEvent` input as wheel-left and wheel-right mouse protocol events when application mouse tracking is active.
- Use the dominant axis for diagonal trackpad gestures, preserving vertical behavior when both axes are equal.
- Normalize horizontal pixel deltas against cell width and keep independent partial-scroll accumulators for each axis.
- Add unit coverage for all four wheel directions, diagonal gestures, and per-axis pixel accumulation.
- Add a Playwright test that exercises horizontal wheel input through the browser event path.

## Motivation

The mouse protocol and encoders already support wheel-left and wheel-right actions, but the browser mouse service only consumed `deltaY`. As a result, horizontal two-finger gestures were discarded before terminal applications could receive them.

## Backward compatibility

- The change is limited to application mouse reporting. Passive scrollback and alt-buffer key emulation retain their existing vertical-only behavior.
- Pure vertical wheel events follow the existing normalization, sensitivity, modifier, and reporting paths.
- Equal-axis diagonal events continue to resolve vertically.
- No public API, dependency, option, or mouse-protocol extension is introduced; the implementation uses the existing wheel-left and wheel-right actions.
- The intentional behavior change is limited to horizontal-only and horizontally dominant wheel events, which are now reported instead of discarded.

Dominant-axis selection tolerates normal trackpad cross-axis noise while ensuring that one browser wheel event produces only one terminal mouse report.

## Verification

- `npm run build`
- `npm run esbuild`
- `npm run lint-changes`
- `npm run test-unit` — 2,407 passing
- `npx playwright test -c out-esbuild-test/playwright/playwright.config.js test/playwright/MouseTracking.test.ts` — 19 passing across Chromium, Firefox, and WebKit; 8 existing WebKit exclusions
